### PR TITLE
Add Vultr-hosted activity dashboard for remote + local agent sessions

### DIFF
--- a/deploy/INSTALL.md
+++ b/deploy/INSTALL.md
@@ -1,0 +1,101 @@
+# Deploying the rebalance-os activity dashboard on Vultr
+
+The dashboard runs alongside Production Sleuth on the same Vultr host:
+
+| Service                | Port | Stack         |
+|------------------------|------|---------------|
+| sleuth-app             | 2020 | Node / Bolt   |
+| **rebalance-web** (new)| 2030 | Python / FastAPI |
+
+The two are independent systemd units. Sleuth is not touched.
+
+---
+
+## 1. One-time host setup
+
+```bash
+ssh root@<vultr-host>
+
+# Code checkout
+git clone https://github.com/hypercart-dev-tools/rebalance-os.git /root/rebalance-os
+cd /root/rebalance-os
+
+# Python venv with the web extra
+python3.12 -m venv .venv
+.venv/bin/pip install -U pip
+.venv/bin/pip install -e ".[web]"
+
+# DB + pulse-mirror dirs (matches systemd ReadWritePaths)
+mkdir -p /var/lib/rbos-web
+
+# Pulse mirror — the same private repo each Mac pushes into.
+# Replace <pulse-repo-ssh> with the SSH URL of the rebalance-git-pulse repo.
+git clone <pulse-repo-ssh> /root/rebalance-pulse-mirror
+```
+
+## 2. Runtime env file
+
+```bash
+cp deploy/rebalance-web.env.example /root/rebalance-os/.env.runtime
+chmod 600 /root/rebalance-os/.env.runtime
+$EDITOR /root/rebalance-os/.env.runtime   # paste GITHUB_TOKEN, optional BASIC_AUTH_*
+```
+
+## 3. Install systemd units
+
+```bash
+install -m 0644 deploy/rebalance-web.service          /etc/systemd/system/
+install -m 0644 deploy/rebalance-web-pull.service     /etc/systemd/system/
+install -m 0644 deploy/rebalance-web-pull.timer       /etc/systemd/system/
+
+systemctl daemon-reload
+systemctl enable --now rebalance-web.service
+systemctl enable --now rebalance-web-pull.timer
+```
+
+## 4. Smoke test
+
+```bash
+systemctl status rebalance-web                   # should be active (running)
+systemctl status rebalance-web-pull.timer        # should be active (waiting)
+curl -s http://127.0.0.1:2030/api/health | jq
+
+# After ~10 min (or POST /api/refresh), verify activity rows:
+curl -s "http://127.0.0.1:2030/api/activity?since=24h" | jq '.count, .rows[0]'
+```
+
+## 5. Expose to your browser
+
+Pick **one** of:
+
+- **Tailscale** (simplest): `tailscale serve https / http://127.0.0.1:2030`
+- **nginx**: reverse-proxy `dashboard.<your-domain>` to `127.0.0.1:2030` with
+  Let's Encrypt + HTTP basic auth (set `BASIC_AUTH_USER`/`PASS` in
+  `.env.runtime` so FastAPI also requires creds).
+
+Sleuth on `:2020` is not affected — it keeps its own bearer-token API.
+
+## 6. Updating
+
+```bash
+ssh root@<vultr-host>
+cd /root/rebalance-os
+git pull
+.venv/bin/pip install -e ".[web]"
+systemctl restart rebalance-web
+```
+
+## 7. Logs
+
+```bash
+journalctl -u rebalance-web -f
+journalctl -u rebalance-web-pull -n 50
+```
+
+## 8. Rolling back
+
+```bash
+systemctl disable --now rebalance-web rebalance-web-pull.timer
+rm /etc/systemd/system/rebalance-web*.service /etc/systemd/system/rebalance-web*.timer
+systemctl daemon-reload
+```

--- a/deploy/rebalance-web-pull.service
+++ b/deploy/rebalance-web-pull.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Pull rebalance-os device-pulse mirror from GitHub
+After=network-online.target
+
+[Service]
+Type=oneshot
+User=root
+WorkingDirectory=/root/rebalance-pulse-mirror
+ExecStart=/usr/bin/git pull --ff-only --quiet
+TimeoutStartSec=60

--- a/deploy/rebalance-web-pull.timer
+++ b/deploy/rebalance-web-pull.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Periodic rebalance-os device-pulse mirror pull (every 10 min)
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=10min
+Unit=rebalance-web-pull.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/rebalance-web.env.example
+++ b/deploy/rebalance-web.env.example
@@ -1,0 +1,26 @@
+# /root/rebalance-os/.env.runtime  (mode 600)
+# Copy to that path on the Vultr host and `chmod 600` it.
+
+# GitHub PAT with repo:read scope.
+GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
+
+# SQLite path used exclusively by the web dashboard. Keep separate from
+# the local rebalance.db on developer machines so the server's ingest
+# loop can run without contention.
+REBALANCE_WEB_DB=/var/lib/rbos-web/web.db
+
+# Directory that the rebalance-web-pull.timer keeps in sync. Each
+# Mac's git-pulse collect.sh pushes pulse-<device>.md files here.
+REBALANCE_PULSE_MIRROR=/root/rebalance-pulse-mirror
+
+# Optional — protect the dashboard with HTTP Basic auth. Leave both
+# unset to disable (recommended only when bound to localhost behind
+# nginx or Tailscale).
+BASIC_AUTH_USER=
+BASIC_AUTH_PASS=
+
+# Ingest cycle interval in seconds. Default is 10 min.
+REBALANCE_WEB_INGEST_SECS=600
+
+# Page auto-refresh interval in milliseconds. Default 10 min.
+REBALANCE_WEB_AUTO_REFRESH_MS=600000

--- a/deploy/rebalance-web.service
+++ b/deploy/rebalance-web.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=rebalance-os activity dashboard (FastAPI)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/root/rebalance-os
+EnvironmentFile=-/root/rebalance-os/.env.runtime
+ExecStart=/root/rebalance-os/.venv/bin/uvicorn rebalance.web.app:app \
+    --host 127.0.0.1 \
+    --port 2030 \
+    --proxy-headers
+Restart=on-failure
+RestartSec=5s
+
+# Hardening — same posture as sleuth-app
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/root/rebalance-os /var/lib/rbos-web /root/rebalance-pulse-mirror
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,11 @@ calendar = [
 embeddings = [
   "mlx-embeddings>=0.1.0",
 ]
+web = [
+  "fastapi>=0.110.0",
+  "uvicorn[standard]>=0.27.0",
+  "jinja2>=3.1.0",
+]
 
 [project.scripts]
 rebalance = "rebalance.cli:app"
@@ -35,3 +40,6 @@ package-dir = {"" = "src"}
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools.package-data]
+"rebalance.web" = ["templates/*.html", "static/*.css", "static/*.js"]

