### PR TITLE
fix(tests): strip ANSI from CLI error output to unbreak CI

### DIFF
--- a/tests/test_calendar_create_event_cli.py
+++ b/tests/test_calendar_create_event_cli.py
@@ -2,6 +2,7 @@
 
 import json
 import pickle
+import re
 import tempfile
 import unittest
 from pathlib import Path
@@ -11,6 +12,15 @@ from unittest.mock import patch
 from typer.testing import CliRunner
 
 from rebalance.cli import app
+
+
+# Typer/Rich now wraps each `--flag` token in cyan ANSI escapes, which breaks
+# plain-string assertIn matches against rendered error panels.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
 
 
 class CalendarCreateEventCliTests(unittest.TestCase):
@@ -92,7 +102,7 @@ class CalendarCreateEventCliTests(unittest.TestCase):
                 )
 
         self.assertNotEqual(result.exit_code, 0)
-        error_output = result.stderr or result.output
+        error_output = _strip_ansi(result.stderr or result.output)
         self.assertIn("missing the required write scope", error_output)
         self.assertIn("setup_calendar_oauth.py --write-access", error_output)
         self.assertIn("--test", error_output)

--- a/tests/test_calendar_weekly_report_cli.py
+++ b/tests/test_calendar_weekly_report_cli.py
@@ -1,5 +1,6 @@
 """Tests for weekly report write-back into the vault."""
 
+import re
 import tempfile
 import unittest
 from datetime import date
@@ -12,6 +13,15 @@ from rebalance.cli import app
 from rebalance.ingest.calendar_config import CalendarConfig
 from rebalance.ingest.embedder import EmbedResult
 from rebalance.ingest.note_ingester import IngestResult
+
+
+# Typer/Rich now wraps each `--flag` token in cyan ANSI escapes, which breaks
+# plain-string assertIn matches against rendered error panels.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
 
 
 def _insert_events(database_path: Path, events: list[tuple], calendar_id: str = "primary") -> None:
@@ -115,4 +125,4 @@ class CalendarWeeklyReportCliTests(unittest.TestCase):
             )
 
             self.assertNotEqual(result.exit_code, 0)
-            self.assertIn("--vault or REBALANCE_VAULT is required", result.output)
+            self.assertIn("--vault or REBALANCE_VAULT is required", _strip_ansi(result.output))


### PR DESCRIPTION
## Summary

Fixes the 2 pre-existing CI failures that have been red on `main` since at least 2026-05-06 (e.g. run [25411002695](https://github.com/Hypercart-Dev-Tools/rebalance-OS/actions/runs/25411002695) on commit `f8aeac4`):

- `test_missing_write_scope_fails_before_write` (test_calendar_create_event_cli.py:97)
- `test_write_week_note_requires_vault` (test_calendar_weekly_report_cli.py:118)

**Root cause:** Typer/Rich now wraps each `--flag` token in the rendered error panel with cyan ANSI escapes around the dashes:

```
Expected: "setup_calendar_oauth.py --write-access"
Actual:   "setup_calendar_oauth.py \x1b[1;36m-\x1b[0m\x1b[1;36m-write\x1b[0m\x1b[1;36m-access\x1b[0m"
```

So the literal-string `assertIn(...)` calls fail because the dashes aren't contiguous in the output anymore.

**Fix:** add a tiny `_strip_ansi()` helper in each affected test file and apply it to the two failing assertions only. Other CLI assertions in these files use plain strings (e.g. "Week note written to") that don't get colorized, so they're left untouched.

## Test plan

- [x] Run only the 2 fixed tests: both pass locally
- [x] Run full suite: the 2 CI failures are gone (4 unrelated locally-failing tests remain — they're config-dependent and pass on CI)
- [ ] CI on this PR is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)