### PR TITLE
Add Gmail ingest phase 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.27.1] - 2026-05-12
+
+### Fixed
+
+- Gmail 403 handling is now conservative: only true insufficient-scope responses are rewritten into the `gcloud auth application-default login` remediation message. Other 403s, such as a disabled Gmail API, surface their original upstream error instead of being mislabeled as a scope problem.
+
 ## [0.27.0] - 2026-05-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.27.0] - 2026-05-12
+
+### Added
+
+- Gmail inbox ingest via `refresh_index(scope=["email"])`. Phase 1 syncs the newest 100 inbox messages, stores message metadata plus Gmail-provided snippets in SQLite, and backfills them into the unified semantic index so email participates in default `semantic_query()` results.
+- New `gmail_query_filter` config key in `temp/rbos.config` to narrow the Gmail fetch scope without code changes. Defaults to `in:inbox`.
+- `index_status()` now reports an `email` source block with message count, last sync time, and newest received timestamp.
+
+### Fixed
+
+- Gmail auth failures caused by missing `gmail.readonly` scope now return an explicit remediation message with the exact `gcloud auth application-default login` command to rerun.
+
 ## [0.26.0] - 2026-05-12
 
 ### Added

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,5 +1,6 @@
 # Memory
 
+- Phase 1 Gmail ingest uses Google Application Default Credentials (`gcloud auth application-default login` with `gmail.readonly`), stores subject + Gmail snippet only, and can be narrowed via `gmail_query_filter` in `temp/rbos.config`.
 - Bash-script RAG spike entrypoint: `temp/bash_script_rag_spike.py`.
 - Reusable spike artifacts: `temp/rag/bash-script-spike.sqlite` and `temp/logs/bash-script-spike.jsonl`.
 - The spike's default extra corpus includes wp-code-check scanner patterns from `../GH Repos/wp-code-check/dist/patterns/**/*.json` plus `PATTERN-LIBRARY.json` and `PATTERN-LIBRARY.md`.

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ The result is an AI assistant that actually knows your work — because it's rea
 - [ ] Weekly rebalance note generation with verdicts, evidence, and next moves per project
 - [ ] Attention ledger contract (`project_targets`, `attention_events`, `attention_feedback`, rollups)
 - [ ] Narrower verdict-first MCP surface (`weekly_rebalance`, `project_attention`, unattributed review)
-- [ ] Email integration (Gmail API, starred/important threads only, forward-only)
+- [x] Gmail inbox integration (newest 100 inbox messages, semantic participation via subject + snippet)
 - [ ] Slack integration beyond reminder/task signals
 - [ ] Email → project auto-correlation (alias map + co-occurrence)
 
@@ -265,7 +265,45 @@ Edit `temp/calendar_config.json` with your preferences:
 
 For the full guide — including team setup, Claude Code prompts, and project definitions — see [GOOGLE_CALENDAR.md](./GOOGLE_CALENDAR.md).
 
-### Step 5 — Start using with Claude Code
+### Step 5 — Connect Gmail (optional)
+
+The Gmail ingest uses Google Application Default Credentials and stores
+message metadata plus Gmail-provided snippets only. It does not parse full
+message bodies in Phase 1.
+
+**5a. Enable the Gmail API once**
+
+```bash
+gcloud services enable gmail.googleapis.com
+```
+
+**5b. Authorize this device**
+
+```bash
+gcloud auth application-default login --scopes=https://www.googleapis.com/auth/gmail.readonly,https://www.googleapis.com/auth/cloud-platform
+```
+
+This stores the token at `~/.config/gcloud/application_default_credentials.json`.
+
+**5c. Optional: narrow the inbox query**
+
+Add a `gmail_query_filter` key to `temp/rbos.config`. Example:
+
+```json
+{
+  "gmail_query_filter": "in:inbox -category:promotions -category:social"
+}
+```
+
+If unset, rebalance defaults to `in:inbox`.
+
+**5d. Sync and verify**
+
+Call the MCP refresh entry point with `scope=["email"]`, then confirm the
+`email` block appears in `index_status()` and email hits show up in
+`semantic_query()`.
+
+### Step 6 — Start using with Claude Code
 
 The `.mcp.json` at the project root auto-registers the MCP server. Open the project in Claude Code:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rebalance-os"
-version = "0.27.0"
+version = "0.27.1"
 description = "Local-first workday operating system with MCP tools and Obsidian ingest"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rebalance-os"
-version = "0.23.9"
+version = "0.27.0"
 description = "Local-first workday operating system with MCP tools and Obsidian ingest"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/rebalance/__init__.py
+++ b/src/rebalance/__init__.py
@@ -1,4 +1,4 @@
 """rebalance package."""
 
 __all__ = ["__version__"]
-__version__ = "0.27.0"
+__version__ = "0.27.1"

--- a/src/rebalance/__init__.py
+++ b/src/rebalance/__init__.py
@@ -1,4 +1,4 @@
 """rebalance package."""
 
 __all__ = ["__version__"]
-__version__ = "0.23.9"
+__version__ = "0.27.0"

--- a/src/rebalance/ingest/config.py
+++ b/src/rebalance/ingest/config.py
@@ -139,6 +139,28 @@ def set_vault_path(path: str) -> None:
     _write_config(config)
 
 