--- a/src/rebalance/ingest/agent_tags.py
+++ b/src/rebalance/ingest/agent_tags.py
@@ -1,0 +1,82 @@
+"""
+Classify a unit of GitHub activity by its likely originator.
+
+Distinguishes between:
+- ``claude-cloud`` — Claude Code cloud sessions (branch ``claude/*`` or
+  Co-authored-by trailer naming Claude)
+- ``codex-cloud`` — OpenAI Codex Cloud sessions (branch ``codex/*`` or the
+  ``chatgpt-codex-connector[bot]`` author)
+- ``lovable``     — Lovable UI editor (``lovable-dev[bot]`` / ``lovable[bot]``
+  author, or branch starting with ``lovable-``)
+- ``local-vscode``— Local VS Code agent sessions on user's Macs (commit
+  message carries the git-pulse device marker injected by collect.sh)
+- ``human``       — Anything else
+
+Pure logic — no I/O, no database access. Easy to unit-test.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+LOVABLE_AUTHORS = {"lovable-dev[bot]", "lovable[bot]"}
+CODEX_AUTHORS = {"chatgpt-codex-connector[bot]", "codex-bot[bot]"}
+CLAUDE_AUTHORS = {"claude[bot]", "claude-bot[bot]"}
+
+_DEVICE_MARKER_RE = re.compile(r"\[git-pulse:device=[A-Za-z0-9_.-]+\]")
+_COAUTHOR_RE = re.compile(
+    r"Co-authored-by:\s*([^<\n]+?)\s*<", re.IGNORECASE | re.MULTILINE
+)
+
+
+def _coauthor_names(message: str) -> list[str]:
+    if not message:
+        return []
+    return [m.group(1).strip().lower() for m in _COAUTHOR_RE.finditer(message)]
+
+
+def classify(
+    *,
+    branch: str | None = None,
+    author_login: str | None = None,
+    committer_login: str | None = None,
+    commit_message: str | None = None,
+    co_authors: Iterable[str] | None = None,
+) -> str:
+    """Return one of ``claude-cloud``, ``codex-cloud``, ``lovable``,
+    ``local-vscode``, ``human``.
+    """
+    branch = (branch or "").strip()
+    author = (author_login or "").strip()
+    committer = (committer_login or "").strip()
+    message = commit_message or ""
+
+    explicit = [c.lower() for c in (co_authors or [])]
+    parsed = _coauthor_names(message)
+    coauthors = set(explicit) | set(parsed)
+
+    if author in LOVABLE_AUTHORS or committer in LOVABLE_AUTHORS:
+        return "lovable"
+    if branch.startswith("lovable-") or branch.startswith("lovable/"):
+        return "lovable"
+
+    if author in CODEX_AUTHORS or committer in CODEX_AUTHORS:
+        return "codex-cloud"
+    if branch.startswith("codex/"):
+        return "codex-cloud"
+
+    if author in CLAUDE_AUTHORS or committer in CLAUDE_AUTHORS:
+        return "claude-cloud"
+    if branch.startswith("claude/"):
+        return "claude-cloud"
+    if any("claude" in name for name in coauthors):
+        return "claude-cloud"
+
+    if _DEVICE_MARKER_RE.search(message):
+        return "local-vscode"
+
+    return "human"
+
+
+__all__ = ["classify"]

--- a/src/rebalance/ingest/db.py
+++ b/src/rebalance/ingest/db.py
@@ -461,6 +461,37 @@ def ensure_github_schema(conn: sqlite3.Connection) -> None:
     )
 
     conn.execute("""
