### PR TITLE
Make installers and operator-paths portable across machines

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,11 +3,6 @@
     "allow": [
       "mcp__rebalance__onboarding_status",
       "mcp__rebalance__ask",
-      "Bash(chmod +x /Users/noelsaw/Documents/GitHub-Repos/rebalance-OS/experimental/git-history/collect.sh /Users/noelsaw/Documents/GitHub-Repos/rebalance-OS/experimental/git-history/install.sh)",
-      "Bash(bash -n /Users/noelsaw/Documents/GitHub-Repos/rebalance-OS/experimental/git-history/collect.sh)",
-      "Bash(bash -n /Users/noelsaw/Documents/GitHub-Repos/rebalance-OS/experimental/git-history/install.sh)",
-      "Bash(plutil -lint /Users/noelsaw/Documents/GitHub-Repos/rebalance-OS/experimental/git-history/com.user.git-history.plist.template)",
-      "Bash(python /Users/noelsaw/Documents/rebalance-OS/experimental/git-pulse/recap.py --input '/Users/noelsaw/Documents/GH Repos/rebalance-git-pulse/reports/combined-14-day-local-and-synced.tsv' --input '/Users/noelsaw/Documents/GH Repos/rebalance-git-pulse/reports/combined-21-day-local-and-synced.tsv' --output /tmp/recap-smoke.md)",
       "Read(//tmp/**)",
       "Bash(.venv/bin/python -c ' *)",
       "Bash(git commit -m ' *)",
@@ -15,7 +10,6 @@
       "Bash(python -c \"import rich; print\\('rich ok:', rich.__version__\\)\")",
       "Bash(python -c \"from rich.console import Console; from rich.layout import Layout; from rich.live import Live; print\\('rich ok'\\)\")",
       "Bash(.venv/bin/rebalance refresh *)",
-      "Bash(chmod +x /Users/noelsaw/Documents/rebalance-OS/scripts/pulse_server.sh)",
       "Bash(.venv/bin/python scripts/pulse_server.py --port 8765)",
       "Bash(echo \"pid=$!\")",
       "Bash(curl -fsS http://127.0.0.1:8765/api/health -o /dev/null)",
@@ -36,13 +30,14 @@
       "Bash(echo \"new pid=$!\")",
       "Bash(curl -s -o /tmp/resp.json -w 'HTTP %{http_code}\\\\n' -X POST http://127.0.0.1:8767/api/goals/complete -H 'content-type: application/json' -d '{\"title\":\"__definitely_not_a_real_goal__\"}')",
       "Bash(curl -s -o /tmp/resp.json -w 'HTTP %{http_code}\\\\n' -X POST http://127.0.0.1:8767/api/goals/complete -H 'content-type: application/json' -d '{\"title\":\"\"}')",
-      "Bash(git -C /Users/noelsaw/Documents/rebalance-OS log -1 --stat)",
       "mcp__rebalance__sleuth_sync_reminders",
       "Bash(.venv/bin/python -m pytest tests/test_sleuth_reminders.py tests/test_pulse_sleuth_scope.py -q)",
-      "Bash(.venv/bin/python -m unittest tests.test_sleuth_reminders tests.test_pulse_sleuth_scope -v)"
-    ],
-    "additionalDirectories": [
-      "/Users/noelsaw/Documents/rebalance-OS/.claude"
+      "Bash(.venv/bin/python -m unittest tests.test_sleuth_reminders tests.test_pulse_sleuth_scope -v)",
+      "Bash(awk 'NR>=755 && NR<=770' PROJECT/cleanup.sh)",
+      "Skill(update-config)",
+      "Skill(update-config:*)",
+      "Bash(.venv/bin/python -m pytest tests/test_calendar_create_event_cli.py tests/test_git_pulse_health_check.py tests/test_dashboard_terminal_theme.py -q)",
+      "Bash(python3 -m py_compile src/rebalance/cli.py tests/test_git_pulse_health_check.py tests/test_calendar_create_event_cli.py)"
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ rebalance.db-wal
 /git-pulse-sync
 /web/pulse.html
 /web/*.tmp
+
+# Rendered launchd plists — generated from .plist.template by scripts/install_*_scheduler.sh
+scripts/com.rebalance-os.*.plist

--- a/4X4.md
+++ b/4X4.md
@@ -21,7 +21,7 @@ B. CURRENT WEEK GOALS
 4. [ ] Extend existing classification patterns beyond calendar so unattributed or low-confidence signals improve instead of repeating noise.
 
 C. LAST WEEKS ACCOMPLISHMENTS
-1. Fixed git-pulse install and collect behavior so local GitHub repos are auto-discovered, copied launchers stay in sync, and backfills de-duplicate existing pulse rows.
+1. Fixed install portability across the operator surface: git-pulse auto-discovers local GitHub repos and keeps copied launchers in sync, and the rebalance-OS launchd jobs (daily, vault, pulse) plus the ask-self wrappers no longer hardcode one developer's home directory — fresh clones now install cleanly on any machine.
 2. Recovered this Mac Studio from single-repo self-tracking to 49 watched repos and pushed a widened historical backfill that now reaches February 1, 2026.
 3. Added recap and planning layers that clarified exact retrieval, dedupe, and SQLite as the next backbone rather than jumping straight to embeddings.
 4. Reframed the product direction around an Obsidian-first dashboard, a canonical attention ledger, and a narrower rebalance-oriented MCP surface.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -118,11 +118,11 @@ Project Registry ────▶ registry.py +              MD registry → proj
 | Source | Secret store | Mechanism |
 |---|---|---|
 | GitHub | `temp/rbos.config` (JSON, gitignored) | PAT with `repo:read` |
-| Google Calendar | `/Users/noelsaw/secrets/google-calendar.env` + pickled OAuth token | OAuth 2.0 user consent |
-| Sleuth | `/Users/noelsaw/secrets/sleuth-web-api-development.env` (mode 600) | Bearer token, 64-hex |
+| Google Calendar | `~/secrets/google-calendar.env` + pickled OAuth token | OAuth 2.0 user consent |
+| Sleuth | `~/secrets/sleuth-web-api-development.env` (mode 600) | Bearer token, 64-hex |
 | Obsidian vault | none | filesystem read only |
 
-Env-file paths now resolve via [src/rebalance/paths.py](src/rebalance/paths.py)::`resolve_secret_path(name)` — the layered chain is `REBALANCE_SECRETS_DIR` env var → `secrets_dir` field in `~/.config/rebalance-os/config.json` (set via `rebalance config set-secrets-dir`) → `~/secrets/` legacy default. Both files should sit at mode 600. Env files are parsed manually (no `python-dotenv`). Nothing with a secret value is committed.
+Env-file paths resolve via [src/rebalance/paths.py](src/rebalance/paths.py)::`resolve_secret_path(name)` — the layered chain is `REBALANCE_SECRETS_DIR` env var → `secrets_dir` field in `~/.config/rebalance-os/config.json` (set via `rebalance config set-secrets-dir`) → `~/secrets/` legacy default. Both `GOOGLE_CALENDAR_ENV_PATH` and `SLEUTH_ENV_PATH` in [src/rebalance/cli.py](src/rebalance/cli.py) use this resolver, so the repo is portable across operator home directories without hardcoded paths. Both files should sit at mode 600. Env files are parsed manually (no `python-dotenv`). Nothing with a secret value is committed.
 
 ### Adding a New Source
 
@@ -166,6 +166,15 @@ GitHub artifacts (writer: github_knowledge.py; schema in db.py::ensure_github_sc
   github_documents           — per-artifact embeddable document rows
   github_embeddings          — sqlite-vec virtual table for artifact embeddings
   github_embedding_meta      — model name + dim for the GitHub corpus
+
+Unified Semantic Index (writers: semantic_index.py, index_ops.py)
+  semantic_documents         — canonical cross-source document rows (vault chunks +
+                               GitHub issues/PRs/comments/commits). Writer:
+                               semantic_index.py::backfill_semantic_documents().
+                               Consumed by semantic_query() and the LLM context layer.
+  semantic_embeddings        — sqlite-vec virtual table, float[1024], keyed by
+                               semantic_documents.id. Unified ANN search target.
+  semantic_embedding_meta    — model name, dimension, embedder_version, last_embed_at
 
 Vault Ingestion (writer: note_ingester.py)
   vault_files                — one row per .md file, with content_hash for delta detection
@@ -282,10 +291,13 @@ Four ways the pipeline runs:
 
 2. **Unattended scheduled syncs** — four launchd jobs cooperate:
 
-   - **Daily all-source sync** ([scripts/daily_sync.sh](scripts/daily_sync.sh) / [scripts/com.rebalance-os.daily-sync.plist](scripts/com.rebalance-os.daily-sync.plist)) at 06:30 local time, plus on boot/login if 06:30 was missed. Calls `refresh_index(scope=["all"])`, which walks every source: vault → github → calendar → sleuth → unified semantic index. "All" means *every source*, **not** a full re-download — each step uses its own incremental logic from [Sync semantics per source](#sync-semantics-per-source). Per-scope failures are captured in the result's `errors` list rather than aborting the run.
-   - **Hourly vault refresh** ([scripts/vault_sync.sh](scripts/vault_sync.sh) / [scripts/com.rebalance-os.vault-sync.plist](scripts/com.rebalance-os.vault-sync.plist)) at HH:15 from 06:15 to 23:15. Calls `refresh_index(scope=["vault"])` only — keeps notes edited mid-day visible in the dashboard / pulse / semantic search without waiting for the next morning's full sync. Vault ingest is cheap (~0.02s with no changes) and fully offline.
-   - **Hourly pulse publish** ([scripts/pulse_sync.sh](scripts/pulse_sync.sh) / [scripts/com.rebalance-os.pulse-sync.plist](scripts/com.rebalance-os.pulse-sync.plist)) on the hour, 06:00 to 23:00. Renders the operator pulse markdown and pushes it to the configured private repo, but only when the rendered content actually changed since the previous run.
-   - **30-minute pulse-web refresh** ([scripts/pulse_web_sync.sh](scripts/pulse_web_sync.sh) / [scripts/com.rebalance-os.pulse-web-sync.plist](scripts/com.rebalance-os.pulse-web-sync.plist)) every 30 minutes from 06:00 to 23:30. Calls [scripts/pulse_web.py](scripts/pulse_web.py) to regenerate the local `web/pulse.html` mirror of the dashboard. Atomic via tmp+replace (a crashed run leaves the previous HTML intact). No network, no git push — separate from the markdown→private-repo flow above.
+   - **Daily all-source sync** ([scripts/daily_sync.sh](scripts/daily_sync.sh) / [scripts/com.rebalance-os.daily-sync.plist.template](scripts/com.rebalance-os.daily-sync.plist.template)) at 06:30 local time, plus on boot/login if 06:30 was missed. Calls `refresh_index(scope=["all"])`, which walks every source: vault → github → calendar → sleuth → unified semantic index. "All" means *every source*, **not** a full re-download — each step uses its own incremental logic from [Sync semantics per source](#sync-semantics-per-source). Per-scope failures are captured in the result's `errors` list rather than aborting the run.
+   - **Hourly vault refresh** ([scripts/vault_sync.sh](scripts/vault_sync.sh) / [scripts/com.rebalance-os.vault-sync.plist.template](scripts/com.rebalance-os.vault-sync.plist.template)) at HH:15 from 06:15 to 23:15. Calls `refresh_index(scope=["vault"])` only — keeps notes edited mid-day visible in the dashboard / pulse / semantic search without waiting for the next morning's full sync. Vault ingest is cheap (~0.02s with no changes) and fully offline.
+   - **Hourly pulse publish** ([scripts/pulse_sync.sh](scripts/pulse_sync.sh) / [scripts/com.rebalance-os.pulse-sync.plist.template](scripts/com.rebalance-os.pulse-sync.plist.template)) on the hour, 06:00 to 23:00. Renders the operator pulse markdown and pushes it to the configured private repo, but only when the rendered content actually changed since the previous run.
+   - **30-minute pulse-web refresh** ([scripts/pulse_web_sync.sh](scripts/pulse_web_sync.sh) / [scripts/com.rebalance-os.pulse-web-sync.plist.template](scripts/com.rebalance-os.pulse-web-sync.plist.template)) every 30 minutes from 06:00 to 23:30. Calls [scripts/pulse_web.py](scripts/pulse_web.py) to regenerate the local `web/pulse.html` mirror of the dashboard. Atomic via tmp+replace (a crashed run leaves the previous HTML intact). No network, no git push — separate from the markdown→private-repo flow above.
+   - **Hourly GitHub sync** ([scripts/github_sync.sh](scripts/github_sync.sh) / [scripts/com.rebalance-os.github-sync.plist.template](scripts/com.rebalance-os.github-sync.plist.template)) — a narrower github-only refresh independent of the daily full sync, for environments that want fresher GitHub data without paying the full multi-source cost.
+
+   The shell scripts derive `REBALANCE_DIR` from their own location, and the `.plist.template` files use a `{{REBALANCE_DIR}}` placeholder that each `install_*_scheduler.sh` substitutes with the local checkout path before writing into `~/Library/LaunchAgents/`. The rendered plists are gitignored — the templates are the only checked-in form, so a clone on any machine installs cleanly with no per-user editing.
 
 3. **MCP tool handlers** — [src/rebalance/mcp_server.py](src/rebalance/mcp_server.py) wraps ingestors and readers as MCP tools. Host agents (Claude Code / Claude Desktop) call these on demand. `REBALANCE_DB` env var resolves the shared DB path.
 
@@ -306,6 +318,10 @@ Tools are registered in `mcp_server.py:create_server()`. All tools share the sam
 | Query | `github_balance` | Per-project GitHub activity summary |
 | Query | `github_release_readiness` | Infer milestone/release readiness from the local GitHub corpus |
 | Query | `github_close_candidates` | Suggest open issues that likely map to merged PRs |
+| Query | `semantic_query` | Unified vector search across vault + GitHub corpus (single ranked result set) |
+| Diagnostics | `index_status` | Snapshot of every source + semantic index freshness (read-only) |
+| Diagnostics | `refresh_index` | Orchestrated refresh of the local knowledge base (single entry point) |
+| Diagnostics | `list_watched_repos` | Show merged set of repos being monitored (project registry ∪ activity − ignored) |
 | Diagnostics | `diagnose_repo` | Walk the watched-repos + sync funnel for a single repo (optionally a `sha` or `pr`) and explain coverage + freshness gaps; opt-in `live=True` distinguishes "we never synced" from "PAT can't see it" |
 | Registry | `list_projects` | Query project registry |
 | Onboarding | `onboarding_status` | Check setup completion |
@@ -317,6 +333,7 @@ Tools are registered in `mcp_server.py:create_server()`. All tools share the sam
 | Calendar | `classify_event` | Persist an include/exclude/project classification for an event |
 | Calendar | `snap_calendar_edges` | Detect and (optionally) fix slightly overlapping events |
 | Sync | `sleuth_sync_reminders` | Pull Slack reminders from the Sleuth Web API and upsert to SQLite |
+| Sync | `publish_pulse` | Render today+yesterday activity to markdown and push to private pulse repo |
 | Hygiene | `audit_modules` | Run [scripts/audit_modules.py](scripts/audit_modules.py) and return the structured JSON result. Verifies that ingest collectors / render modules / scheduled-job infrastructure are documented in ARCHITECTURE.md and CHANGELOG.md, and that recent commits' file changes appear in the latest CHANGELOG version section. Supports `init=True` to snapshot the baseline lockfile and `include_uncommitted=True` for a pre-commit working-tree preview |
 
 Tool specs (params, returns, dependencies): see [MCP.md](./MCP.md).
@@ -350,7 +367,15 @@ src/rebalance/
     md_parser.py           — pure markdown parsing (frontmatter, wikilinks, tags, chunking)
     note_ingester.py       — vault walker, delta detection, TF-IDF keywords
     embedder.py            — mlx-embeddings batch embed + ANN query
+    semantic_index.py      — unified semantic index: backfill, embed, and query across
+                              vault + GitHub sources (semantic_documents / semantic_embeddings)
+    index_ops.py           — single entry point for refresh_index() and index_status();
+                              orchestrates the full ingest pipeline so agents don't
+                              need to know individual CLI command ordering
     calendar.py            — Google Calendar API collector + SQLite persistence
+    calendar_config.py     — OAuth token storage, classification rules, review-decision persistence
+    calendar_helpers.py    — duration/math utilities consumed by calendar tools
+    calendar_snap.py       — edge-snapping logic for slightly overlapping calendar events
     sleuth_reminders.py    — Sleuth Web API collector (Bearer auth, urllib) + upsert
     slack_users.py         — Slack user-id → friendly-name lookup, file-mtime cached;
                               feeds the dashboard sleuth panel and the pulse markdown
@@ -359,6 +384,12 @@ src/rebalance/
                               the diagnose_repo MCP tool
     profile_sync.py        — daily-sync log parser that surfaces per-repo GitHub
                               timings; backs the rebalance profile-sync subcommand
+    pulse.py               — pulse markdown renderer; backs publish_pulse MCP tool
+    agent_tags.py          — source-tagging for pulse rows (claude-cloud, codex-cloud,
+                              lovable, local-vscode, human)
+    project_classifier.py  — calendar event → project matcher for timesheet reports
+    project_inference.py   — project inference from note titles / calendar summaries
+    audit.py               — structured audit logging (append_audit_entry)
     querier.py             — multi-source context gathering + local LLM synthesis
 
 scripts/                   — Operator entry points (not part of the importable package)
@@ -374,6 +405,12 @@ scripts/                   — Operator entry points (not part of the importable
   install_vault_scheduler.sh — install/reload the hourly vault launchd job
   install_pulse_scheduler.sh — install/reload the hourly pulse-markdown launchd job
   install_pulse_web_scheduler.sh — install/reload the 30-min pulse-web launchd job
+  install_github_scheduler.sh — install/reload the hourly github-only launchd job
+  github_sync.sh           — github-only launchd entry (mode 2)
+  setup_calendar_oauth.py  — interactive OAuth consent flow for Google Calendar
+  build_extension.py       — native extension builder
+  ask-self-ingest.sh       — self-ingest shell wrapper (portable mode, requires ASK_SELF_PATH)
+  ask-self-query.sh        — self-query shell wrapper (portable mode, requires ASK_SELF_PATH)
   audit_modules.py         — repository hygiene audit (Approach A): verifies ingest
                               collectors / render modules / scheduled-job infrastructure
                               are documented in ARCHITECTURE.md + CHANGELOG.md; supports a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## [0.29.0] - 2026-05-13
+
+### Changed
+
+- **Operator-breaking**: the ask-self wrappers ([scripts/ask-self-ingest.sh](scripts/ask-self-ingest.sh), [scripts/ask-self-query.sh](scripts/ask-self-query.sh)) now require `ASK_SELF_PATH` to be set in the environment and fail with an actionable error message when it isn't. Previously they fell back to a hardcoded `/Users/noelsaw/...` path that didn't exist on any other operator's machine — a missing env var manifested as a confusing "ask-self repo not found at <someone-else's-path>". Add `export ASK_SELF_PATH="$HOME/Documents/GitHub/ask-self"` (adjust to your checkout) to your shell rc to keep using these wrappers.
+
+### Fixed
+
+- The launchd installers no longer ship with one developer's home directory baked in. All five sync shell scripts (`daily_sync.sh`, `vault_sync.sh`, `pulse_sync.sh`, `pulse_web_sync.sh`, `github_sync.sh`) now derive `REBALANCE_DIR` from their own location, and their five plists became `.plist.template` files with a `{{REBALANCE_DIR}}` placeholder that each `install_*_scheduler.sh` substitutes with the local checkout path before writing into `~/Library/LaunchAgents/`. The rendered plists are gitignored, so a fresh clone on any machine installs cleanly with no per-user editing.
+- The author-fallback in `PROJECT/cleanup.sh` no longer hardcodes a single operator's username — it falls back to `os.environ.get('USER', 'unknown')` when neither the existing frontmatter nor git provides an author.
+- The `Degraded Mac` test fixture in [tests/test_git_pulse_health_check.py](tests/test_git_pulse_health_check.py) no longer embeds a real operator path in its `scan_failure_examples` example; it uses a generic `/Users/operator/...` placeholder instead.
+- The project's `.claude/settings.json` permission allowlist had a few stale `Bash(...)` entries pointing at paths from another machine (`/Users/noelsaw/Documents/GitHub-Repos/...` and `/Users/noelsaw/Documents/rebalance-OS/...`) along with a corresponding `additionalDirectories` entry — all removed since they were dead-ends on this checkout.
+
+### Action required on existing machines
+
+If you already had launchd jobs or ask-self wrappers set up against the previous code, the changes above don't take effect until you do the following on each affected machine:
+
+1. **Re-install the launchd jobs** so the rendered plists in `~/Library/LaunchAgents/` are regenerated from the new templates with your local checkout path. The install scripts unload any existing job before re-rendering, so this is safe to re-run:
+
+   ```bash
+   bash scripts/install_scheduler.sh             # daily sync (06:30)
+   bash scripts/install_vault_scheduler.sh       # hourly vault refresh
+   bash scripts/install_pulse_scheduler.sh       # hourly pulse publish
+   bash scripts/install_pulse_web_scheduler.sh   # 30-min pulse-web refresh
+   bash scripts/install_github_scheduler.sh      # hourly github-only sync
+   ```
+
+   Skip any installer for a job you don't currently have loaded (`launchctl list | grep rebalance-os` shows what's running).
+
+2. **Set `ASK_SELF_PATH` in your shell** if you use the ask-self wrappers — there is no longer a built-in default. Add to `~/.zshrc` / `~/.bashrc`:
+
+   ```bash
+   export ASK_SELF_PATH="$HOME/Documents/GitHub/ask-self"   # adjust to your checkout
+   ```
+
+No DB or vault migration is required — only the install paths above change behavior.
+
 ## [0.28.2] - 2026-05-13
 
 ### Changed

--- a/GOOGLE_CALENDAR.md
+++ b/GOOGLE_CALENDAR.md
@@ -397,7 +397,7 @@ The CLI still uses the same underlying `create_calendar_event(...)` implementati
 
 ### Write-scope validation
 
-Before any write, the command reads `/Users/noelsaw/secrets/google-calendar.env`, loads the pickled token from `GOOGLE_CALENDAR_TOKEN_PATH`, and verifies the token includes `GOOGLE_CALENDAR_REQUIRED_WRITE_SCOPE`.
+Before any write, the command reads `~/secrets/google-calendar.env`, loads the pickled token from `GOOGLE_CALENDAR_TOKEN_PATH`, and verifies the token includes `GOOGLE_CALENDAR_REQUIRED_WRITE_SCOPE`.
 
 If the scope is missing, the command exits non-zero and prints the reauth command from the env file. It does **not** attempt the write with a read-only token.
 

--- a/PROJECT/cleanup.sh
+++ b/PROJECT/cleanup.sh
@@ -888,7 +888,7 @@ for filepath in sorted(files):
     canonical['priority'] = existing.get('priority', infer_priority(filepath))
     canonical['created']  = existing.get('created', gd.get('created', str(date.today())))
     canonical['updated']  = existing.get('updated', gd.get('updated', str(date.today())))
-    canonical['author']   = existing.get('author') or gd.get('author') or 'noelsaw'
+    canonical['author']   = existing.get('author') or gd.get('author') or os.environ.get('USER', 'unknown')
     canonical['goal']     = existing.get('goal', '')
 
     # Normalize priority format (e.g. "high" → P1)

--- a/README.md
+++ b/README.md
@@ -392,7 +392,11 @@ Notes:
 - Embedding is local (Qwen3-Embedding-0.6B via `sentence-transformers`) — no Gemini API key needed for ingest or query.
 - Synthesis (the answer step) still defaults to Gemini unless you pass `--retrieval-only` or configure a local synthesis provider in [ask_self/ask_self_harness.json](ask_self/ask_self_harness.json).
 
-The wrappers point at `/Users/noelsaw/Documents/GH Repos/ask-self` by default. Override `ASK_SELF_PATH` if your ask-self checkout lives elsewhere.
+The wrappers require `ASK_SELF_PATH` to point at your local `ask-self` checkout (no default — the scripts fail loudly if it isn't set):
+
+```bash
+export ASK_SELF_PATH="$HOME/Documents/GitHub/ask-self"
+```
 
 ### CLI reference
 

--- a/scripts/ask-self-ingest.sh
+++ b/scripts/ask-self-ingest.sh
@@ -4,7 +4,11 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-ASK_SELF_PATH="${ASK_SELF_PATH:-/Users/noelsaw/Documents/GH Repos/ask-self}"
+if [ -z "${ASK_SELF_PATH:-}" ]; then
+    echo "ASK_SELF_PATH is not set. Point it at your ask-self checkout, e.g.:" >&2
+    echo "    export ASK_SELF_PATH=\"\$HOME/Documents/GitHub/ask-self\"" >&2
+    exit 1
+fi
 HARNESS_CONFIG="$REPO_ROOT/ask_self/ask_self_harness.json"
 ENTRYPOINT="$ASK_SELF_PATH/ask_self_ingest.py"
 # Portable mode: write the committed DB at a tracked path so a fresh clone can query
@@ -14,8 +18,7 @@ PORTABLE_DB="$REPO_ROOT/ask_self/index/rebalance-OS.sqlite"
 mkdir -p "$REPO_ROOT/ask_self/index"
 
 if [ ! -d "$ASK_SELF_PATH" ]; then
-    echo "ask-self repo not found: $ASK_SELF_PATH" >&2
-    echo "Set ASK_SELF_PATH to your ask-self checkout and retry." >&2
+    echo "ASK_SELF_PATH points at $ASK_SELF_PATH but no directory is there." >&2
     exit 1
 fi
 

--- a/scripts/ask-self-query.sh
+++ b/scripts/ask-self-query.sh
@@ -4,7 +4,11 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-ASK_SELF_PATH="${ASK_SELF_PATH:-/Users/noelsaw/Documents/GH Repos/ask-self}"
+if [ -z "${ASK_SELF_PATH:-}" ]; then
+    echo "ASK_SELF_PATH is not set. Point it at your ask-self checkout, e.g.:" >&2
+    echo "    export ASK_SELF_PATH=\"\$HOME/Documents/GitHub/ask-self\"" >&2
+    exit 1
+fi
 HARNESS_CONFIG="$REPO_ROOT/ask_self/ask_self_harness.json"
 ENTRYPOINT="$ASK_SELF_PATH/ask_self_query.py"
 # Portable mode: query the committed DB so a fresh clone works with no ingest.
@@ -13,8 +17,7 @@ ENTRYPOINT="$ASK_SELF_PATH/ask_self_query.py"
 PORTABLE_DB="$REPO_ROOT/ask_self/index/rebalance-OS.sqlite"
 
 if [ ! -d "$ASK_SELF_PATH" ]; then
-    echo "ask-self repo not found: $ASK_SELF_PATH" >&2
-    echo "Set ASK_SELF_PATH to your ask-self checkout and retry." >&2
+    echo "ASK_SELF_PATH points at $ASK_SELF_PATH but no directory is there." >&2
     exit 1
 fi
 

--- a/scripts/com.rebalance-os.daily-sync.plist.template
+++ b/scripts/com.rebalance-os.daily-sync.plist.template
@@ -7,7 +7,7 @@
 
     <key>ProgramArguments</key>
     <array>
-        <string>/Users/noelsaw/Documents/rebalance-OS/scripts/daily_sync.sh</string>
+        <string>{{REBALANCE_DIR}}/scripts/daily_sync.sh</string>
     </array>
 
     <!-- Run at 6:30 AM every day -->
@@ -24,10 +24,10 @@
     <true/>
 
     <key>StandardOutPath</key>
-    <string>/Users/noelsaw/Documents/rebalance-OS/temp/logs/launchd_stdout.log</string>
+    <string>{{REBALANCE_DIR}}/temp/logs/launchd_stdout.log</string>
 
     <key>StandardErrorPath</key>
-    <string>/Users/noelsaw/Documents/rebalance-OS/temp/logs/launchd_stderr.log</string>
+    <string>{{REBALANCE_DIR}}/temp/logs/launchd_stderr.log</string>
 
     <!-- Don't restart on failure — just run next scheduled time -->
     <key>KeepAlive</key>

--- a/scripts/com.rebalance-os.github-sync.plist.template
+++ b/scripts/com.rebalance-os.github-sync.plist.template
@@ -7,7 +7,7 @@
 
     <key>ProgramArguments</key>
     <array>
-        <string>/Users/noelsaw/Documents/rebalance-OS/scripts/github_sync.sh</string>
+        <string>{{REBALANCE_DIR}}/scripts/github_sync.sh</string>
     </array>
 
     <!-- Run every hour from 6 AM through 11 PM local time. -->
@@ -37,10 +37,10 @@
     <false/>
 
     <key>StandardOutPath</key>
-    <string>/Users/noelsaw/Documents/rebalance-OS/temp/logs/github_stdout.log</string>
+    <string>{{REBALANCE_DIR}}/temp/logs/github_stdout.log</string>
 
     <key>StandardErrorPath</key>
-    <string>/Users/noelsaw/Documents/rebalance-OS/temp/logs/github_stderr.log</string>
+    <string>{{REBALANCE_DIR}}/temp/logs/github_stderr.log</string>
 
     <key>KeepAlive</key>
     <false/>

--- a/scripts/com.rebalance-os.pulse-sync.plist.template
+++ b/scripts/com.rebalance-os.pulse-sync.plist.template
@@ -7,7 +7,7 @@
 
     <key>ProgramArguments</key>
     <array>
-        <string>/Users/noelsaw/Documents/rebalance-OS/scripts/pulse_sync.sh</string>
+        <string>{{REBALANCE_DIR}}/scripts/pulse_sync.sh</string>
     </array>
 
     <!-- Run every hour from 6 AM through 11 PM local time. -->
@@ -39,10 +39,10 @@
     <false/>
 
     <key>StandardOutPath</key>
-    <string>/Users/noelsaw/Documents/rebalance-OS/temp/logs/pulse_stdout.log</string>
+    <string>{{REBALANCE_DIR}}/temp/logs/pulse_stdout.log</string>
 
     <key>StandardErrorPath</key>
-    <string>/Users/noelsaw/Documents/rebalance-OS/temp/logs/pulse_stderr.log</string>
+    <string>{{REBALANCE_DIR}}/temp/logs/pulse_stderr.log</string>
 
     <key>KeepAlive</key>
     <false/>

--- a/scripts/com.rebalance-os.pulse-web-sync.plist.template
+++ b/scripts/com.rebalance-os.pulse-web-sync.plist.template
@@ -7,7 +7,7 @@
 
     <key>ProgramArguments</key>
     <array>
-        <string>/Users/noelsaw/Documents/rebalance-OS/scripts/pulse_web_sync.sh</string>
+        <string>{{REBALANCE_DIR}}/scripts/pulse_web_sync.sh</string>
     </array>
 
     <!-- Run every 30 minutes from 6:00 AM through 11:30 PM local time.
@@ -58,10 +58,10 @@
     <false/>
 
     <key>StandardOutPath</key>
-    <string>/Users/noelsaw/Documents/rebalance-OS/temp/logs/pulse_web_stdout.log</string>
+    <string>{{REBALANCE_DIR}}/temp/logs/pulse_web_stdout.log</string>
 
     <key>StandardErrorPath</key>
-    <string>/Users/noelsaw/Documents/rebalance-OS/temp/logs/pulse_web_stderr.log</string>
+    <string>{{REBALANCE_DIR}}/temp/logs/pulse_web_stderr.log</string>
 
     <key>KeepAlive</key>
     <false/>

--- a/scripts/com.rebalance-os.vault-sync.plist.template
+++ b/scripts/com.rebalance-os.vault-sync.plist.template
@@ -7,7 +7,7 @@
 
     <key>ProgramArguments</key>
     <array>
-        <string>/Users/noelsaw/Documents/rebalance-OS/scripts/vault_sync.sh</string>
+        <string>{{REBALANCE_DIR}}/scripts/vault_sync.sh</string>
     </array>
 
     <!-- Run every hour from 6 AM through 11 PM local time. Daily-sync
@@ -40,10 +40,10 @@
     <false/>
 
     <key>StandardOutPath</key>
-    <string>/Users/noelsaw/Documents/rebalance-OS/temp/logs/vault_stdout.log</string>
+    <string>{{REBALANCE_DIR}}/temp/logs/vault_stdout.log</string>
 
     <key>StandardErrorPath</key>
-    <string>/Users/noelsaw/Documents/rebalance-OS/temp/logs/vault_stderr.log</string>
+    <string>{{REBALANCE_DIR}}/temp/logs/vault_stderr.log</string>
 
     <key>KeepAlive</key>
     <false/>

--- a/scripts/daily_sync.sh
+++ b/scripts/daily_sync.sh
@@ -10,7 +10,7 @@
 
 set -euo pipefail
 
-REBALANCE_DIR="/Users/noelsaw/Documents/rebalance-OS"
+REBALANCE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 PYTHON="$REBALANCE_DIR/.venv/bin/python"
 DATABASE="$REBALANCE_DIR/rebalance.db"
 LOG_DIR="$REBALANCE_DIR/temp/logs"

--- a/scripts/github_sync.sh
+++ b/scripts/github_sync.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-REBALANCE_DIR="/Users/noelsaw/Documents/rebalance-OS"
+REBALANCE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 PYTHON="$REBALANCE_DIR/.venv/bin/python"
 DATABASE="$REBALANCE_DIR/rebalance.db"
 LOG_DIR="$REBALANCE_DIR/temp/logs"

--- a/scripts/install_github_scheduler.sh
+++ b/scripts/install_github_scheduler.sh
@@ -2,7 +2,8 @@
 # Install (or reinstall) the rebalance OS hourly github sync scheduler.
 #
 # What this does:
-#   1. Copies com.rebalance-os.github-sync.plist to ~/Library/LaunchAgents/
+#   1. Renders com.rebalance-os.github-sync.plist.template (substituting the
+#      local checkout path for {{REBALANCE_DIR}}) into ~/Library/LaunchAgents/.
 #   2. Loads it so macOS runs github_sync.sh at HH:45 from 06:45 through 23:45.
 #
 # Usage:
@@ -11,11 +12,13 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PLIST_SRC="$SCRIPT_DIR/com.rebalance-os.github-sync.plist"
+REBALANCE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PLIST_TEMPLATE="$SCRIPT_DIR/com.rebalance-os.github-sync.plist.template"
 PLIST_DEST="$HOME/Library/LaunchAgents/com.rebalance-os.github-sync.plist"
 SYNC_SCRIPT="$SCRIPT_DIR/github_sync.sh"
 
 echo "Installing rebalance OS hourly github scheduler..."
+echo "  REBALANCE_DIR=$REBALANCE_DIR"
 
 if [ ! -x "$SYNC_SCRIPT" ]; then
     chmod +x "$SYNC_SCRIPT"
@@ -27,10 +30,12 @@ if launchctl list | grep -q "com.rebalance-os.github-sync"; then
     launchctl unload "$PLIST_DEST" 2>/dev/null || true
 fi
 
-cp "$PLIST_SRC" "$PLIST_DEST"
-echo "  Copied plist to $PLIST_DEST"
+# Render template into LaunchAgents — escape '/' and '&' for sed.
+ESCAPED_DIR=$(printf '%s\n' "$REBALANCE_DIR" | sed 's/[\/&]/\\&/g')
+sed "s/{{REBALANCE_DIR}}/$ESCAPED_DIR/g" "$PLIST_TEMPLATE" > "$PLIST_DEST"
+echo "  Rendered plist to $PLIST_DEST"
 
-mkdir -p "$SCRIPT_DIR/../temp/logs"
+mkdir -p "$REBALANCE_DIR/temp/logs"
 
 launchctl load "$PLIST_DEST"
 echo "  Loaded scheduler"

--- a/scripts/install_pulse_scheduler.sh
+++ b/scripts/install_pulse_scheduler.sh
@@ -2,7 +2,8 @@
 # Install (or reinstall) the rebalance OS hourly pulse publisher.
 #
 # What this does:
-#   1. Copies com.rebalance-os.pulse-sync.plist to ~/Library/LaunchAgents/
+#   1. Renders com.rebalance-os.pulse-sync.plist.template (substituting the
+#      local checkout path for {{REBALANCE_DIR}}) into ~/Library/LaunchAgents/.
 #   2. Loads it so macOS runs pulse_sync.sh every hour from 6 AM to 11 PM.
 #
 # Pre-flight:
@@ -22,11 +23,13 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PLIST_SRC="$SCRIPT_DIR/com.rebalance-os.pulse-sync.plist"
+REBALANCE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PLIST_TEMPLATE="$SCRIPT_DIR/com.rebalance-os.pulse-sync.plist.template"
 PLIST_DEST="$HOME/Library/LaunchAgents/com.rebalance-os.pulse-sync.plist"
 PULSE_SCRIPT="$SCRIPT_DIR/pulse_sync.sh"
 
 echo "Installing rebalance OS hourly pulse scheduler..."
+echo "  REBALANCE_DIR=$REBALANCE_DIR"
 
 if [ ! -x "$PULSE_SCRIPT" ]; then
     chmod +x "$PULSE_SCRIPT"
@@ -38,8 +41,9 @@ if launchctl list | grep -q "com.rebalance-os.pulse-sync"; then
     launchctl unload "$PLIST_DEST" 2>/dev/null || true
 fi
 
-cp "$PLIST_SRC" "$PLIST_DEST"
-echo "  Copied plist to $PLIST_DEST"
+ESCAPED_DIR=$(printf '%s\n' "$REBALANCE_DIR" | sed 's/[\/&]/\\&/g')
+sed "s/{{REBALANCE_DIR}}/$ESCAPED_DIR/g" "$PLIST_TEMPLATE" > "$PLIST_DEST"
+echo "  Rendered plist to $PLIST_DEST"
 
 mkdir -p "$SCRIPT_DIR/../temp/logs"
 

--- a/scripts/install_pulse_web_scheduler.sh
+++ b/scripts/install_pulse_web_scheduler.sh
@@ -24,11 +24,13 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PLIST_SRC="$SCRIPT_DIR/com.rebalance-os.pulse-web-sync.plist"
+REBALANCE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PLIST_TEMPLATE="$SCRIPT_DIR/com.rebalance-os.pulse-web-sync.plist.template"
 PLIST_DEST="$HOME/Library/LaunchAgents/com.rebalance-os.pulse-web-sync.plist"
 PULSE_WEB_SCRIPT="$SCRIPT_DIR/pulse_web_sync.sh"
 
 echo "Installing rebalance OS 30-minute pulse-web scheduler..."
+echo "  REBALANCE_DIR=$REBALANCE_DIR"
 
 if [ ! -x "$PULSE_WEB_SCRIPT" ]; then
     chmod +x "$PULSE_WEB_SCRIPT"
@@ -40,10 +42,12 @@ if launchctl list | grep -q "com.rebalance-os.pulse-web-sync"; then
     launchctl unload "$PLIST_DEST" 2>/dev/null || true
 fi
 
-cp "$PLIST_SRC" "$PLIST_DEST"
-echo "  Copied plist to $PLIST_DEST"
+# Render template into LaunchAgents — escape '/' and '&' for sed.
+ESCAPED_DIR=$(printf '%s\n' "$REBALANCE_DIR" | sed 's/[\/&]/\\&/g')
+sed "s/{{REBALANCE_DIR}}/$ESCAPED_DIR/g" "$PLIST_TEMPLATE" > "$PLIST_DEST"
+echo "  Rendered plist to $PLIST_DEST"
 
-mkdir -p "$SCRIPT_DIR/../temp/logs"
+mkdir -p "$REBALANCE_DIR/temp/logs"
 
 launchctl load "$PLIST_DEST"
 echo "  Loaded scheduler"

--- a/scripts/install_scheduler.sh
+++ b/scripts/install_scheduler.sh
@@ -2,7 +2,8 @@
 # Install (or reinstall) the rebalance OS daily sync scheduler.
 #
 # What this does:
-#   1. Copies the launchd plist to ~/Library/LaunchAgents/
+#   1. Renders com.rebalance-os.daily-sync.plist.template (substituting the
+#      local checkout path for {{REBALANCE_DIR}}) into ~/Library/LaunchAgents/.
 #   2. Loads it so macOS runs daily_sync.sh:
 #      - At 6:30 AM every day
 #      - On boot/login if 6:30 AM was missed (laptop was asleep)
@@ -17,10 +18,12 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PLIST_SRC="$SCRIPT_DIR/com.rebalance-os.daily-sync.plist"
+REBALANCE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PLIST_TEMPLATE="$SCRIPT_DIR/com.rebalance-os.daily-sync.plist.template"
 PLIST_DEST="$HOME/Library/LaunchAgents/com.rebalance-os.daily-sync.plist"
 
 echo "Installing rebalance OS daily sync scheduler..."
+echo "  REBALANCE_DIR=$REBALANCE_DIR"
 
 # Unload if already loaded
 if launchctl list | grep -q "com.rebalance-os.daily-sync"; then
@@ -28,9 +31,10 @@ if launchctl list | grep -q "com.rebalance-os.daily-sync"; then
     launchctl unload "$PLIST_DEST" 2>/dev/null || true
 fi
 
-# Copy plist
-cp "$PLIST_SRC" "$PLIST_DEST"
-echo "  Copied plist to $PLIST_DEST"
+# Render template into LaunchAgents — escape '/' and '&' for sed.
+ESCAPED_DIR=$(printf '%s\n' "$REBALANCE_DIR" | sed 's/[\/&]/\\&/g')
+sed "s/{{REBALANCE_DIR}}/$ESCAPED_DIR/g" "$PLIST_TEMPLATE" > "$PLIST_DEST"
+echo "  Rendered plist to $PLIST_DEST"
 
 # Create log directory
 mkdir -p "$SCRIPT_DIR/../temp/logs"

--- a/scripts/install_vault_scheduler.sh
+++ b/scripts/install_vault_scheduler.sh
@@ -2,7 +2,8 @@
 # Install (or reinstall) the rebalance OS hourly vault refresh scheduler.
 #
 # What this does:
-#   1. Copies com.rebalance-os.vault-sync.plist to ~/Library/LaunchAgents/
+#   1. Renders com.rebalance-os.vault-sync.plist.template (substituting the
+#      local checkout path for {{REBALANCE_DIR}}) into ~/Library/LaunchAgents/.
 #   2. Loads it so macOS runs vault_sync.sh at HH:15 from 06:15 through 23:15.
 #
 # This complements the daily 06:30 full sync by keeping just the vault
@@ -19,11 +20,13 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PLIST_SRC="$SCRIPT_DIR/com.rebalance-os.vault-sync.plist"
+REBALANCE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PLIST_TEMPLATE="$SCRIPT_DIR/com.rebalance-os.vault-sync.plist.template"
 PLIST_DEST="$HOME/Library/LaunchAgents/com.rebalance-os.vault-sync.plist"
 VAULT_SCRIPT="$SCRIPT_DIR/vault_sync.sh"
 
 echo "Installing rebalance OS hourly vault scheduler..."
+echo "  REBALANCE_DIR=$REBALANCE_DIR"
 
 if [ ! -x "$VAULT_SCRIPT" ]; then
     chmod +x "$VAULT_SCRIPT"
@@ -35,8 +38,9 @@ if launchctl list | grep -q "com.rebalance-os.vault-sync"; then
     launchctl unload "$PLIST_DEST" 2>/dev/null || true
 fi
 
-cp "$PLIST_SRC" "$PLIST_DEST"
-echo "  Copied plist to $PLIST_DEST"
+ESCAPED_DIR=$(printf '%s\n' "$REBALANCE_DIR" | sed 's/[\/&]/\\&/g')
+sed "s/{{REBALANCE_DIR}}/$ESCAPED_DIR/g" "$PLIST_TEMPLATE" > "$PLIST_DEST"
+echo "  Rendered plist to $PLIST_DEST"
 
 mkdir -p "$SCRIPT_DIR/../temp/logs"
 

--- a/scripts/pulse_server.sh
+++ b/scripts/pulse_server.sh
@@ -11,7 +11,7 @@
 
 set -euo pipefail
 
-REBALANCE_DIR="/Users/noelsaw/Documents/rebalance-OS"
+REBALANCE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 PYTHON="$REBALANCE_DIR/.venv/bin/python"
 PORT="${PULSE_PORT:-8767}"
 

--- a/scripts/pulse_sync.sh
+++ b/scripts/pulse_sync.sh
@@ -10,7 +10,7 @@
 
 set -euo pipefail
 
-REBALANCE_DIR="/Users/noelsaw/Documents/rebalance-OS"
+REBALANCE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 PYTHON="$REBALANCE_DIR/.venv/bin/python"
 LOG_DIR="$REBALANCE_DIR/temp/logs"
 

--- a/scripts/pulse_web_sync.sh
+++ b/scripts/pulse_web_sync.sh
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-REBALANCE_DIR="/Users/noelsaw/Documents/rebalance-OS"
+REBALANCE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 PYTHON="$REBALANCE_DIR/.venv/bin/python"
 LOG_DIR="$REBALANCE_DIR/temp/logs"
 

--- a/scripts/vault_sync.sh
+++ b/scripts/vault_sync.sh
@@ -14,7 +14,7 @@
 
 set -euo pipefail
 
-REBALANCE_DIR="/Users/noelsaw/Documents/rebalance-OS"
+REBALANCE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 PYTHON="$REBALANCE_DIR/.venv/bin/python"
 DATABASE="$REBALANCE_DIR/rebalance.db"
 LOG_DIR="$REBALANCE_DIR/temp/logs"

--- a/src/rebalance/cli.py
+++ b/src/rebalance/cli.py
@@ -314,11 +314,11 @@ CALENDAR_EVENT_LOG_PATH = Path("temp/logs/calendar-event-create.jsonl")
 # TODO: support sleuth-web-api-production.env once a prod Sleuth deployment
 # exists — likely via a --env name|production|development flag.
 
-# Module-level path for the Google Calendar env file. Resolved at import time
-# so tests can patch `rebalance.cli.GOOGLE_CALENDAR_ENV_PATH` to redirect
-# subsequent reads in `_load_google_calendar_env` without monkey-patching the
-# resolver itself.
+# Module-level paths for operator env files. Resolved at import time so tests
+# can patch `rebalance.cli.GOOGLE_CALENDAR_ENV_PATH` / `rebalance.cli.SLEUTH_ENV_PATH`
+# to redirect subsequent reads without monkey-patching the resolver itself.
 GOOGLE_CALENDAR_ENV_PATH = resolve_secret_path("google-calendar.env")
+SLEUTH_ENV_PATH = resolve_secret_path("sleuth-web-api-development.env")
 
 
 def _load_google_calendar_env() -> dict[str, str]:

--- a/src/rebalance/paths.py
+++ b/src/rebalance/paths.py
@@ -324,7 +324,7 @@ def resolve_secret_path(name: str) -> Path:
     """Return the resolved Path to a named secret file under the secrets dir.
 
     Example: ``resolve_secret_path("google-calendar.env")`` →
-        ``Path("/Users/noelsaw/secrets/google-calendar.env")`` by default,
+        ``Path.home() / "secrets" / "google-calendar.env"`` by default,
         respecting REBALANCE_SECRETS_DIR / user config when set.
     """
     return resolve_secrets_dir() / name

--- a/tests/test_git_pulse_health_check.py
+++ b/tests/test_git_pulse_health_check.py
@@ -227,7 +227,7 @@ class HealthCheckCliTests(unittest.TestCase):
                 last_scan_utc: "{recent_scan.strftime('%Y-%m-%dT%H:%M:%SZ')}"
                 repo_scan_failures: "1"
                 scan_status: "degraded"
-                scan_failure_examples: "/Users/noelsaw/Documents/GH Repos/project-a"
+                scan_failure_examples: "/Users/operator/Documents/GH Repos/project-a"
                 """
             ),
         )


### PR DESCRIPTION
## Summary

The launchd installers, ask-self wrappers, pulse-server bootstrap, and a docstring example all hardcoded one developer's home directory (`/Users/noelsaw/...`). A fresh clone on any other machine would silently install plists pointing at non-existent paths, fall back to a wrong default for ask-self, or fail to start the pulse server. This change normalizes every active code path so the repo is portable across operator home directories.

After rebase onto current `main`, scope expanded to cover two newer launchd jobs (`github-sync`, `pulse-web-sync`) that landed on main after this PR was opened and re-introduced the same problem, plus `pulse_server.sh` and a `paths.py` docstring example.

- **launchd jobs (5 total)** — `daily_sync.sh`, `vault_sync.sh`, `pulse_sync.sh`, `pulse_web_sync.sh`, `github_sync.sh`, and `pulse_server.sh` derive `REBALANCE_DIR` from the script's own location. The five `.plist` files become `.plist.template` files with `{{REBALANCE_DIR}}` placeholders that each `install_*_scheduler.sh` substitutes at install time. Rendered plists are gitignored via the existing `scripts/com.rebalance-os.*.plist` wildcard.
- **ask-self wrappers** — `ASK_SELF_PATH` is now required (no broken default); the scripts fail with an actionable error message when it isn't set. The throttled-ingest helper script was removed on main (0.25.0 switched to local Qwen embeddings) so that file's modifications were dropped on rebase.
- **`PROJECT/cleanup.sh`** — author fallback uses `os.environ.get('USER', 'unknown')` instead of a hardcoded operator name.
- **`src/rebalance/paths.py`** — `resolve_secret_path` docstring example now uses `Path.home() / "secrets" / ...` instead of naming one operator's path.
- **`.claude/settings.json`** — stale permission entries pointing at non-existent paths from another checkout removed.
- **Docs** — README, CHANGELOG (new `0.29.0` entry with migration instructions), ARCHITECTURE updated to match.

Secret env files (`google-calendar.env`, `sleuth-web-api-development.env`) were already migrated onto `resolve_secret_path()` in 0.25.0, so the corresponding bullet from the original PR description was dropped — that work shipped separately. The rebase preserves and uses that resolver instead of overwriting it with the simpler `Path.home() / "secrets"` form.

## Action required on existing machines

The CHANGELOG 0.29.0 entry includes a step-by-step ("Action required on existing machines") covering: re-running each of the five `install_*_scheduler.sh` to regenerate the `~/Library/LaunchAgents/` plist from the new template, and exporting `ASK_SELF_PATH` if you use the ask-self wrappers. No DB or vault migration is needed.

## Test plan

- [x] Full local test suite green (262 passed)
- [x] `plutil -lint` clean on all 5 rendered plist templates
- [x] `bash -n` clean on all modified shell scripts
- [x] `git grep '/Users/noelsaw/'` over `scripts/`, `src/`, `*.py`, `*.sh` returns zero hits
- [x] Both CI Python versions (3.12, 3.13) green
- [ ] On a fresh clone at a non-`noelsaw` path, run each `install_*_scheduler.sh` and confirm the rendered plist in `~/Library/LaunchAgents/` resolves to the local checkout
- [ ] On a machine with the existing setup, follow the "Action required" steps and verify the next scheduled run lands