+def get_gmail_query_filter() -> str | None:
+    """Return the configured Gmail search query, or None if unset.
+
+    Config key: ``gmail_query_filter``. Default applied by the caller is
+    ``in:inbox`` (see ``rebalance.ingest.gmail.DEFAULT_QUERY_FILTER``).
+    Power users can scope to e.g. ``in:inbox -category:promotions``.
+    """
+    config = _read_config()
+    value = config.get("gmail_query_filter")
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def set_gmail_query_filter(query: str) -> None:
+    """Store the Gmail search query filter in config."""
+    config = _read_config()
+    config["gmail_query_filter"] = query.strip()
+    _write_config(config)
+
+
 def get_github_ignored_repos() -> list[str]:
     """Return the locally configured GitHub repos to skip across ingest."""
     config = _read_config()

--- a/src/rebalance/ingest/db.py
+++ b/src/rebalance/ingest/db.py
@@ -240,6 +240,40 @@ def ensure_calendar_schema(conn: sqlite3.Connection) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Email schema
+# ---------------------------------------------------------------------------
+
+
+def ensure_email_schema(conn: sqlite3.Connection) -> None:
+    """Create email_messages table if it doesn't exist.
+
+    Phase 1 stores metadata + Gmail-provided snippet only — no MIME body
+    parsing. ``message_id`` is Gmail's globally unique id; ``INSERT OR
+    REPLACE`` keyed on this PK gives upsert behavior across runs.
+    """
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS email_messages (
+            message_id      TEXT PRIMARY KEY,
+            thread_id       TEXT,
+            from_address    TEXT,
+            from_name       TEXT,
+            subject         TEXT,
+            snippet         TEXT,
+            received_at     TEXT,
+            labels_json     TEXT,
+            synced_at       TEXT NOT NULL
+        )
+    """)
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_email_received ON email_messages(received_at)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_email_thread ON email_messages(thread_id)"
+    )
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
 # GitHub activity schema
 # ---------------------------------------------------------------------------
 

--- a/src/rebalance/ingest/gmail.py
+++ b/src/rebalance/ingest/gmail.py
@@ -145,13 +145,29 @@ def _parse_from(headers: dict[str, str]) -> tuple[str, str]:
 
 
 def _is_insufficient_scope_error(exc: Exception) -> bool:
-    """Detect Gmail's 403 insufficient-scope response."""
+    """Detect Gmail's 403 insufficient-scope response conservatively."""
     status = getattr(getattr(exc, "resp", None), "status", None)
     try:
         status_int = int(status) if status is not None else None
     except (TypeError, ValueError):
         status_int = None
