### PR TITLE
Add GH Actions + Pages activity dashboard (server-free alternative)

### DIFF
--- a/.github/workflows/update-status.yml
+++ b/.github/workflows/update-status.yml
@@ -1,0 +1,66 @@
+name: Update activity status
+
+# Refreshes data/status.json (and the static frontend) on the orphan
+# `gh-pages` branch. Active hours only — 8am-8pm Pacific year-round, with
+# a small DST drift (PDT: 8am-9pm, PST: 7am-8pm). The cron is UTC.
+#
+# Cadence: every 15 minutes during the active window.
+# Budget:  ~52 runs/day × 30 days × ≤1 min each = ~1,560 min/month
+#          (free tier on a private repo is 2,000 min/month).
+#
+# Manual trigger: Actions tab → "Update activity status" → "Run workflow".
+
+on:
+  schedule:
+    - cron: '*/15 15-23,0-3 * * *'
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/update-status.yml'
+      - 'scripts/build_status.py'
+      - 'scripts/publish_gh_pages.sh'
+      - 'docs/**'
+      - 'src/rebalance/ingest/agent_tags.py'
+
+concurrency:
+  group: update-status
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # If you add the device-pulse repo as a submodule under
+          # ``experimental/git-pulse-mirror/``, flip this to ``recursive``
+          # and provide a deploy key via ``ssh-key:`` below.
+          submodules: false
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Build status.json
+        env:
+          # Use a fine-scoped PAT (repo:read on the orgs you watch) stored
+          # as a secret. The default GITHUB_TOKEN won't see other repos.
+          GH_TOKEN: ${{ secrets.STATUS_GH_TOKEN }}
+          # Optional override — comma-separated owner/name list. When unset
+          # the script discovers repos from the user's events feed.
+          REBALANCE_WATCH_REPOS: ${{ vars.REBALANCE_WATCH_REPOS }}
+        run: |
+          python scripts/build_status.py --out /tmp/status.json --window-days 7
+
+      - name: Publish to gh-pages branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: bash scripts/publish_gh_pages.sh /tmp/status.json

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ rebalance.db-wal
 /reports
 /git-pulse-reports
 /git-pulse-sync
+docs/data/

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,64 @@
+# Activity status dashboard (GitHub Pages)
+
+Single static page that fuses GitHub remote activity (Claude Code cloud,
+Codex Cloud, Lovable) with local VS Code agent work.  Hosted on GitHub
+Pages at the orphan `gh-pages` branch and auto-refreshed every 10 min.
+
+```
+.github/workflows/update-status.yml   ─┐
+scripts/build_status.py                │ runs every 15 min during 8am-8pm PT
+scripts/publish_gh_pages.sh           ─┘ → commits to orphan gh-pages branch
+
+docs/index.html, docs/app.{js,css}     ─→ copied into gh-pages by the Action
+
+(GitHub Pages)                         ─→ serves https://<org>.github.io/<repo>/
+```
+
+## One-time setup
+
+1. **Pages source** — Settings → Pages → "Build and deployment" →
+   "Deploy from a branch" → branch `gh-pages` / `(root)`. Save.
+   The branch will be created automatically by the first Action run.
+
+2. **Status PAT** — create a fine-scoped Personal Access Token with
+   `repo:read` on the orgs you want to monitor. Settings → Secrets and
+   variables → Actions → New repository secret → name `STATUS_GH_TOKEN`,
+   paste the token.
+
+3. **(Optional) Watch list** — Settings → Secrets and variables →
+   Actions → Variables → New repository variable →
+   name `REBALANCE_WATCH_REPOS`, value `owner1/repo1,owner2/repo2,…`.
+   When unset, the Action discovers repos from the user's events feed
+   (last 14 days).
+
+4. **(Optional) Local pulse data** — to pull device pulse markdown
+   files into the data feed, add the device-pulse repo as a submodule
+   under `experimental/git-pulse-mirror/`, then flip
+   `submodules: false` → `submodules: recursive` in the workflow.
+
+5. **First run** — Actions tab → "Update activity status" → "Run
+   workflow". The first run creates the `gh-pages` branch and uploads
+   `data/status.json` plus the static frontend.
+
+## Local development
+
+Generate a `status.json` against the live GitHub API and serve the page
+locally — no Action involved:
+
+```bash
+GH_TOKEN=$(gh auth token) python scripts/build_status.py \
+    --out docs/data/status.json --window-days 7
+mkdir -p docs/data
+python -m http.server -d docs 8080
+# open http://localhost:8080
+```
+
+## Cron and budget
+
+- Cron: `*/15 15-23,0-3 * * *` (UTC) — covers 8am–8pm Pacific year-round
+  with ±1 h DST drift.
+- Cost: ~52 runs/day × 30 days × ≤1 min each ≈ **1,560 min/month**, well
+  under the 2,000 min/month free tier on a private repo.
+- Skip-on-no-change: `publish_gh_pages.sh` runs `git diff --cached
+  --quiet` and exits without committing if nothing changed, so quiet
+  hours produce zero commits.