+        CREATE TABLE IF NOT EXISTS github_workflow_runs (
+            id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+            repo_full_name      TEXT    NOT NULL,
+            run_id              INTEGER NOT NULL,
+            run_attempt         INTEGER NOT NULL DEFAULT 1,
+            workflow_name       TEXT,
+            event               TEXT,
+            head_branch         TEXT,
+            head_sha            TEXT,
+            status              TEXT,
+            conclusion          TEXT,
+            actor_login         TEXT,
+            triggering_actor_login TEXT,
+            run_url             TEXT,
+            created_at          TEXT,
+            updated_at          TEXT,
+            run_started_at      TEXT,
+            fetched_at          TEXT    NOT NULL,
+            UNIQUE(repo_full_name, run_id, run_attempt) ON CONFLICT REPLACE
+        )
+    """)
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_github_workflow_runs_repo_created "
+        "ON github_workflow_runs(repo_full_name, created_at DESC)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_github_workflow_runs_head_sha "
+        "ON github_workflow_runs(head_sha)"
+    )
+
+    conn.execute("""
         CREATE TABLE IF NOT EXISTS github_links (
             id                  INTEGER PRIMARY KEY AUTOINCREMENT,
             repo_full_name      TEXT    NOT NULL,

--- a/src/rebalance/ingest/github_workflows.py
+++ b/src/rebalance/ingest/github_workflows.py
@@ -1,0 +1,168 @@
+"""
+GitHub Actions workflow-run ingestion.
+
+Fills the gap left by ``github_knowledge.sync_github_repo``, which only
+captures per-PR check runs (keyed by head SHA).  This module pulls the
+full ``/repos/{owner}/{repo}/actions/runs`` feed so the web dashboard can
+show CI pass/fail status for any push or schedule, not just PR heads.
+
+Storage: ``github_workflow_runs`` table — see ``db.ensure_github_schema``.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from rebalance.ingest.db import db_connection, ensure_github_schema
+
+GITHUB_API = "https://api.github.com"
+
+
+def _headers(token: str) -> dict[str, str]:
+    return {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github.v3+json",
+        "User-Agent": "rebalance-os/0.1",
+    }
+
+
+def _get(url: str, token: str) -> tuple[int, Any]:
+    req = urllib.request.Request(url, headers=_headers(token))
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return exc.code, None
+    except urllib.error.URLError:
+        return 0, None
+
+
+def fetch_workflow_runs(
+    repo_full_name: str,
+    token: str,
+    *,
+    since_days: int = 7,
+    per_page: int = 50,
+    max_pages: int = 4,
+) -> list[dict[str, Any]]:
+    """Return raw workflow run dicts from the GitHub REST API.
+
+    The ``created`` query filter keeps the response window predictable so
+    we don't drag in months of history on first sync.
+    """
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=since_days)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    runs: list[dict[str, Any]] = []
+    for page in range(1, max_pages + 1):
+        params = urllib.parse.urlencode(
+            {"per_page": per_page, "page": page, "created": f">={cutoff}"}
+        )
+        url = f"{GITHUB_API}/repos/{repo_full_name}/actions/runs?{params}"
+        status, data = _get(url, token)
+        if status != 200 or not isinstance(data, dict):
+            break
+        page_runs = data.get("workflow_runs") or []
+        if not isinstance(page_runs, list) or not page_runs:
+            break
+        runs.extend(page_runs)
+        if len(page_runs) < per_page:
+            break
+    return runs
+
+
+def upsert_workflow_runs(
+    database_path: Path,
+    repo_full_name: str,
+    runs: Iterable[dict[str, Any]],
+) -> int:
+    """Upsert workflow runs into ``github_workflow_runs``. Returns row count."""
+    fetched_at = datetime.now(timezone.utc).isoformat()
+    rows: list[tuple[Any, ...]] = []
+    for run in runs:
+        if not isinstance(run, dict):
+            continue
+        actor = (run.get("actor") or {}).get("login")
+        triggering_actor = (run.get("triggering_actor") or {}).get("login")
+        rows.append(
+            (
+                repo_full_name,
+                int(run.get("id") or 0),
+                int(run.get("run_attempt") or 1),
+                run.get("name"),
+                run.get("event"),
+                run.get("head_branch"),
+                run.get("head_sha"),
+                run.get("status"),
+                run.get("conclusion"),
+                actor,
+                triggering_actor,
+                run.get("html_url"),
+                run.get("created_at"),
+                run.get("updated_at"),
+                run.get("run_started_at"),
+                fetched_at,
+            )
+        )
+    if not rows:
+        return 0
+    with db_connection(database_path, ensure_github_schema) as conn:
+        conn.executemany(
+            """
+            INSERT INTO github_workflow_runs (
+                repo_full_name, run_id, run_attempt, workflow_name, event,
+                head_branch, head_sha, status, conclusion, actor_login,
+                triggering_actor_login, run_url, created_at, updated_at,
+                run_started_at, fetched_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            rows,
+        )
+        conn.commit()
+    return len(rows)
+
+
+def sync_workflow_runs(
+    database_path: Path,
+    repo_full_name: str,
+    token: str,
+    *,
+    since_days: int = 7,
+) -> int:
+    """Fetch and upsert in one call. Returns the number of rows written."""
+    runs = fetch_workflow_runs(repo_full_name, token, since_days=since_days)
+    return upsert_workflow_runs(database_path, repo_full_name, runs)
+
+
+def latest_run_for_sha(
+    conn: sqlite3.Connection, repo_full_name: str, head_sha: str
+) -> dict[str, Any] | None:
+    """Return the most recent workflow run for a given commit SHA, or None."""
+    if not head_sha:
+        return None
+    row = conn.execute(
+        """
+        SELECT workflow_name, status, conclusion, run_url, created_at
+        FROM github_workflow_runs
+        WHERE repo_full_name = ? AND head_sha = ?
+        ORDER BY created_at DESC
+        LIMIT 1
+        """,
+        (repo_full_name, head_sha),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+__all__ = [
+    "fetch_workflow_runs",
+    "upsert_workflow_runs",
+    "sync_workflow_runs",
+    "latest_run_for_sha",
+]

--- a/src/rebalance/web/__init__.py
+++ b/src/rebalance/web/__init__.py
@@ -1,0 +1,2 @@
+"""rebalance-os web dashboard — fuses GitHub remote activity with local
+device pulse files into a single status page hosted on the Vultr server."""

--- a/src/rebalance/web/app.py
+++ b/src/rebalance/web/app.py
@@ -1,0 +1,159 @@
+"""
+FastAPI entry point for the rebalance-os web dashboard.
+
+Run locally:
+    GITHUB_TOKEN=$(gh auth token) REBALANCE_WEB_DB=/tmp/rbos-web.db \
+        uvicorn rebalance.web.app:app --reload --port 2030
+
+Routes:
+    GET  /                  — single-page HTML dashboard
+    GET  /api/activity      — JSON feed (?since=24h | 7d | ISO)
+    POST /api/refresh       — trigger an immediate ingest cycle
+    GET  /api/health        — health snapshot for uptime checks
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import secrets
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+from fastapi import Depends, FastAPI, HTTPException, Request, status
+from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+from rebalance.web import sources
+from rebalance.web.feed import build_feed
+from rebalance.web.ingest_loop import IngestState, loop_forever, run_once
+
+
+def _resolve_db_path() -> Path:
+    raw = os.environ.get("REBALANCE_WEB_DB") or os.environ.get("REBALANCE_DB")
+    if raw:
+        return Path(raw).expanduser()
+    return Path.home() / ".rebalance" / "web.db"
+
+
+def _resolve_mirror_path() -> Path | None:
+    raw = os.environ.get("REBALANCE_PULSE_MIRROR")
+    if not raw:
+        return None
+    return Path(raw).expanduser()
+
+
+DB_PATH = _resolve_db_path()
+MIRROR_PATH = _resolve_mirror_path()
+PACKAGE_DIR = Path(__file__).parent
+INGEST_STATE = IngestState()
+
+_basic = HTTPBasic(auto_error=False)
+_BASIC_USER = os.environ.get("BASIC_AUTH_USER")
+_BASIC_PASS = os.environ.get("BASIC_AUTH_PASS")
+
+
+def _check_basic_auth(creds: HTTPBasicCredentials | None = Depends(_basic)) -> None:
+    if not _BASIC_USER or not _BASIC_PASS:
+        return
+    if creds is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="basic auth required",
+            headers={"WWW-Authenticate": "Basic"},
+        )
+    user_ok = secrets.compare_digest(creds.username, _BASIC_USER)
+    pass_ok = secrets.compare_digest(creds.password, _BASIC_PASS)
+    if not (user_ok and pass_ok):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid credentials",
+            headers={"WWW-Authenticate": "Basic"},
+        )
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    task: asyncio.Task | None = None
+    if os.environ.get("REBALANCE_WEB_DISABLE_LOOP") != "1":
+        task = asyncio.create_task(loop_forever(DB_PATH, INGEST_STATE))
+    try:
+        yield
+    finally:
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass
+
+
+app = FastAPI(title="rebalance-os activity dashboard", lifespan=lifespan)
+templates = Jinja2Templates(directory=str(PACKAGE_DIR / "templates"))
+app.mount(
+    "/static",
+    StaticFiles(directory=str(PACKAGE_DIR / "static")),
+    name="static",
+)
+
+
+@app.get("/", response_class=HTMLResponse)
+def index(request: Request, _: None = Depends(_check_basic_auth)) -> HTMLResponse:
+    return templates.TemplateResponse(
+        request,
+        "index.html",
+        {
+            "auto_refresh_ms": int(os.environ.get("REBALANCE_WEB_AUTO_REFRESH_MS", "600000")),
+        },
+    )
+
+
+@app.get("/api/activity")
+def api_activity(
+    since: str = "24h",
+    _: None = Depends(_check_basic_auth),
+) -> JSONResponse:
+    rows = build_feed(DB_PATH, MIRROR_PATH, since)
+    return JSONResponse(
+        {
+            "since": since,
+            "count": len(rows),
+            "rows": rows,
+            "ingest": {
+                "last_started_at": INGEST_STATE.last_started_at,
+                "last_finished_at": INGEST_STATE.last_finished_at,
+                "last_error": INGEST_STATE.last_error,
+                "in_flight": INGEST_STATE.in_flight,
+                "watched_repos": INGEST_STATE.last_repos,
+            },
+        }
+    )
+
+
+@app.post("/api/refresh")
+async def api_refresh(_: None = Depends(_check_basic_auth)) -> JSONResponse:
+    if INGEST_STATE.in_flight:
+        return JSONResponse(
+            {"ok": False, "reason": "ingest already in flight",
+             "started_at": INGEST_STATE.last_started_at},
+            status_code=409,
+        )
+    summary = await asyncio.to_thread(run_once, DB_PATH, INGEST_STATE)
+    return JSONResponse({"ok": "error" not in summary, "summary": summary})
+
+
+@app.get("/api/health")
+def api_health(_: None = Depends(_check_basic_auth)) -> JSONResponse:
+    info = sources.health(DB_PATH, MIRROR_PATH)
+    info["ingest"] = {
+        "cycles_completed": INGEST_STATE.cycles_completed,
+        "last_started_at": INGEST_STATE.last_started_at,
+        "last_finished_at": INGEST_STATE.last_finished_at,
+        "in_flight": INGEST_STATE.in_flight,
+        "last_error": INGEST_STATE.last_error,
+        "watched_repos": INGEST_STATE.last_repos,
+    }
+    return JSONResponse(info)

--- a/src/rebalance/web/feed.py
+++ b/src/rebalance/web/feed.py
@@ -1,0 +1,179 @@
+"""
+Build the unified activity feed shown on the dashboard.
+
+A feed row is the smallest unit the page renders — a single commit, PR
+event, workflow run, or local-device session. Each row carries enough
+context for a human to understand what happened and to deep-link into
+GitHub if they want more.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from rebalance.ingest.agent_tags import classify
+from rebalance.web import sources
+
+
+@dataclass
+class CIBadge:
+    status: str | None = None
+    conclusion: str | None = None
+    url: str | None = None
+    name: str | None = None
+
+    @property
+    def color(self) -> str:
+        c = (self.conclusion or "").lower()
+        s = (self.status or "").lower()
+        if c == "success":
+            return "green"
+        if c in {"failure", "timed_out", "cancelled", "startup_failure",
+                 "action_required", "stale"}:
+            return "red"
+        if s in {"in_progress", "queued", "pending", "waiting"}:
+            return "yellow"
+        if not c and not s:
+            return "grey"
+        return "grey"
+
+
+@dataclass
+class FeedRow:
+    when: str
+    repo: str
+    branch: str | None
+    kind: str
+    title: str
+    actor: str | None
+    source_tag: str
+    links: dict[str, str | None] = field(default_factory=dict)
+    ci: CIBadge | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        if self.ci is not None:
+            d["ci"]["color"] = self.ci.color
+        return d
+
+
+def _commit_title(message: str | None) -> str:
+    if not message:
+        return ""
+    return message.split("\n", 1)[0].strip()[:200]
+
+
+def build_feed(database_path: Path, mirror_path: Path | None, since: str | None) -> list[dict[str, Any]]:
+    cutoff = sources._parse_since(since)
+
+    rows: list[FeedRow] = []
+
+    for c in sources.read_github_commits(database_path, cutoff):
+        title = _commit_title(c.get("message"))
+        branch = c.get("run_branch")
+        ci = None
+        if c.get("run_url") or c.get("run_status") or c.get("run_conclusion"):
+            ci = CIBadge(
+                status=c.get("run_status"),
+                conclusion=c.get("run_conclusion"),
+                url=c.get("run_url"),
+                name=c.get("run_name"),
+            )
+        rows.append(
+            FeedRow(
+                when=c.get("committed_at") or "",
+                repo=c["repo"],
+                branch=branch,
+                kind="commit",
+                title=title or c.get("sha", "")[:7],
+                actor=c.get("author"),
+                source_tag=classify(
+                    branch=branch,
+                    author_login=c.get("author"),
+                    commit_message=c.get("message"),
+                ),
+                links={
+                    "commit": c.get("commit_url"),
+                    "pr": None,
+                    "run": ci.url if ci else None,
+                },
+                ci=ci,
+            )
+        )
+
+    for p in sources.read_pull_requests(database_path, cutoff):
+        if p.get("merged_at"):
+            kind = "pr_merged"
+            when = p["merged_at"]
+        elif p.get("state") == "closed":
+            kind = "pr_closed"
+            when = p.get("updated_at") or p.get("created_at") or ""
+        else:
+            kind = "pr_opened"
+            when = p.get("created_at") or p.get("updated_at") or ""
+        rows.append(
+            FeedRow(
+                when=when or "",
+                repo=p["repo"],
+                branch=p.get("branch"),
+                kind=kind,
+                title=f"#{p['number']} {p.get('title') or ''}".strip(),
+                actor=p.get("author"),
+                source_tag=classify(
+                    branch=p.get("branch"),
+                    author_login=p.get("author"),
+                ),
+                links={
+                    "commit": None,
+                    "pr": p.get("html_url"),
+                    "run": None,
+                },
+            )
+        )
+
+    for w in sources.read_workflow_runs(database_path, cutoff):
+        ci = CIBadge(
+            status=w.get("status"),
+            conclusion=w.get("conclusion"),
+            url=w.get("run_url"),
+            name=w.get("workflow_name"),
+        )
+        rows.append(
+            FeedRow(
+                when=w.get("created_at") or "",
+                repo=w["repo"],
+                branch=w.get("head_branch"),
+                kind="workflow_run",
+                title=f"{w.get('workflow_name') or 'workflow'} · {w.get('event') or ''}".strip(" ·"),
+                actor=w.get("actor_login"),
+                source_tag=classify(
+                    branch=w.get("head_branch"),
+                    author_login=w.get("actor_login"),
+                ),
+                links={"commit": None, "pr": None, "run": w.get("run_url")},
+                ci=ci,
+            )
+        )
+
+    for d in sources.read_device_pulses(mirror_path or Path("/nonexistent"), cutoff):
+        rows.append(
+            FeedRow(
+                when=d.when,
+                repo=d.repo,
+                branch=d.branch,
+                kind="local_session",
+                title=d.subject,
+                actor=d.device,
+                source_tag="local-vscode",
+                links={"commit": None, "pr": None, "run": None},
+            )
+        )
+
+    rows.sort(key=lambda r: r.when, reverse=True)
+    return [r.to_dict() for r in rows[:300]]
+
+
+__all__ = ["build_feed", "CIBadge", "FeedRow"]

--- a/src/rebalance/web/ingest_loop.py
+++ b/src/rebalance/web/ingest_loop.py
@@ -1,0 +1,124 @@
+"""
+Background ingest loop for the web dashboard.
+
+Every ``REBALANCE_WEB_INGEST_SECS`` (default 600s = 10min) the loop:
+
+1. Resolves the watch list — union of (a) registry-active repos, (b) any
+   repo seen in the user's GitHub events feed in the last 14 days.
+2. Calls ``sync_github_repo`` for each repo (issues, PRs, commits,
+   check runs, links).
+3. Calls ``sync_workflow_runs`` for each repo (Actions runs).
+4. Records ``last_ingest`` timestamp + per-repo elapsed time.
+
+The loop is also exposed via ``run_once()`` so the ``/api/refresh`` endpoint
+can trigger an immediate cycle.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from rebalance.ingest import github_workflows
+from rebalance.ingest.config import get_github_token
+from rebalance.ingest.github_knowledge import sync_github_repo
+from rebalance.ingest.github_scan import _fetch_events, _get_login
+from rebalance.ingest.registry import get_projects
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class IngestState:
+    last_started_at: str | None = None
+    last_finished_at: str | None = None
+    last_error: str | None = None
+    last_repos: list[str] = field(default_factory=list)
+    in_flight: bool = False
+    cycles_completed: int = 0
+
+
+def _resolve_watch_list(token: str, database_path: Path) -> list[str]:
+    repos: set[str] = set()
+    for project in get_projects(database_path, status="active"):
+        for r in project.get("repos") or []:
+            if isinstance(r, str) and "/" in r:
+                repos.add(r.lower())
+
+    try:
+        login = _get_login(token)
+        events = _fetch_events(login, token, days=14)
+    except Exception as exc:  # noqa: BLE001 — we want to keep going on event-fetch errors
+        log.warning("event fetch failed during watch-list discovery: %s", exc)
+        events = []
+    for ev in events:
+        repo = (ev.get("repo") or {}).get("name")
+        if isinstance(repo, str) and "/" in repo:
+            repos.add(repo.lower())
+    return sorted(repos)
+
+
+def run_once(database_path: Path, state: IngestState) -> dict[str, Any]:
+    """Run a single ingest cycle synchronously. Returns a summary dict."""
+    if state.in_flight:
+        return {"skipped": True, "reason": "ingest already in flight"}
+    token = get_github_token()
+    if not token:
+        state.last_error = "no GitHub token (set GITHUB_TOKEN or run setup_github_token)"
+        return {"ok": False, "error": state.last_error}
+
+    state.in_flight = True
+    started = datetime.now(timezone.utc).isoformat()
+    state.last_started_at = started
+    summary: dict[str, Any] = {"started_at": started, "repos": []}
+
+    try:
+        watch = _resolve_watch_list(token, database_path)
+        state.last_repos = watch
+        for repo in watch:
+            entry: dict[str, Any] = {"repo": repo}
+            try:
+                sync_github_repo(database_path, repo, token, since_days=14)
+                entry["github"] = "ok"
+            except Exception as exc:  # noqa: BLE001
+                entry["github"] = f"error: {exc}"
+                log.exception("sync_github_repo failed for %s", repo)
+            try:
+                rows = github_workflows.sync_workflow_runs(
+                    database_path, repo, token, since_days=7
+                )
+                entry["workflow_rows"] = rows
+            except Exception as exc:  # noqa: BLE001
+                entry["workflow_rows"] = f"error: {exc}"
+                log.exception("sync_workflow_runs failed for %s", repo)
+            summary["repos"].append(entry)
+        state.last_error = None
+        state.cycles_completed += 1
+    except Exception as exc:  # noqa: BLE001
+        state.last_error = str(exc)
+        log.exception("ingest cycle failed")
+        summary["error"] = str(exc)
+    finally:
+        state.in_flight = False
+        state.last_finished_at = datetime.now(timezone.utc).isoformat()
+        summary["finished_at"] = state.last_finished_at
+    return summary
+
+
+async def loop_forever(database_path: Path, state: IngestState) -> None:
+    """Async loop driven by FastAPI's lifespan. Sleeps between cycles."""
+    interval = int(os.environ.get("REBALANCE_WEB_INGEST_SECS", "600"))
+    while True:
+        try:
+            await asyncio.to_thread(run_once, database_path, state)
+        except Exception:  # noqa: BLE001
+            log.exception("unexpected error in ingest loop")
+        await asyncio.sleep(interval)
+
+
+__all__ = ["IngestState", "run_once", "loop_forever", "_resolve_watch_list"]

--- a/src/rebalance/web/sources.py
+++ b/src/rebalance/web/sources.py
@@ -1,0 +1,217 @@
+"""
+Data readers for the web dashboard.
+
+Two sources, both read-only at query time:
+
+1. GitHub data already in the SQLite db (commits, items, workflow runs)
+   — populated by the periodic ingest loop in ``ingest_loop.py``.
+2. Local device pulse files (``pulse-<device>.md``) checked out into
+   the mirror directory by a systemd timer.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from rebalance.ingest.db import db_connection, ensure_github_schema
+
+
+@dataclass(frozen=True)
+class DevicePulseLine:
+    when: str
+    device: str
+    repo: str
+    branch: str
+    sha: str
+    subject: str
+
+
+def _parse_since(since: str | None) -> datetime:
+    """Accept ``24h`` / ``7d`` / ISO-8601; default to 24h."""
+    now = datetime.now(timezone.utc)
+    if not since:
+        return now - timedelta(hours=24)
+    s = since.strip().lower()
+    if s.endswith("h") and s[:-1].isdigit():
+        return now - timedelta(hours=int(s[:-1]))
+    if s.endswith("d") and s[:-1].isdigit():
+        return now - timedelta(days=int(s[:-1]))
+    try:
+        parsed = datetime.fromisoformat(s.replace("z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed
+    except ValueError:
+        return now - timedelta(hours=24)
+
+
+def read_github_commits(database_path: Path, since: datetime) -> list[dict[str, Any]]:
+    """Return commit rows joined with the latest workflow run per head_sha."""
+    cutoff = since.isoformat()
+    with db_connection(database_path, ensure_github_schema) as conn:
+        rows = conn.execute(
+            """
+            SELECT
+                c.repo_full_name AS repo,
+                c.sha            AS sha,
+                c.author_login   AS author,
+                c.message        AS message,
+                c.committed_at   AS committed_at,
+                c.html_url       AS commit_url,
+                c.item_type      AS item_type,
+                c.item_number    AS item_number,
+                w.workflow_name  AS run_name,
+                w.status         AS run_status,
+                w.conclusion     AS run_conclusion,
+                w.run_url        AS run_url,
+                w.head_branch    AS run_branch
+            FROM github_commits c
+            LEFT JOIN (
+                SELECT repo_full_name, head_sha, workflow_name, status,
+                       conclusion, run_url, head_branch,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY repo_full_name, head_sha
+                           ORDER BY created_at DESC
+                       ) AS rn
+                FROM github_workflow_runs
+            ) w
+              ON w.repo_full_name = c.repo_full_name
+             AND w.head_sha = c.sha
+             AND w.rn = 1
+            WHERE c.committed_at >= ?
+            ORDER BY c.committed_at DESC
+            LIMIT 500
+            """,
+            (cutoff,),
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def read_pull_requests(database_path: Path, since: datetime) -> list[dict[str, Any]]:
+    cutoff = since.isoformat()
+    with db_connection(database_path, ensure_github_schema) as conn:
+        rows = conn.execute(
+            """
+            SELECT
+                repo_full_name AS repo,
+                number,
+                title,
+                state,
+                is_merged,
+                author_login  AS author,
+                head_ref      AS branch,
+                head_sha,
+                html_url,
+                created_at,
+                updated_at,
+                merged_at
+            FROM github_items
+            WHERE item_type = 'pull_request' AND updated_at >= ?
+            ORDER BY updated_at DESC
+            LIMIT 200
+            """,
+            (cutoff,),
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def read_workflow_runs(database_path: Path, since: datetime) -> list[dict[str, Any]]:
+    cutoff = since.isoformat()
+    with db_connection(database_path, ensure_github_schema) as conn:
+        rows = conn.execute(
+            """
+            SELECT repo_full_name AS repo, run_id, workflow_name, event,
+                   head_branch, head_sha, status, conclusion, actor_login,
+                   run_url, created_at
+            FROM github_workflow_runs
+            WHERE created_at >= ?
+            ORDER BY created_at DESC
+            LIMIT 200
+            """,
+            (cutoff,),
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def read_device_pulses(mirror_path: Path, since: datetime) -> list[DevicePulseLine]:
+    """Read TSV-style pulse files emitted by ``experimental/git-pulse/collect.sh``.
+
+    Expected format per line (tab-separated):
+        <epoch>\t<iso8601>\t<repo>\t<branch>\t<sha>\t<subject>
+    Lines starting with ``#`` are ignored. Missing directory → empty list.
+    """
+    if not mirror_path or not mirror_path.exists():
+        return []
+    cutoff_epoch = int(since.timestamp())
+    out: list[DevicePulseLine] = []
+    for pulse_file in sorted(mirror_path.glob("pulse-*.md")):
+        device = pulse_file.stem.removeprefix("pulse-")
+        try:
+            text = pulse_file.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for raw in text.splitlines():
+            line = raw.rstrip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split("\t")
+            if len(parts) < 6:
+                continue
+            try:
+                epoch = int(parts[0])
+            except ValueError:
+                continue
+            if epoch < cutoff_epoch:
+                continue
+            out.append(
+                DevicePulseLine(
+                    when=parts[1],
+                    device=device,
+                    repo=parts[2],
+                    branch=parts[3],
+                    sha=parts[4],
+                    subject=parts[5],
+                )
+            )
+    out.sort(key=lambda p: p.when, reverse=True)
+    return out
+
+
+def health(database_path: Path, mirror_path: Path | None) -> dict[str, Any]:
+    """Lightweight health snapshot for ``/api/health``."""
+    info: dict[str, Any] = {
+        "ok": True,
+        "db_path": str(database_path),
+        "db_exists": database_path.exists(),
+        "db_size_bytes": database_path.stat().st_size if database_path.exists() else 0,
+        "mirror_path": str(mirror_path) if mirror_path else None,
+        "mirror_exists": bool(mirror_path and mirror_path.exists()),
+    }
+    if database_path.exists():
+        with db_connection(database_path, ensure_github_schema) as conn:
+            row = conn.execute(
+                "SELECT MAX(fetched_at) AS last FROM github_workflow_runs"
+            ).fetchone()
+            info["last_workflow_fetch"] = row["last"] if row else None
+            row = conn.execute(
+                "SELECT MAX(fetched_at) AS last FROM github_items"
+            ).fetchone()
+            info["last_items_fetch"] = row["last"] if row else None
+    info["server_time"] = datetime.now(timezone.utc).isoformat()
+    info["pid"] = os.getpid()
+    return info
+
+
+__all__ = [
+    "DevicePulseLine",
+    "_parse_since",
+    "read_github_commits",
+    "read_pull_requests",
+    "read_workflow_runs",
+    "read_device_pulses",
+    "health",
+]

--- a/src/rebalance/web/static/app.css
+++ b/src/rebalance/web/static/app.css
@@ -1,0 +1,125 @@
+:root {
+    --bg: #0e1116;
+    --fg: #e6edf3;
+    --muted: #8b949e;
+    --accent: #58a6ff;
+    --rule: #21262d;
+    --green: #3fb950;
+    --red: #f85149;
+    --yellow: #d29922;
+    --grey: #6e7681;
+    --chip-bg: #161b22;
+}
+
+* { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--fg);
+    font: 13px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+header {
+    padding: 12px 20px;
+    border-bottom: 1px solid var(--rule);
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    position: sticky;
+    top: 0;
+    background: var(--bg);
+    z-index: 10;
+}
+
+header h1 {
+    font-size: 14px;
+    margin: 0;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+}
+
+.controls { display: flex; gap: 12px; align-items: center; flex: 1; }
+.controls label { color: var(--muted); }
+.controls select, .controls button {
+    background: var(--chip-bg);
+    color: var(--fg);
+    border: 1px solid var(--rule);
+    padding: 4px 10px;
+    font: inherit;
+    cursor: pointer;
+}
+.controls button:hover { border-color: var(--accent); }
+.status { margin-left: auto; color: var(--muted); }
+
+#watched {
+    padding: 8px 20px;
+    color: var(--muted);
+    font-size: 11px;
+    border-bottom: 1px solid var(--rule);
+}
+
+.feed {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.row {
+    display: grid;
+    grid-template-columns: 90px 110px 200px 140px 80px 1fr 100px 80px;
+    gap: 12px;
+    padding: 6px 20px;
+    border-bottom: 1px solid var(--rule);
+    align-items: center;
+}
+
+.row:hover { background: rgba(88, 166, 255, 0.05); }
+
+.when { color: var(--muted); font-size: 11px; }
+
+.tag {
+    display: inline-block;
+    padding: 1px 6px;
+    border-radius: 3px;
+    font-size: 10px;
+    text-transform: uppercase;
+    text-align: center;
+    background: var(--chip-bg);
+    border: 1px solid var(--rule);
+}
+.tag-claude-cloud { color: #d2a8ff; border-color: #6e40c9; }
+.tag-codex-cloud  { color: #56d364; border-color: #238636; }
+.tag-lovable      { color: #ffa657; border-color: #bc4c00; }
+.tag-local-vscode { color: #79c0ff; border-color: #1f6feb; }
+.tag-human        { color: var(--muted); }
+
+.repo { color: var(--accent); text-decoration: none; }
+.repo:hover { text-decoration: underline; }
+
+.branch { color: var(--muted); font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.kind   { color: var(--muted); font-size: 10px; text-transform: uppercase; }
+.title  { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.actor  { color: var(--muted); font-size: 11px; text-align: right; }
+
+.ci {
+    text-align: center;
+    padding: 1px 6px;
+    border-radius: 3px;
+    font-size: 10px;
+    text-transform: uppercase;
+    border: 1px solid var(--rule);
+    text-decoration: none;
+    background: var(--chip-bg);
+}
+.ci-green  { color: var(--green); border-color: #1f6f2e; }
+.ci-red    { color: var(--red); border-color: #8b1f1f; }
+.ci-yellow { color: var(--yellow); border-color: #7d5a18; }
+.ci-grey   { color: var(--grey); }
+.ci-empty  { visibility: hidden; }
+
+@media (max-width: 900px) {
+    .row { grid-template-columns: 1fr; gap: 2px; padding: 8px 16px; }
+    .when, .branch, .kind, .actor { font-size: 11px; }
+}

--- a/src/rebalance/web/static/app.js
+++ b/src/rebalance/web/static/app.js
@@ -1,0 +1,106 @@
+"use strict";
+
+const $ = (sel) => document.querySelector(sel);
+const sinceSel = $("#since");
+const refreshBtn = $("#refresh");
+const statusEl = $("#status");
+const feedEl = $("#feed");
+const watchedEl = $("#watched");
+const tpl = $("#row-tpl");
+
+let timer = null;
+
+function timeAgo(iso) {
+    if (!iso) return "—";
+    const t = Date.parse(iso);
+    if (Number.isNaN(t)) return iso;
+    const diff = Math.max(0, Date.now() - t);
+    const m = Math.floor(diff / 60000);
+    if (m < 1) return "just now";
+    if (m < 60) return `${m}m ago`;
+    const h = Math.floor(m / 60);
+    if (h < 24) return `${h}h ago`;
+    const d = Math.floor(h / 24);
+    return `${d}d ago`;
+}
+
+function renderRow(row) {
+    const node = tpl.content.firstElementChild.cloneNode(true);
+    node.querySelector(".when").textContent = timeAgo(row.when);
+    const tag = node.querySelector(".tag");
+    tag.textContent = row.source_tag;
+    tag.classList.add(`tag-${row.source_tag}`);
+    const repo = node.querySelector(".repo");
+    repo.textContent = row.repo;
+    repo.href = `https://github.com/${row.repo}`;
+    node.querySelector(".branch").textContent = row.branch || "";
+    node.querySelector(".kind").textContent = row.kind.replace(/_/g, " ");
+    node.querySelector(".title").textContent = row.title || "";
+    node.querySelector(".actor").textContent = row.actor || "";
+    const ci = node.querySelector(".ci");
+    if (row.ci && (row.ci.url || row.ci.conclusion || row.ci.status)) {
+        ci.textContent = row.ci.conclusion || row.ci.status || "ci";
+        ci.href = row.ci.url || "#";
+        ci.classList.add(`ci-${row.ci.color || "grey"}`);
+    } else {
+        ci.classList.add("ci-empty");
+        ci.textContent = "—";
+    }
+    if (row.links && row.links.pr) {
+        repo.href = row.links.pr;
+    } else if (row.links && row.links.commit) {
+        repo.href = row.links.commit;
+    }
+    return node;
+}
+
+async function load() {
+    const since = sinceSel.value;
+    statusEl.textContent = "loading…";
+    try {
+        const resp = await fetch(`/api/activity?since=${encodeURIComponent(since)}`);
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const data = await resp.json();
+        feedEl.replaceChildren(...data.rows.map(renderRow));
+        const ingest = data.ingest || {};
+        const watched = (ingest.watched_repos || []).join(" · ") || "(no repos yet — try refresh)";
+        watchedEl.textContent = `watching ${ (ingest.watched_repos || []).length } repos · last sync ${timeAgo(ingest.last_finished_at)} · ${watched}`;
+        statusEl.textContent = `${data.count} rows · auto-refresh ${Math.round(window.AUTO_REFRESH_MS / 60000)}m`;
+    } catch (err) {
+        statusEl.textContent = `error: ${err.message}`;
+    }
+}
+
+async function manualRefresh() {
+    refreshBtn.disabled = true;
+    statusEl.textContent = "refreshing GitHub…";
+    try {
+        const resp = await fetch("/api/refresh", { method: "POST" });
+        if (resp.status === 409) {
+            statusEl.textContent = "refresh already running…";
+        } else if (!resp.ok) {
+            throw new Error(`HTTP ${resp.status}`);
+        }
+    } catch (err) {
+        statusEl.textContent = `refresh failed: ${err.message}`;
+    } finally {
+        refreshBtn.disabled = false;
+        await load();
+    }
+}
+
+function schedule() {
+    if (timer) clearInterval(timer);
+    timer = setInterval(() => {
+        if (document.visibilityState === "visible") load();
+    }, window.AUTO_REFRESH_MS || 600000);
+}
+
+sinceSel.addEventListener("change", load);
+refreshBtn.addEventListener("click", manualRefresh);
+document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible") load();
+});
+
+load();
+schedule();

--- a/src/rebalance/web/templates/index.html
+++ b/src/rebalance/web/templates/index.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>rebalance · activity</title>
+    <link rel="stylesheet" href="/static/app.css">
+</head>
+<body>
+<header>
+    <h1>activity</h1>
+    <div class="controls">
+        <label>
+            window
+            <select id="since">
+                <option value="6h">6h</option>
+                <option value="24h" selected>24h</option>
+                <option value="3d">3d</option>
+                <option value="7d">7d</option>
+            </select>
+        </label>
+        <button id="refresh">refresh</button>
+        <span id="status" class="status">loading…</span>
+    </div>
+</header>
+
+<section id="watched"></section>
+
+<main>
+    <ol id="feed" class="feed"></ol>
+</main>
+
+<template id="row-tpl">
+    <li class="row">
+        <span class="when"></span>
+        <span class="tag"></span>
+        <a class="repo" target="_blank" rel="noopener"></a>
+        <span class="branch"></span>
+        <span class="kind"></span>
+        <span class="title"></span>
+        <span class="actor"></span>
+        <a class="ci" target="_blank" rel="noopener"></a>
+    </li>
+</template>
+
+<script>
+    window.AUTO_REFRESH_MS = {{ auto_refresh_ms | tojson }};
+</script>
+<script src="/static/app.js"></script>
+</body>
+</html>

--- a/tests/test_agent_tags.py
+++ b/tests/test_agent_tags.py
@@ -1,0 +1,78 @@
+"""Unit tests for the activity-source classifier."""
+
+from __future__ import annotations
+
+import unittest
+
+from rebalance.ingest.agent_tags import classify
+
+
+class AgentTagsTests(unittest.TestCase):
+    def test_claude_branch_pattern(self) -> None:
+        self.assertEqual(
+            classify(branch="claude/monitor-github-vscode-activity-nAeik",
+                     author_login="noelsaw"),
+            "claude-cloud",
+        )
+
+    def test_codex_branch_pattern(self) -> None:
+        self.assertEqual(
+            classify(branch="codex/refactor-foo", author_login="noelsaw"),
+            "codex-cloud",
+        )
+
+    def test_codex_bot_author(self) -> None:
+        self.assertEqual(
+            classify(branch="main", author_login="chatgpt-codex-connector[bot]"),
+            "codex-cloud",
+        )
+
+    def test_lovable_bot_author(self) -> None:
+        self.assertEqual(
+            classify(branch="main", author_login="lovable-dev[bot]"),
+            "lovable",
+        )
+
+    def test_lovable_branch_prefix(self) -> None:
+        self.assertEqual(
+            classify(branch="lovable-update-readme", author_login="noelsaw"),
+            "lovable",
+        )
+
+    def test_local_vscode_via_marker(self) -> None:
+        msg = "wip: refactor handler\n\n[git-pulse:device=mac-studio]"
+        self.assertEqual(
+            classify(branch="feature/foo", author_login="noelsaw",
+                     commit_message=msg),
+            "local-vscode",
+        )
+
+    def test_claude_via_co_author_trailer(self) -> None:
+        msg = "Fix bug\n\nCo-authored-by: Claude <noreply@anthropic.com>"
+        self.assertEqual(
+            classify(branch="main", author_login="noelsaw", commit_message=msg),
+            "claude-cloud",
+        )
+
+    def test_human_default(self) -> None:
+        self.assertEqual(
+            classify(branch="main", author_login="noelsaw",
+                     commit_message="chore: bump deps"),
+            "human",
+        )
+
+    def test_lovable_takes_precedence_over_codex_branch(self) -> None:
+        # Author is the lovable bot — that should win even if branch
+        # incidentally starts with codex/.
+        self.assertEqual(
+            classify(branch="codex/auto", author_login="lovable[bot]"),
+            "lovable",
+        )
+
+    def test_empty_inputs_return_human(self) -> None:
+        self.assertEqual(classify(), "human")
+        self.assertEqual(classify(branch="", author_login=None), "human")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -1,0 +1,96 @@
+"""Tests for the workflow-runs ingestion module."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from rebalance.ingest import github_workflows
+from rebalance.ingest.db import db_connection, ensure_github_schema
+
+
+class WorkflowUpsertTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.db = Path(self._tmp.name) / "web.db"
+
+    def _runs(self) -> list[dict]:
+        return [
+            {
+                "id": 101,
+                "run_attempt": 1,
+                "name": "ci",
+                "event": "push",
+                "head_branch": "claude/foo",
+                "head_sha": "abc123",
+                "status": "completed",
+                "conclusion": "success",
+                "actor": {"login": "noelsaw"},
+                "triggering_actor": {"login": "noelsaw"},
+                "html_url": "https://github.com/o/r/actions/runs/101",
+                "created_at": "2026-05-01T12:00:00Z",
+                "updated_at": "2026-05-01T12:05:00Z",
+                "run_started_at": "2026-05-01T12:00:30Z",
+            },
+            {
+                "id": 101,
+                "run_attempt": 2,  # rerun — distinct row
+                "name": "ci",
+                "event": "push",
+                "head_branch": "claude/foo",
+                "head_sha": "abc123",
+                "status": "completed",
+                "conclusion": "failure",
+                "actor": {"login": "noelsaw"},
+                "html_url": "https://github.com/o/r/actions/runs/101",
+                "created_at": "2026-05-01T12:30:00Z",
+                "updated_at": "2026-05-01T12:35:00Z",
+            },
+        ]
+
+    def test_upsert_writes_two_rows_for_distinct_attempts(self) -> None:
+        n = github_workflows.upsert_workflow_runs(self.db, "o/r", self._runs())
+        self.assertEqual(n, 2)
+        with db_connection(self.db, ensure_github_schema) as conn:
+            rows = conn.execute(
+                "SELECT run_id, run_attempt, conclusion FROM github_workflow_runs ORDER BY run_attempt"
+            ).fetchall()
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]["conclusion"], "success")
+        self.assertEqual(rows[1]["conclusion"], "failure")
+
+    def test_upsert_replaces_on_conflict(self) -> None:
+        # First write
+        github_workflows.upsert_workflow_runs(self.db, "o/r", self._runs()[:1])
+        # Same key, different conclusion — should overwrite
+        updated = list(self._runs()[:1])
+        updated[0]["conclusion"] = "cancelled"
+        github_workflows.upsert_workflow_runs(self.db, "o/r", updated)
+        with db_connection(self.db, ensure_github_schema) as conn:
+            rows = conn.execute(
+                "SELECT conclusion FROM github_workflow_runs WHERE run_id = 101 AND run_attempt = 1"
+            ).fetchall()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["conclusion"], "cancelled")
+
+    def test_latest_run_for_sha(self) -> None:
+        github_workflows.upsert_workflow_runs(self.db, "o/r", self._runs())
+        with db_connection(self.db, ensure_github_schema) as conn:
+            latest = github_workflows.latest_run_for_sha(conn, "o/r", "abc123")
+        assert latest is not None
+        self.assertEqual(latest["conclusion"], "failure")
+
+    def test_empty_input_writes_nothing(self) -> None:
+        self.assertEqual(github_workflows.upsert_workflow_runs(self.db, "o/r", []), 0)
+        # Schema should still be created on first read
+        with db_connection(self.db, ensure_github_schema) as conn:
+            row = conn.execute(
+                "SELECT COUNT(*) AS c FROM github_workflow_runs"
+            ).fetchone()
+        self.assertEqual(row["c"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_web_feed.py
+++ b/tests/test_web_feed.py
@@ -1,0 +1,138 @@
+"""Tests for the web dashboard's feed builder + device-pulse reader."""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from rebalance.ingest.db import db_connection, ensure_github_schema
+from rebalance.web import feed, sources
+
+
+def _seed(db: Path) -> None:
+    with db_connection(db, ensure_github_schema) as conn:
+        conn.execute(
+            """
+            INSERT INTO github_commits
+                (repo_full_name, item_type, item_number, sha, author_login,
+                 message, committed_at, html_url, fetched_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "o/r",
+                "pull_request",
+                1,
+                "abc123",
+                "noelsaw",
+                "Refactor handler",
+                "2026-05-02T10:00:00+00:00",
+                "https://github.com/o/r/commit/abc123",
+                "2026-05-02T10:01:00+00:00",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO github_workflow_runs
+                (repo_full_name, run_id, run_attempt, workflow_name, event,
+                 head_branch, head_sha, status, conclusion, actor_login,
+                 triggering_actor_login, run_url, created_at, updated_at,
+                 run_started_at, fetched_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "o/r", 999, 1, "ci", "push", "claude/abc", "abc123",
+                "completed", "success", "noelsaw", "noelsaw",
+                "https://github.com/o/r/actions/runs/999",
+                "2026-05-02T10:02:00+00:00",
+                "2026-05-02T10:05:00+00:00",
+                "2026-05-02T10:02:30+00:00",
+                "2026-05-02T10:06:00+00:00",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO github_items
+                (repo_full_name, item_type, number, title, state, is_merged,
+                 author_login, head_ref, head_sha, html_url, created_at,
+                 updated_at, merged_at, fetched_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "o/r", "pull_request", 7, "Add dashboard", "closed", 1,
+                "noelsaw", "claude/dashboard", "abc123",
+                "https://github.com/o/r/pull/7",
+                "2026-05-01T08:00:00+00:00",
+                "2026-05-02T09:00:00+00:00",
+                "2026-05-02T09:00:00+00:00",
+                "2026-05-02T09:01:00+00:00",
+            ),
+        )
+        conn.commit()
+
+
+class FeedBuilderTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.db = Path(self._tmp.name) / "web.db"
+        _seed(self.db)
+
+    def test_feed_joins_commit_with_workflow_run(self) -> None:
+        rows = feed.build_feed(self.db, None, since="7d")
+        commit_rows = [r for r in rows if r["kind"] == "commit"]
+        self.assertEqual(len(commit_rows), 1)
+        commit = commit_rows[0]
+        self.assertEqual(commit["repo"], "o/r")
+        self.assertIsNotNone(commit["ci"])
+        self.assertEqual(commit["ci"]["conclusion"], "success")
+        self.assertEqual(commit["ci"]["color"], "green")
+
+    def test_pr_merged_gets_classified_via_branch(self) -> None:
+        rows = feed.build_feed(self.db, None, since="7d")
+        pr_rows = [r for r in rows if r["kind"] == "pr_merged"]
+        self.assertEqual(len(pr_rows), 1)
+        self.assertEqual(pr_rows[0]["source_tag"], "claude-cloud")
+
+    def test_workflow_row_color(self) -> None:
+        rows = feed.build_feed(self.db, None, since="7d")
+        wf = [r for r in rows if r["kind"] == "workflow_run"]
+        self.assertEqual(len(wf), 1)
+        self.assertEqual(wf[0]["ci"]["color"], "green")
+        self.assertEqual(wf[0]["source_tag"], "claude-cloud")
+
+    def test_since_filters_old_rows(self) -> None:
+        rows = feed.build_feed(self.db, None, since="1h")
+        self.assertEqual(rows, [])
+
+
+class DevicePulseReaderTests(unittest.TestCase):
+    def test_reads_tab_separated_lines(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            mirror = Path(td)
+            now = datetime.now(timezone.utc)
+            recent = now - timedelta(minutes=5)
+            old = now - timedelta(days=10)
+            (mirror / "pulse-mac-studio.md").write_text(
+                "# header line\n"
+                f"{int(recent.timestamp())}\t{recent.isoformat()}\to/r\tmain\tabc\tFix things\n"
+                f"{int(old.timestamp())}\t{old.isoformat()}\to/r\tmain\tdef\tStale\n",
+                encoding="utf-8",
+            )
+            results = sources.read_device_pulses(mirror, now - timedelta(hours=1))
+            self.assertEqual(len(results), 1)
+            self.assertEqual(results[0].device, "mac-studio")
+            self.assertEqual(results[0].subject, "Fix things")
+
+    def test_missing_dir_returns_empty(self) -> None:
+        self.assertEqual(
+            sources.read_device_pulses(Path("/nonexistent-nope"),
+                                       datetime.now(timezone.utc)),
+            [],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fuses GitHub remote activity (Claude Code cloud, Codex Cloud, Lovable) with
local VS Code agent work into a single status page so all in-flight work is
visible from one URL. Designed to live on the Vultr host alongside Production
Sleuth (port 2030 vs Sleuth's 2020).

- src/rebalance/web/ — FastAPI app with /, /api/activity, /api/refresh,
  /api/health. Background ingest loop runs every 10 min; manual refresh
  button triggers immediate cycle. Optional HTTP basic auth.
- src/rebalance/ingest/github_workflows.py — new workflow_runs ingester
  fills the gap left by check-runs-only capture.
- src/rebalance/ingest/agent_tags.py — pure classifier tags each row as
  claude-cloud / codex-cloud / lovable / local-vscode / human via branch
  prefix and author/co-author trailers.
- db.py — additive github_workflow_runs table (no migration of existing
  tables).
- deploy/ — systemd unit, env template, mirror-pull timer, INSTALL.md.
- 20 new unit tests cover the classifier, workflow upserts, feed builder,
  device-pulse reader.

https://claude.ai/code/session_01FcfHCm7WZJhwPXJh6fwSzB