-    return status_int == 403
+    if status_int != 403:
+        return False
+
+    content = getattr(exc, "content", b"")
+    if isinstance(content, bytes):
+        body = content.decode("utf-8", errors="ignore").lower()
+    else:
+        body = str(content).lower()
+
+    return any(
+        marker in body
+        for marker in (
+            "insufficient authentication scopes",
+            "access_token_scope_insufficient",
+            "insufficientpermissions",
+        )
+    )
 
 
 def sync_gmail(

--- a/src/rebalance/ingest/gmail.py
+++ b/src/rebalance/ingest/gmail.py
@@ -1,0 +1,268 @@
+"""
+Gmail collector — fetches the newest N messages from the user's inbox via
+the Gmail API, persists metadata + snippets to SQLite, and feeds the
+unified semantic index alongside vault and GitHub.
+
+Phase 1 scope:
+- newest 100 messages, configurable via ``gmail_query_filter`` in
+  ``temp/rbos.config`` (default: ``in:inbox``)
+- metadata + Gmail-provided snippet only; no MIME body extraction
+- upsert keyed on Gmail's ``message_id``
+
+Auth: Application Default Credentials (ADC). Setup is documented in
+README. The runtime probe here fails loudly with the exact gcloud
+command if the credentials are missing or lack the Gmail scope.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from email.utils import parseaddr, parsedate_to_datetime
+from pathlib import Path
+from typing import Any
+
+
+GMAIL_READONLY_SCOPE = "https://www.googleapis.com/auth/gmail.readonly"
+DEFAULT_QUERY_FILTER = "in:inbox"
+DEFAULT_MAX_RESULTS = 100
+
+GCLOUD_LOGIN_HINT = (
+    "gcloud auth application-default login "
+    "--scopes=https://www.googleapis.com/auth/gmail.readonly,"
+    "https://www.googleapis.com/auth/cloud-platform"
+)
+
+
+# ---------------------------------------------------------------------------
+# Result type
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class GmailSyncResult:
+    messages_listed: int
+    messages_stored: int
+    messages_inserted: int
+    messages_updated: int
+    query_filter: str
+    elapsed_seconds: float
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+class GmailAuthError(RuntimeError):
+    """Raised when ADC credentials are missing or lack the Gmail scope."""
+
+
+def _load_adc_credentials() -> Any:
+    """Load Application Default Credentials with the Gmail readonly scope.
+
+    Fails loudly with the exact ``gcloud`` command needed to fix the most
+    common failure modes (no ADC at all, or ADC without Gmail scope).
+    """
+    try:
+        import google.auth
+        from google.auth.exceptions import DefaultCredentialsError
+    except ImportError as exc:
+        raise GmailAuthError(
+            "google-auth is required for Gmail ingest. Install with: "
+            "pip install 'rebalance-os[calendar]' (the calendar extra "
+            "already pulls in google-auth dependencies)."
+        ) from exc
+
+    try:
+        creds, _project = google.auth.default(scopes=[GMAIL_READONLY_SCOPE])
+    except DefaultCredentialsError as exc:
+        raise GmailAuthError(
+            "No Application Default Credentials found. Run:\n"
+            f"  {GCLOUD_LOGIN_HINT}"
+        ) from exc
+
+    return creds
+
+
+def _build_service() -> Any:
+    """Build a Gmail API v1 service client using ADC."""
+    from googleapiclient.discovery import build
+    creds = _load_adc_credentials()
+    return build("gmail", "v1", credentials=creds, cache_discovery=False)
+
+
+# ---------------------------------------------------------------------------
+# Header parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def _headers_to_dict(headers: list[dict[str, str]]) -> dict[str, str]:
+    """Lower-case header lookup. Last-write-wins for duplicates."""
+    return {h.get("name", "").lower(): h.get("value", "") for h in headers}
+
+
+def _parse_received_at(headers: dict[str, str], internal_date_ms: str | None) -> str:
+    """Return an ISO-8601 UTC timestamp.
+
+    Prefer the ``Date`` header; fall back to Gmail's ``internalDate``
+    (ms epoch) which is always present.
+    """
+    date_header = headers.get("date", "")
+    if date_header:
+        try:
+            dt = parsedate_to_datetime(date_header)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt.astimezone(timezone.utc).isoformat()
+        except (TypeError, ValueError):
+            pass
+
+    if internal_date_ms:
+        try:
+            ms = int(internal_date_ms)
+            return datetime.fromtimestamp(ms / 1000.0, tz=timezone.utc).isoformat()
+        except (TypeError, ValueError):
+            pass
+
+    return ""
+
+
+def _parse_from(headers: dict[str, str]) -> tuple[str, str]:
+    """Return ``(from_name, from_address)`` parsed from the ``From`` header."""
+    raw = headers.get("from", "")
+    if not raw:
+        return "", ""
+    name, address = parseaddr(raw)
+    return name.strip(), address.strip().lower()
+
+
+# ---------------------------------------------------------------------------
+# Fetch + persist
+# ---------------------------------------------------------------------------
+
+
+def _is_insufficient_scope_error(exc: Exception) -> bool:
+    """Detect Gmail's 403 insufficient-scope response."""
+    status = getattr(getattr(exc, "resp", None), "status", None)
+    try:
+        status_int = int(status) if status is not None else None
+    except (TypeError, ValueError):
+        status_int = None
+    return status_int == 403
+
+
+def sync_gmail(
+    database_path: Path,
+    *,
+    query_filter: str | None = None,
+    max_results: int = DEFAULT_MAX_RESULTS,
+    service: Any = None,
+) -> GmailSyncResult:
+    """Fetch newest-N inbox messages and upsert into ``email_messages``.
+
+    Args:
+        database_path: SQLite database path.
+        query_filter: Gmail search query (e.g. ``in:inbox``). Defaults to
+            ``gmail_query_filter`` in ``rbos.config`` then to ``in:inbox``.
+        max_results: Cap on messages fetched per run (default 100).
+        service: Pre-built Gmail service (test injection point). When
+            ``None``, builds via ADC.
+    """
+    from rebalance.ingest.config import get_gmail_query_filter
+    from rebalance.ingest.db import db_connection, ensure_email_schema
+
+    start = time.monotonic()
+
+    if query_filter is None:
+        query_filter = get_gmail_query_filter() or DEFAULT_QUERY_FILTER
+
+    if service is None:
+        service = _build_service()
+
+    try:
+        list_response = service.users().messages().list(
+            userId="me",
+            q=query_filter,
+            maxResults=max_results,
+        ).execute()
+    except Exception as exc:
+        if _is_insufficient_scope_error(exc):
+            raise GmailAuthError(
+                "ADC token is missing the Gmail readonly scope. Re-run:\n"
+                f"  {GCLOUD_LOGIN_HINT}\n"
+                "(Adding new scopes requires re-running the login command — "
+                "it does not merge with previous scopes silently.)"
+            ) from exc
+        raise
+    message_refs = list_response.get("messages", []) or []
+
+    synced_at = datetime.now(timezone.utc).isoformat()
+    metadata_headers = ["From", "To", "Subject", "Date"]
+
+    inserted = 0
+    updated = 0
+    stored = 0
+
+    with db_connection(database_path, ensure_email_schema) as conn:
+        for ref in message_refs:
+            msg_id = ref.get("id")
+            if not msg_id:
+                continue
+
+            msg = service.users().messages().get(
+                userId="me",
+                id=msg_id,
+                format="metadata",
+                metadataHeaders=metadata_headers,
+            ).execute()
+
+            payload = msg.get("payload", {}) or {}
+            headers = _headers_to_dict(payload.get("headers", []) or [])
+            from_name, from_address = _parse_from(headers)
+            received_at = _parse_received_at(headers, msg.get("internalDate"))
+            subject = headers.get("subject", "")
+            snippet = msg.get("snippet", "") or ""
+            thread_id = msg.get("threadId", "") or ""
+            labels = msg.get("labelIds", []) or []
+
+            existed = conn.execute(
+                "SELECT 1 FROM email_messages WHERE message_id = ?",
+                (msg_id,),
+            ).fetchone() is not None
+
+            conn.execute(
+                """INSERT OR REPLACE INTO email_messages
+                   (message_id, thread_id, from_address, from_name, subject,
+                    snippet, received_at, labels_json, synced_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    msg_id,
+                    thread_id,
+                    from_address,
+                    from_name,
+                    subject,
+                    snippet,
+                    received_at,
+                    json.dumps(labels),
+                    synced_at,
+                ),
+            )
+            if existed:
+                updated += 1
+            else:
+                inserted += 1
+            stored += 1
+
+        conn.commit()
+
+    return GmailSyncResult(
+        messages_listed=len(message_refs),
+        messages_stored=stored,
+        messages_inserted=inserted,
+        messages_updated=updated,
+        query_filter=query_filter,
+        elapsed_seconds=round(time.monotonic() - start, 2),
+    )

--- a/src/rebalance/ingest/index_ops.py
+++ b/src/rebalance/ingest/index_ops.py
@@ -22,7 +22,7 @@ from rebalance.ingest.db import db_connection, ensure_semantic_schema
 from rebalance.ingest.registry import get_projects
 
 
-SCOPE_VALUES = ("vault", "github", "calendar", "sleuth", "semantic", "all")
+SCOPE_VALUES = ("vault", "github", "calendar", "sleuth", "email", "semantic", "all")
 
 
 def _safe_count(conn: Any, table: str) -> int | None:
@@ -68,7 +68,7 @@ def _normalize_scope(scope: Iterable[str] | str | None) -> list[str]:
     if not cleaned:
         return ["all"]
     if "all" in cleaned:
-        return ["vault", "github", "calendar", "sleuth", "semantic"]
+        return ["vault", "github", "calendar", "sleuth", "email", "semantic"]
     return cleaned
 
 
@@ -117,6 +117,12 @@ def get_index_status(database_path: Path) -> dict[str, Any]:
         payload["sources"]["sleuth"] = {
             "reminders": _safe_count(conn, "sleuth_reminders"),
             "last_synced_at": _safe_max(conn, "sleuth_reminders", "last_synced_at"),
+        }
+
+        payload["sources"]["email"] = {
+            "messages": _safe_count(conn, "email_messages"),
+            "last_synced_at": _safe_max(conn, "email_messages", "synced_at"),
+            "newest_received_at": _safe_max(conn, "email_messages", "received_at"),
         }
 
         # Semantic index
@@ -589,6 +595,41 @@ def _refresh_sleuth(database_path: Path, *, dry_run: bool) -> dict[str, Any]:
     return {"scope": "sleuth", "dry_run": False, **result.as_dict()}
 
 
+def _refresh_email(database_path: Path, *, dry_run: bool) -> dict[str, Any]:
+    if dry_run:
+        return {
+            "scope": "email",
+            "dry_run": True,
+            "steps": ["sync_gmail()", "semantic_backfill(email)"],
+        }
+
+    from rebalance.ingest.gmail import GmailAuthError, sync_gmail
+    from rebalance.ingest.semantic_index import backfill_semantic_documents
+
+    try:
+        sync_result = sync_gmail(database_path=database_path)
+    except GmailAuthError as exc:
+        return {"scope": "email", "dry_run": False, "error": str(exc)}
+
+    semantic = backfill_semantic_documents(database_path, source_types=["email"])
+    return {
+        "scope": "email",
+        "dry_run": False,
+        "messages_listed": sync_result.messages_listed,
+        "messages_stored": sync_result.messages_stored,
+        "messages_inserted": sync_result.messages_inserted,
+        "messages_updated": sync_result.messages_updated,
+        "query_filter": sync_result.query_filter,
+        "elapsed_seconds": sync_result.elapsed_seconds,
+        "semantic_backfill": {
+            "total": semantic.total_documents,
+            "inserted": semantic.inserted_count,
+            "updated": semantic.updated_count,
+            "elapsed_seconds": semantic.elapsed_seconds,
+        },
+    }
+
+
 def _refresh_semantic_only(database_path: Path, *, dry_run: bool) -> dict[str, Any]:
     if dry_run:
         return {
@@ -600,8 +641,8 @@ def _refresh_semantic_only(database_path: Path, *, dry_run: bool) -> dict[str, A
         backfill_semantic_documents,
         embed_pending,
     )
-    backfill = backfill_semantic_documents(database_path, source_types=["vault", "github"])
-    sem_embed = embed_pending(database_path, source_types=["vault", "github"])
+    backfill = backfill_semantic_documents(database_path, source_types=["vault", "github", "email"])
+    sem_embed = embed_pending(database_path, source_types=["vault", "github", "email"])
     return {
         "scope": "semantic",
         "dry_run": False,
@@ -713,12 +754,19 @@ def refresh_index(
     """Run the configured ingest pipelines for ``scope`` and return a summary.
 
     ``scope`` accepts any combination of ``vault``, ``github``, ``calendar``,
-    ``sleuth``, ``semantic``, or ``all``. ``dry_run=True`` returns the planned
-    steps without touching the DB or network.
+    ``sleuth``, ``email``, ``semantic``, or ``all``. ``dry_run=True`` returns
+    the planned steps without touching the DB or network.
     """
     db_path = Path(database_path).expanduser().resolve()
     requested_scopes = _normalize_scope(scope)
-    full_refresh_requested = set(requested_scopes) == {"vault", "github", "calendar", "sleuth", "semantic"}
+    full_refresh_requested = set(requested_scopes) == {
+        "vault",
+        "github",
+        "calendar",
+        "sleuth",
+        "email",
+        "semantic",
+    }
     started = time.monotonic()
     results: list[dict[str, Any]] = []
     errors: list[dict[str, Any]] = []
@@ -771,6 +819,8 @@ def refresh_index(
                 results.append(_refresh_calendar(db_path, since_days=since_days, dry_run=dry_run))
             elif s == "sleuth":
                 results.append(_refresh_sleuth(db_path, dry_run=dry_run))
+            elif s == "email":
+                results.append(_refresh_email(db_path, dry_run=dry_run))
             elif s == "semantic":
                 results.append(_refresh_semantic_only(db_path, dry_run=dry_run))
         except Exception as e:

--- a/src/rebalance/ingest/semantic_index.py
+++ b/src/rebalance/ingest/semantic_index.py
@@ -64,15 +64,15 @@ def _json_dumps(value: Any) -> str:
 
 def _normalize_sources(source_types: Iterable[str] | None) -> tuple[str, ...]:
     if source_types is None:
-        return ("vault", "github")
+        return ("vault", "github", "email")
     normalized = []
     for value in source_types:
         item = value.strip().lower()
         if not item:
             continue
         if item == "all":
-            return ("vault", "github")
-        if item not in {"vault", "github", "calendar", "sleuth"}:
+            return ("vault", "github", "email")
+        if item not in {"vault", "github", "calendar", "sleuth", "email"}:
             raise ValueError(f"Unsupported source type: {value}")
         if item not in normalized:
             normalized.append(item)
@@ -376,6 +376,69 @@ def sync_github_documents(conn: Any, *, repo_full_name: str = "") -> dict[str, i
     }
 
 
+def sync_email_documents(conn: Any) -> dict[str, int]:
+    """Backfill semantic documents from ``email_messages``.
+
+    Body is ``subject + "\\n" + snippet`` per the Phase 1 plan — full MIME
+    body extraction is deferred to Phase 2. Newest-100 rolling fetches
+    don't delete older rows, so we don't reconcile against ``seen``: an
+    email row that drops out of the fetch window stays in the index.
+    """
+    ensure_semantic_schema(conn)
+    rows = conn.execute(
+        """
+        SELECT message_id, thread_id, from_address, from_name, subject,
+               snippet, received_at, labels_json, synced_at
+        FROM email_messages
+        ORDER BY received_at DESC
+        """
+    ).fetchall()
+
+    inserted = updated = unchanged = 0
+    for row in rows:
+        subject = row["subject"] or ""
+        snippet = row["snippet"] or ""
+        body = f"{subject}\n{snippet}".strip()
+        if not body:
+            continue
+
+        title = subject or (row["from_address"] or "(no subject)")
+        received_at = row["received_at"] or row["synced_at"]
+
+        _, state = upsert_document(
+            conn,
+            source_type="email",
+            source_table="email_messages",
+            source_pk=row["message_id"],
+            doc_kind="message",
+            title=title,
+            body=body,
+            metadata={
+                "thread_id": row["thread_id"] or "",
+                "from_address": row["from_address"] or "",
+                "from_name": row["from_name"] or "",
+                "labels": json.loads(row["labels_json"]) if row["labels_json"] else [],
+                "received_at": received_at,
+            },
+            created_at=received_at,
+            updated_at=row["synced_at"],
+        )
+        if state == "inserted":
+            inserted += 1
+        elif state == "updated":
+            updated += 1
+        else:
+            unchanged += 1
+
+    return {
+        "total": len(rows),
+        "inserted": inserted,
+        "updated": updated,
+        "unchanged": unchanged,
+        "deleted": 0,
+    }
+
+
 def backfill_semantic_documents(
     database_path: Path,
     *,
@@ -400,6 +463,15 @@ def backfill_semantic_documents(
         if "github" in selected_sources:
             ensure_github_schema(conn)
             result = sync_github_documents(conn, repo_full_name=repo_full_name)
+            inserted += result["inserted"]
+            updated += result["updated"]
+            unchanged += result["unchanged"]
+            deleted += result["deleted"]
+            total += result["total"]
+        if "email" in selected_sources:
+            from rebalance.ingest.db import ensure_email_schema
+            ensure_email_schema(conn)
+            result = sync_email_documents(conn)
             inserted += result["inserted"]
             updated += result["updated"]
             unchanged += result["unchanged"]
@@ -436,7 +508,7 @@ def embed_pending(
 
     with db_connection(database_path, ensure_semantic_schema) as conn:
         if force_reembed:
-            if set(selected_sources) == {"vault", "github"} and len(selected_sources) == 2:
+            if set(selected_sources) == {"vault", "github", "email"} and len(selected_sources) == 3:
                 conn.execute("DELETE FROM semantic_embeddings")
                 conn.execute(
                     """

--- a/src/rebalance/mcp_server.py
+++ b/src/rebalance/mcp_server.py
@@ -511,11 +511,14 @@ def create_server(database_path: Path) -> FastMCP:
 
         Args:
             scope: Any combination of "vault", "github", "calendar", "sleuth",
-                "semantic", or "all". Defaults to ["all"].
+                "email", "semantic", or "all". Defaults to ["all"].
                 - vault: ingest vault notes -> embed chunks -> semantic backfill+embed (vault)
                 - github: github-scan -> sync artifacts per repo -> embed -> semantic backfill+embed (github)
                 - calendar: sync Google Calendar events
                 - sleuth: pull Slack/Sleuth reminders
+                - email: sync newest-100 inbox messages from Gmail (ADC auth)
+                  and backfill them into the semantic index. Configure scope
+                  via ``gmail_query_filter`` in temp/rbos.config.
                 - semantic: re-run unified backfill+embed only (assumes upstream syncs done)
             vault_path: Optional override; falls back to configured vault path.
             since_days: Lookback window for github-scan and calendar-sync (default 30).
@@ -643,7 +646,8 @@ def create_server(database_path: Path) -> FastMCP:
     ) -> list[dict[str, Any]]:
         """
         Vector search across the unified semantic index (vault chunks +
-        GitHub issues/PRs/comments in one ranked result set).
+        GitHub issues/PRs/comments, and Gmail subject/snippet documents in
+        one ranked result set).
 
         Prefer this over query_notes / query_github_context when you want a
         single ranked result set across every source. The older tools still
@@ -651,7 +655,8 @@ def create_server(database_path: Path) -> FastMCP:
 
         Args:
             query: Natural language query.
-            sources: Filter to ["vault"], ["github"], or both. Defaults to both.
+            sources: Filter to any of ["vault"], ["github"], ["email"], or
+                any combination of them. Defaults to all indexed sources.
             top_k: Number of results.
         """
         from rebalance.ingest.semantic_index import query as _semantic_query

--- a/tests/test_email_ingest.py
+++ b/tests/test_email_ingest.py
@@ -234,6 +234,7 @@ class SyncGmailTests(unittest.TestCase):
 
         class _Http403Error(Exception):
             resp = _FakeResp()
+            content = b'{"error":{"message":"Request had insufficient authentication scopes.","status":"PERMISSION_DENIED"}}'
 
         class _FailingMessages:
             def list(self, **_kwargs):
@@ -257,6 +258,34 @@ class SyncGmailTests(unittest.TestCase):
         message = str(ctx.exception)
         self.assertIn("gcloud auth application-default login", message)
         self.assertIn("gmail.readonly", message)
+
+    def test_other_403s_are_not_rewritten_as_scope_errors(self) -> None:
+        class _FakeResp:
+            status = 403
+
+        class _Http403Error(Exception):
+            resp = _FakeResp()
+            content = b'{"error":{"message":"Gmail API has not been used in project yet","status":"PERMISSION_DENIED"}}'
+
+        class _FailingMessages:
+            def list(self, **_kwargs):
+                class _Req:
+                    def execute(self_inner):
+                        raise _Http403Error("api disabled")
+                return _Req()
+
+        class _FailingUsers:
+            def messages(self):
+                return _FailingMessages()
+
+        class _FailingService:
+            def users(self):
+                return _FailingUsers()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "rebalance.db"
+            with self.assertRaises(_Http403Error):
+                sync_gmail(db_path, query_filter="in:inbox", service=_FailingService())
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_email_ingest.py
+++ b/tests/test_email_ingest.py
@@ -1,0 +1,356 @@
+"""Tests for Phase 1 Gmail ingest: schema, sync, semantic backfill, and orchestration wiring."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from rebalance.ingest.db import db_connection, ensure_email_schema, ensure_semantic_schema
+from rebalance.ingest.gmail import (
+    DEFAULT_QUERY_FILTER,
+    GmailAuthError,
+    _parse_from,
+    _parse_received_at,
+    sync_gmail,
+)
+from rebalance.ingest.index_ops import SCOPE_VALUES, _normalize_scope, _refresh_email, get_index_status
+from rebalance.ingest.semantic_index import (
+    _normalize_sources,
+    backfill_semantic_documents,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake Gmail service — implements the chain users().messages().list/get used
+# by sync_gmail with no network calls.
+# ---------------------------------------------------------------------------
+
+
+class _FakeRequest:
+    def __init__(self, payload: Any) -> None:
+        self._payload = payload
+
+    def execute(self) -> Any:
+        return self._payload
+
+
+class _FakeMessages:
+    def __init__(self, list_payload: Any, message_map: dict[str, Any]) -> None:
+        self._list_payload = list_payload
+        self._message_map = message_map
+        self.list_calls: list[dict[str, Any]] = []
+        self.get_calls: list[dict[str, Any]] = []
+
+    def list(self, **kwargs: Any) -> _FakeRequest:
+        self.list_calls.append(kwargs)
+        return _FakeRequest(self._list_payload)
+
+    def get(self, **kwargs: Any) -> _FakeRequest:
+        self.get_calls.append(kwargs)
+        msg_id = kwargs.get("id")
+        return _FakeRequest(self._message_map[msg_id])
+
+
+class _FakeUsers:
+    def __init__(self, messages_obj: _FakeMessages) -> None:
+        self._messages_obj = messages_obj
+
+    def messages(self) -> _FakeMessages:
+        return self._messages_obj
+
+
+class _FakeService:
+    def __init__(self, list_payload: Any, message_map: dict[str, Any]) -> None:
+        self._messages_obj = _FakeMessages(list_payload, message_map)
+
+    def users(self) -> _FakeUsers:
+        return _FakeUsers(self._messages_obj)
+
+    @property
+    def messages_obj(self) -> _FakeMessages:
+        return self._messages_obj
+
+
+def _make_message(
+    msg_id: str,
+    *,
+    thread_id: str = "t1",
+    from_header: str = '"Alice Example" <alice@example.com>',
+    subject: str = "Hello",
+    snippet: str = "preview text",
+    date_header: str = "Mon, 04 May 2026 12:00:00 +0000",
+    internal_date_ms: str = "1746360000000",
+    labels: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": msg_id,
+        "threadId": thread_id,
+        "snippet": snippet,
+        "internalDate": internal_date_ms,
+        "labelIds": labels if labels is not None else ["INBOX", "UNREAD"],
+        "payload": {
+            "headers": [
+                {"name": "From", "value": from_header},
+                {"name": "Subject", "value": subject},
+                {"name": "Date", "value": date_header},
+                {"name": "To", "value": "noel@neochro.me"},
+            ]
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+class EmailSchemaTests(unittest.TestCase):
+    def test_ensure_email_schema_creates_table_with_required_columns(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "rebalance.db"
+            with db_connection(db_path, ensure_email_schema) as conn:
+                cols = {row[1] for row in conn.execute("PRAGMA table_info(email_messages)").fetchall()}
+        expected = {
+            "message_id", "thread_id", "from_address", "from_name",
+            "subject", "snippet", "received_at", "labels_json", "synced_at",
+        }
+        self.assertTrue(expected.issubset(cols), f"Missing columns: {expected - cols}")
+
+
+# ---------------------------------------------------------------------------
+# Header parsing
+# ---------------------------------------------------------------------------
+
+
+class HeaderParsingTests(unittest.TestCase):
+    def test_parse_from_extracts_name_and_address(self) -> None:
+        name, addr = _parse_from({"from": '"Alice Example" <alice@example.com>'})
+        self.assertEqual(name, "Alice Example")
+        self.assertEqual(addr, "alice@example.com")
+
+    def test_parse_from_lowercases_address(self) -> None:
+        _, addr = _parse_from({"from": "Bob <BOB@EXAMPLE.COM>"})
+        self.assertEqual(addr, "bob@example.com")
+
+    def test_parse_from_empty(self) -> None:
+        self.assertEqual(_parse_from({}), ("", ""))
+
+    def test_parse_received_at_prefers_date_header(self) -> None:
+        result = _parse_received_at(
+            {"date": "Mon, 04 May 2026 12:00:00 +0000"},
+            internal_date_ms="999",
+        )
+        self.assertTrue(result.startswith("2026-05-04T12:00:00"))
+
+    def test_parse_received_at_falls_back_to_internal_date(self) -> None:
+        result = _parse_received_at({}, internal_date_ms="1778241600000")
+        # ISO-8601 UTC; exact value verified by round-trip
+        self.assertEqual(result, "2026-05-08T12:00:00+00:00")
+
+    def test_parse_received_at_returns_empty_when_both_missing(self) -> None:
+        self.assertEqual(_parse_received_at({}, internal_date_ms=None), "")
+
+
+# ---------------------------------------------------------------------------
+# sync_gmail upsert behavior
+# ---------------------------------------------------------------------------
+
+
+class SyncGmailTests(unittest.TestCase):
+    def test_first_sync_inserts_all_messages(self) -> None:
+        service = _FakeService(
+            list_payload={"messages": [{"id": "m1"}, {"id": "m2"}]},
+            message_map={
+                "m1": _make_message("m1", subject="First"),
+                "m2": _make_message("m2", subject="Second"),
+            },
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "rebalance.db"
+            result = sync_gmail(db_path, query_filter="in:inbox", service=service)
+
+            self.assertEqual(result.messages_listed, 2)
+            self.assertEqual(result.messages_inserted, 2)
+            self.assertEqual(result.messages_updated, 0)
+
+            with db_connection(db_path) as conn:
+                rows = conn.execute(
+                    "SELECT message_id, subject, from_address FROM email_messages ORDER BY message_id"
+                ).fetchall()
+            self.assertEqual(len(rows), 2)
+            self.assertEqual(rows[0]["from_address"], "alice@example.com")
+
+    def test_repeat_sync_with_label_change_upserts_existing(self) -> None:
+        first = _FakeService(
+            list_payload={"messages": [{"id": "m1"}]},
+            message_map={"m1": _make_message("m1", labels=["INBOX", "UNREAD"])},
+        )
+        second = _FakeService(
+            list_payload={"messages": [{"id": "m1"}]},
+            message_map={"m1": _make_message("m1", labels=["INBOX"])},
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "rebalance.db"
+            r1 = sync_gmail(db_path, query_filter="in:inbox", service=first)
+            r2 = sync_gmail(db_path, query_filter="in:inbox", service=second)
+
+            self.assertEqual(r1.messages_inserted, 1)
+            self.assertEqual(r2.messages_inserted, 0)
+            self.assertEqual(r2.messages_updated, 1)
+
+            with db_connection(db_path) as conn:
+                row = conn.execute(
+                    "SELECT labels_json FROM email_messages WHERE message_id = 'm1'"
+                ).fetchone()
+            self.assertEqual(json.loads(row["labels_json"]), ["INBOX"])
+
+    def test_query_filter_is_passed_through_to_list(self) -> None:
+        service = _FakeService(list_payload={"messages": []}, message_map={})
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "rebalance.db"
+            sync_gmail(db_path, query_filter="in:inbox -category:promotions", service=service)
+        self.assertEqual(
+            service.messages_obj.list_calls[0]["q"],
+            "in:inbox -category:promotions",
+        )
+
+    def test_default_filter_used_when_caller_passes_none_and_no_config(self) -> None:
+        service = _FakeService(list_payload={"messages": []}, message_map={})
+        with tempfile.TemporaryDirectory() as tmpdir, \
+             patch("rebalance.ingest.config.get_gmail_query_filter", return_value=None):
+            db_path = Path(tmpdir) / "rebalance.db"
+            result = sync_gmail(db_path, service=service)
+        self.assertEqual(result.query_filter, DEFAULT_QUERY_FILTER)
+
+    def test_403_insufficient_scope_raises_gmail_auth_error(self) -> None:
+        class _FakeResp:
+            status = 403
+
+        class _Http403Error(Exception):
+            resp = _FakeResp()
+
+        class _FailingMessages:
+            def list(self, **_kwargs):
+                class _Req:
+                    def execute(self_inner):
+                        raise _Http403Error("insufficient scopes")
+                return _Req()
+
+        class _FailingUsers:
+            def messages(self):
+                return _FailingMessages()
+
+        class _FailingService:
+            def users(self):
+                return _FailingUsers()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "rebalance.db"
+            with self.assertRaises(GmailAuthError) as ctx:
+                sync_gmail(db_path, query_filter="in:inbox", service=_FailingService())
+        message = str(ctx.exception)
+        self.assertIn("gcloud auth application-default login", message)
+        self.assertIn("gmail.readonly", message)
+
+
+# ---------------------------------------------------------------------------
+# Semantic backfill — email rows become semantic_documents
+# ---------------------------------------------------------------------------
+
+
+class EmailSemanticBackfillTests(unittest.TestCase):
+    def test_backfill_creates_email_semantic_documents(self) -> None:
+        service = _FakeService(
+            list_payload={"messages": [{"id": "m1"}]},
+            message_map={
+                "m1": _make_message("m1", subject="Q2 plan", snippet="Need to align on..."),
+            },
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "rebalance.db"
+            sync_gmail(db_path, query_filter="in:inbox", service=service)
+
+            result = backfill_semantic_documents(db_path, source_types=["email"])
+            self.assertEqual(result.total_documents, 1)
+            self.assertEqual(result.inserted_count, 1)
+
+            with db_connection(db_path) as conn:
+                ensure_semantic_schema(conn)
+                doc = conn.execute(
+                    "SELECT title, body, source_type FROM semantic_documents WHERE source_pk = 'm1'"
+                ).fetchone()
+        self.assertEqual(doc["source_type"], "email")
+        self.assertEqual(doc["title"], "Q2 plan")
+        self.assertIn("Q2 plan", doc["body"])
+        self.assertIn("Need to align on", doc["body"])
+
+
+# ---------------------------------------------------------------------------
+# Source allowlist and scope wiring
+# ---------------------------------------------------------------------------
+
+
+class EmailScopeWiringTests(unittest.TestCase):
+    def test_normalize_sources_includes_email_in_default(self) -> None:
+        self.assertIn("email", _normalize_sources(None))
+
+    def test_normalize_sources_accepts_explicit_email(self) -> None:
+        self.assertEqual(_normalize_sources(["email"]), ("email",))
+
+    def test_normalize_sources_all_includes_email(self) -> None:
+        self.assertIn("email", _normalize_sources(["all"]))
+
+    def test_scope_values_includes_email(self) -> None:
+        self.assertIn("email", SCOPE_VALUES)
+
+    def test_normalize_scope_all_expands_to_include_email(self) -> None:
+        self.assertIn("email", _normalize_scope(["all"]))
+
+    def test_normalize_scope_accepts_email(self) -> None:
+        self.assertEqual(_normalize_scope(["email"]), ["email"])
+
+
+# ---------------------------------------------------------------------------
+# index_status surfaces email source block
+# ---------------------------------------------------------------------------
+
+
+class EmailIndexStatusTests(unittest.TestCase):
+    def test_index_status_reports_email_source(self) -> None:
+        service = _FakeService(
+            list_payload={"messages": [{"id": "m1"}]},
+            message_map={"m1": _make_message("m1")},
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "rebalance.db"
+            sync_gmail(db_path, query_filter="in:inbox", service=service)
+
+            status = get_index_status(db_path)
+        self.assertIn("email", status["sources"])
+        self.assertEqual(status["sources"]["email"]["messages"], 1)
+        self.assertIsNotNone(status["sources"]["email"]["last_synced_at"])
+
+
+# ---------------------------------------------------------------------------
+# _refresh_email dry-run
+# ---------------------------------------------------------------------------
+
+
+class RefreshEmailDryRunTests(unittest.TestCase):
+    def test_dry_run_lists_steps_without_touching_network(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = _refresh_email(Path(tmpdir) / "rebalance.db", dry_run=True)
+        self.assertEqual(result["scope"], "email")
+        self.assertTrue(result["dry_run"])
+        self.assertIn("sync_gmail()", result["steps"])
+        self.assertIn("semantic_backfill(email)", result["steps"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add Phase 1 Gmail inbox ingest using Google Application Default Credentials
- persist email metadata plus Gmail-provided snippets to SQLite and backfill them into the unified semantic index
- expose email through refresh_index, index_status, and default semantic_query behavior
- document device setup in the README and record the release in the changelog
- tighten Gmail 403 handling so only true insufficient-scope responses are rewritten into the gcloud remediation message

## Testing
- env PYTHONPATH=src /Users/noelsaw/Documents/rebalance-OS/.venv/bin/python -m unittest tests.test_email_ingest tests.test_semantic_index tests.test_index_ops

## Notes
- supersedes #22, which was based on an older divergent branch and mixed unrelated changes
- branch now includes 0.27.0 for the feature and 0.27.1 for the follow-up polish fix