--- a/docs/app.css
+++ b/docs/app.css
@@ -1,0 +1,125 @@
+:root {
+    --bg: #0e1116;
+    --fg: #e6edf3;
+    --muted: #8b949e;
+    --accent: #58a6ff;
+    --rule: #21262d;
+    --green: #3fb950;
+    --red: #f85149;
+    --yellow: #d29922;
+    --grey: #6e7681;
+    --chip-bg: #161b22;
+}
+
+* { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--fg);
+    font: 13px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+header {
+    padding: 12px 20px;
+    border-bottom: 1px solid var(--rule);
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    position: sticky;
+    top: 0;
+    background: var(--bg);
+    z-index: 10;
+}
+
+header h1 {
+    font-size: 14px;
+    margin: 0;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+}
+
+.controls { display: flex; gap: 12px; align-items: center; flex: 1; flex-wrap: wrap; }
+.controls label { color: var(--muted); }
+.controls select, .controls button {
+    background: var(--chip-bg);
+    color: var(--fg);
+    border: 1px solid var(--rule);
+    padding: 4px 10px;
+    font: inherit;
+    cursor: pointer;
+}
+.controls button:hover { border-color: var(--accent); }
+.status { margin-left: auto; color: var(--muted); }
+
+#watched {
+    padding: 8px 20px;
+    color: var(--muted);
+    font-size: 11px;
+    border-bottom: 1px solid var(--rule);
+}
+
+.feed {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.row {
+    display: grid;
+    grid-template-columns: 90px 110px 240px 140px 80px 1fr 100px 80px;
+    gap: 12px;
+    padding: 6px 20px;
+    border-bottom: 1px solid var(--rule);
+    align-items: center;
+}
+
+.row:hover { background: rgba(88, 166, 255, 0.05); }
+
+.when { color: var(--muted); font-size: 11px; }
+
+.tag {
+    display: inline-block;
+    padding: 1px 6px;
+    border-radius: 3px;
+    font-size: 10px;
+    text-transform: uppercase;
+    text-align: center;
+    background: var(--chip-bg);
+    border: 1px solid var(--rule);
+}
+.tag-claude-cloud { color: #d2a8ff; border-color: #6e40c9; }
+.tag-codex-cloud  { color: #56d364; border-color: #238636; }
+.tag-lovable      { color: #ffa657; border-color: #bc4c00; }
+.tag-local-vscode { color: #79c0ff; border-color: #1f6feb; }
+.tag-human        { color: var(--muted); }
+
+.repo { color: var(--accent); text-decoration: none; }
+.repo:hover { text-decoration: underline; }
+
+.branch { color: var(--muted); font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.kind   { color: var(--muted); font-size: 10px; text-transform: uppercase; }
+.title  { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.actor  { color: var(--muted); font-size: 11px; text-align: right; }
+
+.ci {
+    text-align: center;
+    padding: 1px 6px;
+    border-radius: 3px;
+    font-size: 10px;
+    text-transform: uppercase;
+    border: 1px solid var(--rule);
+    text-decoration: none;
+    background: var(--chip-bg);
+}
+.ci-green  { color: var(--green); border-color: #1f6f2e; }
+.ci-red    { color: var(--red); border-color: #8b1f1f; }
+.ci-yellow { color: var(--yellow); border-color: #7d5a18; }
+.ci-grey   { color: var(--grey); }
+.ci-empty  { visibility: hidden; }
+
+@media (max-width: 900px) {
+    .row { grid-template-columns: 1fr; gap: 2px; padding: 8px 16px; }
+    .when, .branch, .kind, .actor { font-size: 11px; }
+}

--- a/docs/app.js
+++ b/docs/app.js
@@ -1,0 +1,127 @@
+"use strict";
+
+const AUTO_REFRESH_MS = 600_000;   // 10 minutes — same cadence as the cron
+const STATUS_URL = "./data/status.json";
+
+const $ = (sel) => document.querySelector(sel);
+const sinceSel = $("#since");
+const sourceSel = $("#source");
+const refreshBtn = $("#refresh");
+const statusEl = $("#status");
+const feedEl = $("#feed");
+const watchedEl = $("#watched");
+const tpl = $("#row-tpl");
+
+let timer = null;
+let cache = { rows: [], generated_at: null, watched_repos: [] };
+
+function timeAgo(iso) {
+    if (!iso) return "—";
+    const t = Date.parse(iso);
+    if (Number.isNaN(t)) return iso;
+    const diff = Math.max(0, Date.now() - t);
+    const m = Math.floor(diff / 60000);
+    if (m < 1) return "just now";
+    if (m < 60) return `${m}m ago`;
+    const h = Math.floor(m / 60);
+    if (h < 24) return `${h}h ago`;
+    const d = Math.floor(h / 24);
+    return `${d}d ago`;
+}
+
+function parseSinceMs(value) {
+    if (!value) return 24 * 3600 * 1000;
+    const num = parseInt(value, 10);
+    if (value.endsWith("h")) return num * 3600 * 1000;
+    if (value.endsWith("d")) return num * 86400 * 1000;
+    return num;
+}
+
+function applyFilters(rows) {
+    const sinceMs = parseSinceMs(sinceSel.value);
+    const cutoff = Date.now() - sinceMs;
+    const sourceFilter = sourceSel.value;
+    return rows.filter((r) => {
+        if (sourceFilter !== "all" && r.source_tag !== sourceFilter) return false;
+        const ts = Date.parse(r.when);
+        if (Number.isFinite(ts) && ts < cutoff) return false;
+        return true;
+    });
+}
+
+function renderRow(row) {
+    const node = tpl.content.firstElementChild.cloneNode(true);
+    node.querySelector(".when").textContent = timeAgo(row.when);
+
+    const tag = node.querySelector(".tag");
+    tag.textContent = row.source_tag || "human";
+    tag.classList.add(`tag-${row.source_tag || "human"}`);
+
+    const repo = node.querySelector(".repo");
+    repo.textContent = row.repo;
+    if (row.links && row.links.pr) {
+        repo.href = row.links.pr;
+    } else if (row.links && row.links.commit) {
+        repo.href = row.links.commit;
+    } else {
+        repo.href = `https://github.com/${row.repo}`;
+    }
+
+    node.querySelector(".branch").textContent = row.branch || "";
+    node.querySelector(".kind").textContent = (row.kind || "").replace(/_/g, " ");
+    node.querySelector(".title").textContent = row.title || "";
+    node.querySelector(".actor").textContent = row.actor || "";
+
+    const ci = node.querySelector(".ci");
+    if (row.ci && (row.ci.url || row.ci.conclusion || row.ci.status)) {
+        ci.textContent = row.ci.conclusion || row.ci.status || "ci";
+        ci.href = row.ci.url || "#";
+        ci.classList.add(`ci-${row.ci.color || "grey"}`);
+    } else {
+        ci.classList.add("ci-empty");
+        ci.textContent = "—";
+    }
+    return node;
+}
+
+function render() {
+    const rows = applyFilters(cache.rows || []);
+    feedEl.replaceChildren(...rows.map(renderRow));
+    const watched = cache.watched_repos || [];
+    watchedEl.textContent =
+        `watching ${watched.length} repos · ` +
+        `data generated ${timeAgo(cache.generated_at)} · ` +
+        (watched.join(" · ") || "(none yet — first cron run pending)");
+    statusEl.textContent =
+        `${rows.length}/${(cache.rows || []).length} rows · ` +
+        `auto-refresh ${Math.round(AUTO_REFRESH_MS / 60000)}m`;
+}
+
+async function load() {
+    statusEl.textContent = "loading…";
+    try {
+        const resp = await fetch(`${STATUS_URL}?t=${Date.now()}`, { cache: "no-store" });
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        cache = await resp.json();
+        render();
+    } catch (err) {
+        statusEl.textContent = `error: ${err.message}`;
+    }
+}
+
+function schedule() {
+    if (timer) clearInterval(timer);
+    timer = setInterval(() => {
+        if (document.visibilityState === "visible") load();
+    }, AUTO_REFRESH_MS);
+}
+
+sinceSel.addEventListener("change", render);
+sourceSel.addEventListener("change", render);
+refreshBtn.addEventListener("click", load);
+document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible") load();
+});
+
+load();
+schedule();

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>rebalance · activity</title>
+    <link rel="stylesheet" href="./app.css">
+</head>
+<body>
+<header>
+    <h1>activity</h1>
+    <div class="controls">
+        <label>
+            window
+            <select id="since">
+                <option value="6h">6h</option>
+                <option value="24h" selected>24h</option>
+                <option value="3d">3d</option>
+                <option value="7d">7d</option>
+            </select>
+        </label>
+        <label>
+            source
+            <select id="source">
+                <option value="all" selected>all</option>
+                <option value="claude-cloud">claude-cloud</option>
+                <option value="codex-cloud">codex-cloud</option>
+                <option value="lovable">lovable</option>
+                <option value="local-vscode">local-vscode</option>
+                <option value="human">human</option>
+            </select>
+        </label>
+        <button id="refresh" title="Re-fetch status.json (CDN may be ~1 min stale)">refresh</button>
+        <span id="status" class="status">loading…</span>
+    </div>
+</header>
+
+<section id="watched"></section>
+
+<main>
+    <ol id="feed" class="feed"></ol>
+</main>
+
+<template id="row-tpl">
+    <li class="row">
+        <span class="when"></span>
+        <span class="tag"></span>
+        <a class="repo" target="_blank" rel="noopener"></a>
+        <span class="branch"></span>
+        <span class="kind"></span>
+        <span class="title"></span>
+        <span class="actor"></span>
+        <a class="ci" target="_blank" rel="noopener"></a>
+    </li>
+</template>
+
+<script src="./app.js"></script>
+</body>
+</html>

--- a/scripts/build_status.py
+++ b/scripts/build_status.py
@@ -1,0 +1,506 @@
+#!/usr/bin/env python3
+"""
+Build the activity-status JSON consumed by the GitHub Pages dashboard.
+
+Designed to run inside ``.github/workflows/update-status.yml`` — one process,
+no SQLite, no FastAPI. Pulls fresh data from the GitHub REST API and writes a
+single ``status.json`` to the path passed via ``--out``.
+
+Output shape (frozen — frontend depends on it):
+
+    {
+      "generated_at": ISO-8601 UTC,
+      "window_days":  int,
+      "watched_repos": [...],
+      "rate_limit":   {"remaining": int, "limit": int, "reset_at": str},
+      "rows": [
+        {
+          "when":       ISO-8601,
+          "repo":       "owner/name",
+          "branch":     "claude/abc" | null,
+          "kind":       "commit" | "pr_opened" | "pr_merged" | "pr_closed"
+                        | "workflow_run" | "local_session",
+          "title":      str,
+          "actor":      str | null,
+          "source_tag": "claude-cloud" | "codex-cloud" | "lovable"
+                        | "local-vscode" | "human",
+          "links":      {"commit": url|null, "pr": url|null, "run": url|null},
+          "ci":         {"status", "conclusion", "url", "name", "color"} | null
+        }
+      ]
+    }
+
+Usage:
+    GH_TOKEN=ghp_… python scripts/build_status.py --out /tmp/status.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from rebalance.ingest.agent_tags import classify  # noqa: E402
+
+GITHUB_API = "https://api.github.com"
+DEFAULT_WINDOW_DAYS = 7
+EVENT_DISCOVERY_DAYS = 14
+DEFAULT_PER_REPO_LIMIT = 30
+USER_AGENT = "rebalance-os-status/0.1"
+
+
+# ---------------------------------------------------------------------------
+# HTTP helper with rate-limit handling
+# ---------------------------------------------------------------------------
+
+
+class GitHubClient:
+    def __init__(self, token: str) -> None:
+        self.token = token
+        self.rate_limit: dict[str, Any] = {"remaining": None, "limit": None, "reset_at": None}
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"token {self.token}",
+            "Accept": "application/vnd.github.v3+json",
+            "User-Agent": USER_AGENT,
+        }
+
+    def get(self, url: str) -> tuple[int, Any]:
+        req = urllib.request.Request(url, headers=self._headers())
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                self._record_limits(resp.headers)
+                return resp.status, json.loads(resp.read().decode())
+        except urllib.error.HTTPError as exc:
+            self._record_limits(exc.headers)
+            return exc.code, None
+        except urllib.error.URLError as exc:
+            print(f"[warn] network error fetching {url}: {exc}", file=sys.stderr)
+            return 0, None
+
+    def _record_limits(self, headers: Any) -> None:
+        if headers is None:
+            return
+        try:
+            remaining = headers.get("X-RateLimit-Remaining")
+            limit = headers.get("X-RateLimit-Limit")
+            reset = headers.get("X-RateLimit-Reset")
+            if remaining is not None:
+                self.rate_limit["remaining"] = int(remaining)
+            if limit is not None:
+                self.rate_limit["limit"] = int(limit)
+            if reset is not None:
+                self.rate_limit["reset_at"] = datetime.fromtimestamp(
+                    int(reset), tz=timezone.utc
+                ).isoformat()
+        except (ValueError, TypeError):
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Repo discovery
+# ---------------------------------------------------------------------------
+
+
+def discover_repos_from_events(client: GitHubClient, days: int) -> list[str]:
+    """Mirror ``github_scan.discover_repos_from_activity`` — events feed."""
+    status, data = client.get(f"{GITHUB_API}/user")
+    if status != 200 or not isinstance(data, dict):
+        return []
+    login = data.get("login")
+    if not login:
+        return []
+
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%d")
+    repos: set[str] = set()
+    for page in range(1, 4):
+        url = f"{GITHUB_API}/users/{login}/events?per_page=100&page={page}"
+        status, events = client.get(url)
+        if status != 200 or not isinstance(events, list):
+            break
+        reached_cutoff = False
+        for ev in events:
+            day = (ev.get("created_at") or "")[:10]
+            if day < cutoff:
+                reached_cutoff = True
+                break
+            repo = (ev.get("repo") or {}).get("name")
+            if isinstance(repo, str) and "/" in repo:
+                repos.add(repo)
+        if reached_cutoff or len(events) < 100:
+            break
+    return sorted(repos)
+
+
+def read_registry_repos(repo_root: Path) -> list[str]:
+    """
+    Read repos from ``Projects/00-project-registry.md`` if checked into the
+    repo. Falls back to an env var ``REBALANCE_WATCH_REPOS`` (comma-sep).
+
+    The registry file lives in the user's vault and is not checked in by
+    default, so most CI runs will rely on the env var or pure event discovery.
+    """
+    env_list = os.environ.get("REBALANCE_WATCH_REPOS", "").strip()
+    if env_list:
+        return [r.strip() for r in env_list.split(",") if r.strip() and "/" in r]
+
+    candidate = repo_root / "Projects" / "00-project-registry.md"
+    if not candidate.exists():
+        return []
+    repos: set[str] = set()
+    for line in candidate.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if "/" in stripped and len(stripped.split()) <= 2:
+            for tok in stripped.replace(",", " ").split():
+                if tok.count("/") == 1 and not tok.startswith(("http", "/", "#", "-")):
+                    repos.add(tok)
+    return sorted(repos)
+
+
+# ---------------------------------------------------------------------------
+# Per-repo fetchers
+# ---------------------------------------------------------------------------
+
+
+def _iso_cutoff(days: int) -> str:
+    return (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def fetch_commits(client: GitHubClient, repo: str, since: str, limit: int) -> list[dict[str, Any]]:
+    params = urllib.parse.urlencode({"since": since, "per_page": limit})
+    status, data = client.get(f"{GITHUB_API}/repos/{repo}/commits?{params}")
+    if status != 200 or not isinstance(data, list):
+        return []
+    return data
+
+
+def fetch_pulls(client: GitHubClient, repo: str, limit: int) -> list[dict[str, Any]]:
+    params = urllib.parse.urlencode(
+        {"state": "all", "sort": "updated", "direction": "desc", "per_page": limit}
+    )
+    status, data = client.get(f"{GITHUB_API}/repos/{repo}/pulls?{params}")
+    if status != 200 or not isinstance(data, list):
+        return []
+    return data
+
+
+def fetch_workflow_runs(
+    client: GitHubClient, repo: str, since: str, limit: int
+) -> list[dict[str, Any]]:
+    params = urllib.parse.urlencode(
+        {"per_page": limit, "created": f">={since}"}
+    )
+    status, data = client.get(f"{GITHUB_API}/repos/{repo}/actions/runs?{params}")
+    if status != 200 or not isinstance(data, dict):
+        return []
+    runs = data.get("workflow_runs") or []
+    return runs if isinstance(runs, list) else []
+
+
+# ---------------------------------------------------------------------------
+# Local pulse files (optional)
+# ---------------------------------------------------------------------------
+
+
+def read_device_pulses(mirror_path: Path, since: datetime) -> list[dict[str, Any]]:
+    if not mirror_path or not mirror_path.exists():
+        return []
+    cutoff_epoch = int(since.timestamp())
+    rows: list[dict[str, Any]] = []
+    for pulse_file in sorted(mirror_path.glob("pulse-*.md")):
+        device = pulse_file.stem.removeprefix("pulse-")
+        try:
+            text = pulse_file.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for raw in text.splitlines():
+            line = raw.rstrip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split("\t")
+            if len(parts) < 6:
+                continue
+            try:
+                epoch = int(parts[0])
+            except ValueError:
+                continue
+            if epoch < cutoff_epoch:
+                continue
+            rows.append(
+                {
+                    "when": parts[1],
+                    "device": device,
+                    "repo": parts[2],
+                    "branch": parts[3],
+                    "sha": parts[4],
+                    "subject": parts[5],
+                }
+            )
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# CI-color helper
+# ---------------------------------------------------------------------------
+
+
+def _ci_color(status: str | None, conclusion: str | None) -> str:
+    c = (conclusion or "").lower()
+    s = (status or "").lower()
+    if c == "success":
+        return "green"
+    if c in {"failure", "timed_out", "cancelled", "startup_failure", "action_required", "stale"}:
+        return "red"
+    if s in {"in_progress", "queued", "pending", "waiting"}:
+        return "yellow"
+    return "grey"
+
+
+def _commit_title(message: str | None) -> str:
+    if not message:
+        return ""
+    return message.split("\n", 1)[0].strip()[:200]
+
+
+# ---------------------------------------------------------------------------
+# Row builders
+# ---------------------------------------------------------------------------
+
+
+def _index_runs_by_sha(runs: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Return the most recent run per head_sha (runs are usually newest-first)."""
+    by_sha: dict[str, dict[str, Any]] = {}
+    for run in runs:
+        sha = run.get("head_sha")
+        if not isinstance(sha, str):
+            continue
+        existing = by_sha.get(sha)
+        if existing is None or (run.get("created_at") or "") > (existing.get("created_at") or ""):
+            by_sha[sha] = run
+    return by_sha
+
+
+def build_rows(
+    repo: str,
+    commits: list[dict[str, Any]],
+    pulls: list[dict[str, Any]],
+    runs: list[dict[str, Any]],
+    pr_window_iso: str,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    runs_by_sha = _index_runs_by_sha(runs)
+
+    for c in commits:
+        commit_block = c.get("commit") or {}
+        author_block = c.get("author") or {}
+        committer_block = c.get("committer") or {}
+        message = commit_block.get("message") or ""
+        sha = c.get("sha") or ""
+        when = (commit_block.get("author") or {}).get("date") or (
+            (commit_block.get("committer") or {}).get("date") or ""
+        )
+        run = runs_by_sha.get(sha)
+        ci = None
+        branch = run.get("head_branch") if run else None
+        if run is not None:
+            ci = {
+                "status": run.get("status"),
+                "conclusion": run.get("conclusion"),
+                "url": run.get("html_url"),
+                "name": run.get("name"),
+                "color": _ci_color(run.get("status"), run.get("conclusion")),
+            }
+        rows.append(
+            {
+                "when": when,
+                "repo": repo,
+                "branch": branch,
+                "kind": "commit",
+                "title": _commit_title(message) or sha[:7],
+                "actor": author_block.get("login") or (commit_block.get("author") or {}).get("name"),
+                "source_tag": classify(
+                    branch=branch,
+                    author_login=author_block.get("login"),
+                    committer_login=committer_block.get("login"),
+                    commit_message=message,
+                ),
+                "links": {
+                    "commit": c.get("html_url"),
+                    "pr": None,
+                    "run": ci["url"] if ci else None,
+                },
+                "ci": ci,
+            }
+        )
+
+    for p in pulls:
+        if (p.get("updated_at") or "") < pr_window_iso:
+            continue
+        head = p.get("head") or {}
+        author = (p.get("user") or {}).get("login")
+        branch = head.get("ref")
+        if p.get("merged_at"):
+            kind, when = "pr_merged", p["merged_at"]
+        elif p.get("state") == "closed":
+            kind, when = "pr_closed", p.get("updated_at") or p.get("created_at") or ""
+        else:
+            kind, when = "pr_opened", p.get("created_at") or p.get("updated_at") or ""
+        rows.append(
+            {
+                "when": when,
+                "repo": repo,
+                "branch": branch,
+                "kind": kind,
+                "title": f"#{p.get('number')} {p.get('title') or ''}".strip(),
+                "actor": author,
+                "source_tag": classify(branch=branch, author_login=author),
+                "links": {
+                    "commit": None,
+                    "pr": p.get("html_url"),
+                    "run": None,
+                },
+                "ci": None,
+            }
+        )
+
+    for run in runs:
+        actor = (run.get("actor") or {}).get("login") or (
+            (run.get("triggering_actor") or {}).get("login")
+        )
+        ci = {
+            "status": run.get("status"),
+            "conclusion": run.get("conclusion"),
+            "url": run.get("html_url"),
+            "name": run.get("name"),
+            "color": _ci_color(run.get("status"), run.get("conclusion")),
+        }
+        rows.append(
+            {
+                "when": run.get("created_at") or "",
+                "repo": repo,
+                "branch": run.get("head_branch"),
+                "kind": "workflow_run",
+                "title": f"{run.get('name') or 'workflow'} · {run.get('event') or ''}".strip(" ·"),
+                "actor": actor,
+                "source_tag": classify(branch=run.get("head_branch"), author_login=actor),
+                "links": {"commit": None, "pr": None, "run": run.get("html_url")},
+                "ci": ci,
+            }
+        )
+
+    return rows
+
+
+def build_local_session_rows(pulses: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for p in pulses:
+        rows.append(
+            {
+                "when": p["when"],
+                "repo": p["repo"],
+                "branch": p.get("branch"),
+                "kind": "local_session",
+                "title": p.get("subject") or "",
+                "actor": p.get("device"),
+                "source_tag": "local-vscode",
+                "links": {"commit": None, "pr": None, "run": None},
+                "ci": None,
+            }
+        )
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build status.json for GH Pages dashboard")
+    parser.add_argument("--out", required=True, type=Path, help="Path to write status.json")
+    parser.add_argument(
+        "--window-days",
+        type=int,
+        default=DEFAULT_WINDOW_DAYS,
+        help="Days of history to include for PRs/workflow runs (default: 7)",
+    )
+    parser.add_argument(
+        "--per-repo",
+        type=int,
+        default=DEFAULT_PER_REPO_LIMIT,
+        help="Max items to fetch per endpoint per repo (default: 30)",
+    )
+    parser.add_argument(
+        "--pulse-mirror",
+        type=Path,
+        default=None,
+        help="Path to a checkout of the device-pulse repo (optional)",
+    )
+    args = parser.parse_args(argv)
+
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if not token:
+        print("error: GH_TOKEN (or GITHUB_TOKEN) is required", file=sys.stderr)
+        return 2
+
+    started = time.monotonic()
+    client = GitHubClient(token)
+
+    repos = set(read_registry_repos(REPO_ROOT))
+    repos.update(discover_repos_from_events(client, EVENT_DISCOVERY_DAYS))
+    watched = sorted(r.lower() for r in repos)
+
+    cutoff = _iso_cutoff(args.window_days)
+    rows: list[dict[str, Any]] = []
+    for repo in watched:
+        commits = fetch_commits(client, repo, cutoff, args.per_repo)
+        pulls = fetch_pulls(client, repo, args.per_repo)
+        runs = fetch_workflow_runs(client, repo, cutoff, args.per_repo)
+        rows.extend(build_rows(repo, commits, pulls, runs, cutoff))
+
+    if args.pulse_mirror:
+        pulses = read_device_pulses(
+            args.pulse_mirror, datetime.now(timezone.utc) - timedelta(days=args.window_days)
+        )
+        rows.extend(build_local_session_rows(pulses))
+
+    rows.sort(key=lambda r: r.get("when") or "", reverse=True)
+    rows = rows[:500]
+
+    payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace(
+            "+00:00", "Z"
+        ),
+        "window_days": args.window_days,
+        "watched_repos": watched,
+        "rate_limit": client.rate_limit,
+        "elapsed_seconds": round(time.monotonic() - started, 2),
+        "rows": rows,
+    }
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(
+        f"wrote {len(rows)} rows across {len(watched)} repos to {args.out} "
+        f"(elapsed {payload['elapsed_seconds']}s, rate-limit "
+        f"{client.rate_limit.get('remaining')}/{client.rate_limit.get('limit')})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/publish_gh_pages.sh
+++ b/scripts/publish_gh_pages.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Publish status.json + the static frontend to the orphan ``gh-pages`` branch.
+#
+# Designed for use inside ``.github/workflows/update-status.yml``. Skips the
+# commit (and the push) when nothing has changed so cron ticks during quiet
+# hours don't pollute git history.
+#
+# Usage:
+#   GITHUB_TOKEN=... GITHUB_REPOSITORY=owner/repo \
+#       scripts/publish_gh_pages.sh /tmp/status.json
+#
+# Required env:
+#   GITHUB_TOKEN       — token with contents:write on the repo
+#   GITHUB_REPOSITORY  — e.g. ``hypercart-dev-tools/rebalance-os``
+#
+# Optional env:
+#   PAGES_COMMIT_NAME  — git author name  (default: github-actions[bot])
+#   PAGES_COMMIT_EMAIL — git author email (default: 41898282+github-actions[bot]@users.noreply.github.com)
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "usage: $0 <path-to-status.json>" >&2
+    exit 2
+fi
+STATUS_JSON="$1"
+if [[ ! -f "$STATUS_JSON" ]]; then
+    echo "error: status JSON not found: $STATUS_JSON" >&2
+    exit 1
+fi
+: "${GITHUB_TOKEN:?GITHUB_TOKEN is required}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+
+NAME="${PAGES_COMMIT_NAME:-github-actions[bot]}"
+EMAIL="${PAGES_COMMIT_EMAIL:-41898282+github-actions[bot]@users.noreply.github.com}"
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DOCS_DIR="$REPO_ROOT/docs"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+REMOTE_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+# Try to clone the existing gh-pages branch; if it doesn't exist yet, create
+# a fresh orphan branch in a clean worktree.
+if git clone --quiet --depth 1 --branch gh-pages "$REMOTE_URL" "$WORK" 2>/dev/null; then
+    echo "checked out existing gh-pages branch"
+else
+    echo "gh-pages branch does not exist yet — initializing"
+    git -c init.defaultBranch=gh-pages init --quiet "$WORK"
+    git -C "$WORK" remote add origin "$REMOTE_URL"
+    git -C "$WORK" checkout --quiet --orphan gh-pages
+    # Ensure the orphan branch starts empty
+    git -C "$WORK" rm -rf --quiet . 2>/dev/null || true
+fi
+
+# Copy frontend (humans edit ``main:/docs``; the orphan branch is a mirror)
+mkdir -p "$WORK/data"
+if [[ -d "$DOCS_DIR" ]]; then
+    cp "$DOCS_DIR"/index.html "$WORK/" 2>/dev/null || true
+    cp "$DOCS_DIR"/app.js     "$WORK/" 2>/dev/null || true
+    cp "$DOCS_DIR"/app.css    "$WORK/" 2>/dev/null || true
+fi
+# Tell GH Pages to skip Jekyll processing (we ship raw HTML/JS).
+touch "$WORK/.nojekyll"
+cp "$STATUS_JSON" "$WORK/data/status.json"
+
+git -C "$WORK" add -A
+if git -C "$WORK" diff --cached --quiet; then
+    echo "no change — skipping commit"
+    exit 0
+fi
+
+git -C "$WORK" -c user.name="$NAME" -c user.email="$EMAIL" \
+    commit --quiet -m "data: $(date -u +%Y-%m-%dT%H:%MZ)"
+
+# Push, with a short retry loop for transient network errors.
+for attempt in 1 2 3 4; do
+    if git -C "$WORK" push --quiet origin gh-pages; then
+        echo "pushed to gh-pages"
+        exit 0
+    fi
+    delay=$((attempt * attempt * 2))
+    echo "push attempt $attempt failed; retrying in ${delay}s" >&2
+    sleep "$delay"
+done
+
+echo "error: push to gh-pages failed after 4 attempts" >&2
+exit 1

--- a/src/rebalance/ingest/agent_tags.py
+++ b/src/rebalance/ingest/agent_tags.py
@@ -1,0 +1,82 @@
+"""
+Classify a unit of GitHub activity by its likely originator.
+
+Distinguishes between:
+- ``claude-cloud`` — Claude Code cloud sessions (branch ``claude/*`` or
+  Co-authored-by trailer naming Claude)
+- ``codex-cloud`` — OpenAI Codex Cloud sessions (branch ``codex/*`` or the
+  ``chatgpt-codex-connector[bot]`` author)
+- ``lovable``     — Lovable UI editor (``lovable-dev[bot]`` / ``lovable[bot]``
+  author, or branch starting with ``lovable-``)
+- ``local-vscode``— Local VS Code agent sessions on user's Macs (commit
+  message carries the git-pulse device marker injected by collect.sh)
+- ``human``       — Anything else
+
+Pure logic — no I/O, no database access. Easy to unit-test.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+LOVABLE_AUTHORS = {"lovable-dev[bot]", "lovable[bot]"}
+CODEX_AUTHORS = {"chatgpt-codex-connector[bot]", "codex-bot[bot]"}
+CLAUDE_AUTHORS = {"claude[bot]", "claude-bot[bot]"}
+
+_DEVICE_MARKER_RE = re.compile(r"\[git-pulse:device=[A-Za-z0-9_.-]+\]")
+_COAUTHOR_RE = re.compile(
+    r"Co-authored-by:\s*([^<\n]+?)\s*<", re.IGNORECASE | re.MULTILINE
+)
+
+
+def _coauthor_names(message: str) -> list[str]:
+    if not message:
+        return []
+    return [m.group(1).strip().lower() for m in _COAUTHOR_RE.finditer(message)]
+
+
+def classify(
+    *,
+    branch: str | None = None,
+    author_login: str | None = None,
+    committer_login: str | None = None,
+    commit_message: str | None = None,
+    co_authors: Iterable[str] | None = None,
+) -> str:
+    """Return one of ``claude-cloud``, ``codex-cloud``, ``lovable``,
+    ``local-vscode``, ``human``.
+    """
+    branch = (branch or "").strip()
+    author = (author_login or "").strip()
+    committer = (committer_login or "").strip()
+    message = commit_message or ""
+
+    explicit = [c.lower() for c in (co_authors or [])]
+    parsed = _coauthor_names(message)
+    coauthors = set(explicit) | set(parsed)
+
+    if author in LOVABLE_AUTHORS or committer in LOVABLE_AUTHORS:
+        return "lovable"
+    if branch.startswith("lovable-") or branch.startswith("lovable/"):
+        return "lovable"
+
+    if author in CODEX_AUTHORS or committer in CODEX_AUTHORS:
+        return "codex-cloud"
+    if branch.startswith("codex/"):
+        return "codex-cloud"
+
+    if author in CLAUDE_AUTHORS or committer in CLAUDE_AUTHORS:
+        return "claude-cloud"
+    if branch.startswith("claude/"):
+        return "claude-cloud"
+    if any("claude" in name for name in coauthors):
+        return "claude-cloud"
+
+    if _DEVICE_MARKER_RE.search(message):
+        return "local-vscode"
+
+    return "human"
+
+
+__all__ = ["classify"]

--- a/tests/test_agent_tags.py
+++ b/tests/test_agent_tags.py
@@ -1,0 +1,78 @@
+"""Unit tests for the activity-source classifier."""
+
+from __future__ import annotations
+
+import unittest
+
+from rebalance.ingest.agent_tags import classify
+
+
+class AgentTagsTests(unittest.TestCase):
+    def test_claude_branch_pattern(self) -> None:
+        self.assertEqual(
+            classify(branch="claude/monitor-github-vscode-activity-nAeik",
+                     author_login="noelsaw"),
+            "claude-cloud",
+        )
+
+    def test_codex_branch_pattern(self) -> None:
+        self.assertEqual(
+            classify(branch="codex/refactor-foo", author_login="noelsaw"),
+            "codex-cloud",
+        )
+
+    def test_codex_bot_author(self) -> None:
+        self.assertEqual(
+            classify(branch="main", author_login="chatgpt-codex-connector[bot]"),
+            "codex-cloud",
+        )
+
+    def test_lovable_bot_author(self) -> None:
+        self.assertEqual(
+            classify(branch="main", author_login="lovable-dev[bot]"),
+            "lovable",
+        )
+
+    def test_lovable_branch_prefix(self) -> None:
+        self.assertEqual(
+            classify(branch="lovable-update-readme", author_login="noelsaw"),
+            "lovable",
+        )
+
+    def test_local_vscode_via_marker(self) -> None:
+        msg = "wip: refactor handler\n\n[git-pulse:device=mac-studio]"
+        self.assertEqual(
+            classify(branch="feature/foo", author_login="noelsaw",
+                     commit_message=msg),
+            "local-vscode",
+        )
+
+    def test_claude_via_co_author_trailer(self) -> None:
+        msg = "Fix bug\n\nCo-authored-by: Claude <noreply@anthropic.com>"
+        self.assertEqual(
+            classify(branch="main", author_login="noelsaw", commit_message=msg),
+            "claude-cloud",
+        )
+
+    def test_human_default(self) -> None:
+        self.assertEqual(
+            classify(branch="main", author_login="noelsaw",
+                     commit_message="chore: bump deps"),
+            "human",
+        )
+
+    def test_lovable_takes_precedence_over_codex_branch(self) -> None:
+        # Author is the lovable bot — that should win even if branch
+        # incidentally starts with codex/.
+        self.assertEqual(
+            classify(branch="codex/auto", author_login="lovable[bot]"),
+            "lovable",
+        )
+
+    def test_empty_inputs_return_human(self) -> None:
+        self.assertEqual(classify(), "human")
+        self.assertEqual(classify(branch="", author_login=None), "human")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_build_status.py
+++ b/tests/test_build_status.py
@@ -1,0 +1,199 @@
+"""Unit tests for ``scripts/build_status.py``.
+
+Exercises the pure helpers (CI color, commit-title extraction, row builder,
+device-pulse reader). Network-touching code is not tested here — the GH
+Action's actual run is the integration test.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "build_status.py"
+
+
+def _load_build_status_module():
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+    spec = importlib.util.spec_from_file_location("build_status", SCRIPT_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+bs = _load_build_status_module()
+
+
+class CiColorTests(unittest.TestCase):
+    def test_success_is_green(self) -> None:
+        self.assertEqual(bs._ci_color("completed", "success"), "green")
+
+    def test_failure_is_red(self) -> None:
+        self.assertEqual(bs._ci_color("completed", "failure"), "red")
+        self.assertEqual(bs._ci_color("completed", "timed_out"), "red")
+        self.assertEqual(bs._ci_color("completed", "cancelled"), "red")
+
+    def test_in_progress_is_yellow(self) -> None:
+        self.assertEqual(bs._ci_color("in_progress", None), "yellow")
+        self.assertEqual(bs._ci_color("queued", None), "yellow")
+
+    def test_unknown_is_grey(self) -> None:
+        self.assertEqual(bs._ci_color(None, None), "grey")
+
+
+class CommitTitleTests(unittest.TestCase):
+    def test_strips_to_first_line(self) -> None:
+        self.assertEqual(bs._commit_title("first line\n\nbody"), "first line")
+
+    def test_truncates_long_titles(self) -> None:
+        long = "x" * 300
+        self.assertEqual(len(bs._commit_title(long)), 200)
+
+    def test_handles_none(self) -> None:
+        self.assertEqual(bs._commit_title(None), "")
+        self.assertEqual(bs._commit_title(""), "")
+
+
+class IndexRunsBySha(unittest.TestCase):
+    def test_keeps_most_recent_per_sha(self) -> None:
+        runs = [
+            {"head_sha": "a", "created_at": "2026-05-01T00:00:00Z", "id": 1},
+            {"head_sha": "a", "created_at": "2026-05-02T00:00:00Z", "id": 2},
+            {"head_sha": "b", "created_at": "2026-05-01T00:00:00Z", "id": 3},
+        ]
+        idx = bs._index_runs_by_sha(runs)
+        self.assertEqual(idx["a"]["id"], 2)
+        self.assertEqual(idx["b"]["id"], 3)
+
+
+class BuildRowsTests(unittest.TestCase):
+    def test_commit_joined_with_workflow_run(self) -> None:
+        commits = [
+            {
+                "sha": "abc1234",
+                "html_url": "https://github.com/o/r/commit/abc1234",
+                "commit": {
+                    "message": "Refactor handler",
+                    "author": {"date": "2026-05-02T10:00:00Z", "name": "Noel"},
+                },
+                "author": {"login": "noelsaw"},
+                "committer": {"login": "noelsaw"},
+            }
+        ]
+        runs = [
+            {
+                "head_sha": "abc1234",
+                "head_branch": "claude/abc",
+                "status": "completed",
+                "conclusion": "success",
+                "html_url": "https://github.com/o/r/actions/runs/1",
+                "name": "ci",
+                "event": "push",
+                "created_at": "2026-05-02T10:05:00Z",
+                "actor": {"login": "noelsaw"},
+            }
+        ]
+        rows = bs.build_rows("o/r", commits, [], runs, "2026-04-25T00:00:00Z")
+        commit_row = next(r for r in rows if r["kind"] == "commit")
+        self.assertEqual(commit_row["source_tag"], "claude-cloud")
+        self.assertEqual(commit_row["ci"]["color"], "green")
+        self.assertEqual(commit_row["branch"], "claude/abc")
+
+    def test_pr_classified_via_branch(self) -> None:
+        pulls = [
+            {
+                "number": 7,
+                "title": "Add dashboard",
+                "state": "closed",
+                "merged_at": "2026-05-02T09:00:00Z",
+                "updated_at": "2026-05-02T09:00:00Z",
+                "html_url": "https://github.com/o/r/pull/7",
+                "head": {"ref": "claude/dashboard"},
+                "user": {"login": "noelsaw"},
+            }
+        ]
+        rows = bs.build_rows("o/r", [], pulls, [], "2026-04-25T00:00:00Z")
+        pr = next(r for r in rows if r["kind"] == "pr_merged")
+        self.assertEqual(pr["source_tag"], "claude-cloud")
+        self.assertEqual(pr["title"], "#7 Add dashboard")
+
+    def test_workflow_row_source_tag(self) -> None:
+        runs = [
+            {
+                "head_sha": "deadbee",
+                "head_branch": "codex/refactor",
+                "status": "completed",
+                "conclusion": "failure",
+                "html_url": "https://github.com/o/r/actions/runs/2",
+                "name": "ci",
+                "event": "push",
+                "created_at": "2026-05-02T11:00:00Z",
+                "actor": {"login": "chatgpt-codex-connector[bot]"},
+            }
+        ]
+        rows = bs.build_rows("o/r", [], [], runs, "2026-04-25T00:00:00Z")
+        wf = next(r for r in rows if r["kind"] == "workflow_run")
+        self.assertEqual(wf["source_tag"], "codex-cloud")
+        self.assertEqual(wf["ci"]["color"], "red")
+
+    def test_pr_outside_window_is_dropped(self) -> None:
+        pulls = [
+            {
+                "number": 1,
+                "title": "Old",
+                "state": "open",
+                "updated_at": "2026-01-01T00:00:00Z",
+                "created_at": "2026-01-01T00:00:00Z",
+                "html_url": "https://github.com/o/r/pull/1",
+                "head": {"ref": "feat"},
+                "user": {"login": "noelsaw"},
+            }
+        ]
+        rows = bs.build_rows("o/r", [], pulls, [], "2026-04-25T00:00:00Z")
+        self.assertEqual(rows, [])
+
+
+class DevicePulseTests(unittest.TestCase):
+    def test_reads_recent_lines_only(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            mirror = Path(td)
+            now = datetime.now(timezone.utc)
+            recent = now - timedelta(minutes=5)
+            old = now - timedelta(days=10)
+            (mirror / "pulse-mac-studio.md").write_text(
+                "# header\n"
+                f"{int(recent.timestamp())}\t{recent.isoformat()}\to/r\tmain\tabc\tFix\n"
+                f"{int(old.timestamp())}\t{old.isoformat()}\to/r\tmain\tdef\tStale\n",
+                encoding="utf-8",
+            )
+            results = bs.read_device_pulses(mirror, now - timedelta(hours=1))
+            self.assertEqual(len(results), 1)
+            self.assertEqual(results[0]["device"], "mac-studio")
+
+    def test_missing_dir_returns_empty(self) -> None:
+        self.assertEqual(
+            bs.read_device_pulses(Path("/nonexistent-xyz"),
+                                  datetime.now(timezone.utc)),
+            [],
+        )
+
+
+class LocalSessionRowsTests(unittest.TestCase):
+    def test_local_session_rows_are_tagged_local_vscode(self) -> None:
+        rows = bs.build_local_session_rows(
+            [{"when": "2026-05-02T10:00:00Z", "device": "mac-studio",
+              "repo": "o/r", "branch": "main", "subject": "wip"}]
+        )
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["source_tag"], "local-vscode")
+        self.assertEqual(rows[0]["actor"], "mac-studio")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Server-free alternative to the Vultr/FastAPI dashboard on
[`claude/monitor-github-vscode-activity-nAeik`](https://github.com/hypercart-dev-tools/rebalance-os/tree/claude/monitor-github-vscode-activity-nAeik).
Branched from `main` so both approaches can be evaluated side by side
without touching each other.

A scheduled GitHub Action writes `data/status.json` to an orphan
`gh-pages` branch; GitHub Pages serves the static page; the page polls
the JSON. No servers, no SQLite, no framework.

### Active hours

Cron `*/15 15-23,0-3 * * *` (UTC) covers **8am–8pm Pacific year-round**
with ±1h DST drift (PDT: 8am–9pm, PST: 7am–8pm). At ~52 runs/day × 30
days × ≤1 min each ≈ **1,560 min/month**, well under the 2,000 min/mo
free tier on a private repo. Skip-on-no-change in the publish script
keeps quiet hours commit-free.

### What's in the diff

| File | Purpose |
|---|---|
| `.github/workflows/update-status.yml` | scheduled cron + manual `workflow_dispatch` |
| `scripts/build_status.py` | pure-stdlib GitHub fetcher (commits, PRs, Actions runs); discovers repos from events feed; classifies each row via `agent_tags.classify()` |
| `scripts/publish_gh_pages.sh` | orphan-branch publisher with skip-on-no-change |
| `docs/index.html`, `app.js`, `app.css` | vanilla-JS static page; same visual layout as the Vultr branch + source-tag filter |
| `docs/README.md` | one-time setup notes |
| `src/rebalance/ingest/agent_tags.py` | cherry-picked from the Vultr branch (hosting-agnostic, pure) |
| `tests/test_agent_tags.py`, `test_build_status.py` | 25 unit tests |

### One-time setup (after merge)

1. Settings → Pages → source = `gh-pages` branch / root.
2. Settings → Secrets → Actions → add `STATUS_GH_TOKEN` (fine-scoped
   PAT with `repo:read` on the orgs you want monitored).
3. (Optional) Settings → Variables → Actions → add
   `REBALANCE_WATCH_REPOS` if you want a curated list instead of pure
   events-feed discovery.
4. Actions tab → "Update activity status" → Run workflow → first run
   creates the `gh-pages` branch.
5. Visit `https://hypercart-dev-tools.github.io/rebalance-os/`.

### Vs. the Vultr branch

Same JSON shape on both sides, so the frontends are interchangeable.
Pick whichever feels right to operate; the loser gets retired.

| | GH Actions + Pages (this PR) | Vultr / FastAPI |
|---|---|---|
| Servers | None | One systemd unit on Vultr |
| Refresh button | Re-fetches JSON (CDN ~1 min stale) | Triggers an immediate ingest cycle |
| Data freshness | 15 min cron + DST drift | 10 min loop, on-demand POST |
| Cost | ~1,560 min/mo (free tier) | shares the existing Vultr box |
| Auth | Private repo + Pages | HTTP basic / Tailscale / nginx |

## Test plan

- [x] 25 unit tests pass locally (classifier, CI-color, row builder, device-pulse reader)
- [x] Bash syntax check passes for `publish_gh_pages.sh`
- [x] Static frontend renders against a fixture `status.json` with all 5 source tags
- [ ] After merge: enable Pages on `gh-pages` branch, add `STATUS_GH_TOKEN` secret
- [ ] Trigger workflow manually and confirm `gh-pages` branch is created with `index.html` + `data/status.json`
- [ ] Confirm second manual trigger logs "no change — skipping commit"
- [ ] Day-2 check: Actions tab shows runs only between ~7am and 9pm Pacific
- [ ] End-of-month: Settings → Billing → confirm <2,000 Action minutes used

https://claude.ai/code/session_01FcfHCm7WZJhwPXJh6fwSzB

---
_Generated by [Claude Code](https://claude.ai/code/session_01FcfHCm7WZJhwPXJh6fwSzB)_