### PR TITLE
refactor(ingest): shared logging, HTTP client, collector registry + fresh-install fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.31.0] - 2026-05-19
+
+### Added
+
+- `Collector` dataclass and `COLLECTORS` source registry in `src/rebalance/ingest/index_ops.py`. `refresh_index` now routes `scope=[...]` through the registry instead of a hard-coded dispatch chain. External integrators can call `register_collector()` to add new data sources without editing the dispatcher. `included_in_all=False` marks opt-in collectors that are skipped by `scope=["all"]`.
+- Shared GitHub HTTP client (`src/rebalance/ingest/_http.py`) extracted from the duplicated `urlopen` + retry + pagination logic in `github_scan.py` and `github_knowledge.py`. Single entry point with 30 s timeout, exponential backoff on 429/5xx, and `per_page=100` automatic pagination.
+- `[project.optional-dependencies] server` group in `pyproject.toml` — `pip install -e '.[server]'` installs `fastapi>=0.110.0` and `uvicorn[standard]>=0.29.0` so the pulse-server venv is reproducible from a fresh clone without manual installs.
+
+### Changed
+
+- Logging bootstrap consolidated: `ingest/` modules now use `logging.getLogger(__name__)` via a shared setup path; the 24 duplicate `Path("rebalance.db"), envvar="REBALANCE_DB"` option declarations across the CLI were deduplicated through the shared `DBOption`.
+
+### Fixed
+
+- `scripts/dashboard.py` data-fetch functions (`fetch_recent_github`, `fetch_repo_activity_counts`, `fetch_vault_recent`, `fetch_recent_emails`, `fetch_watched_summary`) now return empty lists instead of raising when the DB is absent or has no tables yet. Prevents `pulse_web.py` and the terminal dashboard from crashing on a fresh checkout before the first sync.
+
 ## [0.30.0] - 2026-05-14
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,10 @@ calendar = [
 embeddings = [
   "mlx-embeddings>=0.1.0",
 ]
+server = [
+  "fastapi>=0.110.0",
+  "uvicorn[standard]>=0.29.0",
+]
 
 [project.scripts]
 rebalance = "rebalance.cli:app"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rebalance-os"
-version = "0.30.0"
+version = "0.31.0"
 description = "Local-first workday operating system with MCP tools and Obsidian ingest"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/dashboard.py
+++ b/scripts/dashboard.py
@@ -309,23 +309,26 @@ def fetch_watched_summary(now: datetime) -> dict[str, Any]:
     fresh = stale = never = 0
     last_synced_overall: datetime | None = None
     if watched:
-        with db_connection(DB_PATH) as conn:
-            placeholders = ",".join("?" * len(watched))
-            rows = conn.execute(
-                f"""
-                SELECT repo_full_name, MAX(fetched_at) AS last_synced
-                FROM (
-                    SELECT repo_full_name, fetched_at FROM github_items
-                    UNION ALL
-                    SELECT repo_full_name, fetched_at FROM github_commits
-                    UNION ALL
-                    SELECT repo_full_name, fetched_at FROM github_repo_meta
-                )
-                WHERE LOWER(repo_full_name) IN ({placeholders})
-                GROUP BY LOWER(repo_full_name)
-                """,
-                tuple(r.lower() for r in watched),
-            ).fetchall()
+        try:
+            with db_connection(DB_PATH) as conn:
+                placeholders = ",".join("?" * len(watched))
+                rows = conn.execute(
+                    f"""
+                    SELECT repo_full_name, MAX(fetched_at) AS last_synced
+                    FROM (
+                        SELECT repo_full_name, fetched_at FROM github_items
+                        UNION ALL
+                        SELECT repo_full_name, fetched_at FROM github_commits
+                        UNION ALL
+                        SELECT repo_full_name, fetched_at FROM github_repo_meta
+                    )
+                    WHERE LOWER(repo_full_name) IN ({placeholders})
+                    GROUP BY LOWER(repo_full_name)
+                    """,
+                    tuple(r.lower() for r in watched),
+                ).fetchall()
+        except Exception:  # noqa: BLE001 — empty DB before first sync
+            rows = []
         seen = {r["repo_full_name"].lower(): r["last_synced"] for r in rows}
         for repo in watched:
             ts = seen.get(repo.lower())
@@ -362,33 +365,36 @@ def fetch_recent_github(limit: int = 9) -> list[dict[str, Any]]:
         ignored_clause = f"WHERE LOWER(repo_full_name) NOT IN ({placeholders})"
         params.extend(ignored)
 
-    with db_connection(DB_PATH) as conn:
-        rows = conn.execute(
-            f"""
-            SELECT kind, sub, repo_full_name, num, detail, ts, who, html_url FROM (
-                SELECT 'item' AS kind, item_type AS sub, repo_full_name,
-                       number AS num, title AS detail, updated_at AS ts,
-                       author_login AS who, html_url
-                FROM github_items
-                WHERE updated_at IS NOT NULL
-                UNION ALL
-                SELECT 'commit', '', repo_full_name, item_number, message,
-                       committed_at, author_login, html_url
-                FROM github_commits
-                WHERE committed_at IS NOT NULL
-                UNION ALL
-                SELECT 'comment', comment_type, repo_full_name, item_number,
-                       body, created_at, author_login, html_url
-                FROM github_comments
-                WHERE created_at IS NOT NULL
-            )
-            {ignored_clause}
-            ORDER BY ts DESC
-            LIMIT ?
-            """,
-            (*params, limit),
-        ).fetchall()
-    return [dict(r) for r in rows]
+    try:
+        with db_connection(DB_PATH) as conn:
+            rows = conn.execute(
+                f"""
+                SELECT kind, sub, repo_full_name, num, detail, ts, who, html_url FROM (
+                    SELECT 'item' AS kind, item_type AS sub, repo_full_name,
+                           number AS num, title AS detail, updated_at AS ts,
+                           author_login AS who, html_url
+                    FROM github_items
+                    WHERE updated_at IS NOT NULL
+                    UNION ALL
+                    SELECT 'commit', '', repo_full_name, item_number, message,
+                           committed_at, author_login, html_url
+                    FROM github_commits
+                    WHERE committed_at IS NOT NULL
+                    UNION ALL
+                    SELECT 'comment', comment_type, repo_full_name, item_number,
+                           body, created_at, author_login, html_url
+                    FROM github_comments
+                    WHERE created_at IS NOT NULL
+                )
+                {ignored_clause}
+                ORDER BY ts DESC
+                LIMIT ?
+                """,
+                (*params, limit),
+            ).fetchall()
+        return [dict(r) for r in rows]
+    except Exception:  # noqa: BLE001 — empty DB before first sync
+        return []
 
 
 def fetch_repo_activity_counts(days: int = 7, limit: int = 12) -> list[dict[str, Any]]:
@@ -401,45 +407,51 @@ def fetch_repo_activity_counts(days: int = 7, limit: int = 12) -> list[dict[str,
         ignored_clause = f"WHERE LOWER(repo_full_name) NOT IN ({placeholders})"
         params.extend(ignored)
     params.append(limit)
-    with db_connection(DB_PATH) as conn:
-        rows = conn.execute(
-            f"""
-            SELECT repo_full_name, COUNT(*) AS events FROM (
-                SELECT repo_full_name FROM github_items
-                  WHERE updated_at IS NOT NULL
-                    AND updated_at >= datetime('now', ?)
-                UNION ALL
-                SELECT repo_full_name FROM github_commits
-                  WHERE committed_at IS NOT NULL
-                    AND committed_at >= datetime('now', ?)
-                UNION ALL
-                SELECT repo_full_name FROM github_comments
-                  WHERE created_at IS NOT NULL
-                    AND created_at >= datetime('now', ?)
-            )
-            {ignored_clause}
-            GROUP BY repo_full_name
-            ORDER BY events DESC
-            LIMIT ?
-            """,
-            tuple(params),
-        ).fetchall()
-    return [dict(r) for r in rows]
+    try:
+        with db_connection(DB_PATH) as conn:
+            rows = conn.execute(
+                f"""
+                SELECT repo_full_name, COUNT(*) AS events FROM (
+                    SELECT repo_full_name FROM github_items
+                      WHERE updated_at IS NOT NULL
+                        AND updated_at >= datetime('now', ?)
+                    UNION ALL
+                    SELECT repo_full_name FROM github_commits
+                      WHERE committed_at IS NOT NULL
+                        AND committed_at >= datetime('now', ?)
+                    UNION ALL
+                    SELECT repo_full_name FROM github_comments
+                      WHERE created_at IS NOT NULL
+                        AND created_at >= datetime('now', ?)
+                )
+                {ignored_clause}
+                GROUP BY repo_full_name
+                ORDER BY events DESC
+                LIMIT ?
+                """,
+                tuple(params),
+            ).fetchall()
+        return [dict(r) for r in rows]
+    except Exception:  # noqa: BLE001 — empty DB before first sync
+        return []
 
 
 def fetch_vault_recent(limit: int = 6) -> list[dict[str, Any]]:
-    with db_connection(DB_PATH) as conn:
-        rows = conn.execute(
-            """
-            SELECT title, rel_path, last_modified
-            FROM vault_files
-            WHERE last_modified IS NOT NULL
-            ORDER BY last_modified DESC
-            LIMIT ?
-            """,
-            (limit,),
-        ).fetchall()
-    return [dict(r) for r in rows]
+    try:
+        with db_connection(DB_PATH) as conn:
+            rows = conn.execute(
+                """
+                SELECT title, rel_path, last_modified
+                FROM vault_files
+                WHERE last_modified IS NOT NULL
+                ORDER BY last_modified DESC
+                LIMIT ?
+                """,
+                (limit,),
+            ).fetchall()
+        return [dict(r) for r in rows]
+    except Exception:  # noqa: BLE001 — empty DB before first sync
+        return []
 
 
 def fetch_calendar_upcoming(now: datetime, limit: int = 4) -> list[dict[str, Any]]:
@@ -538,18 +550,21 @@ def fetch_sleuth_due(limit: int = 4) -> list[dict[str, Any]]:
 
 
 def fetch_recent_emails(limit: int = 30) -> list[dict[str, Any]]:
-    with db_connection(DB_PATH) as conn:
-        rows = conn.execute(
-            """
-            SELECT message_id, thread_id, from_name, from_address, subject, snippet, received_at, labels_json
-            FROM email_messages
-            WHERE received_at IS NOT NULL
-            ORDER BY received_at DESC
-            LIMIT ?
-            """,
-            (limit,),
-        ).fetchall()
-    return [dict(r) for r in rows]
+    try:
+        with db_connection(DB_PATH) as conn:
+            rows = conn.execute(
+                """
+                SELECT message_id, thread_id, from_name, from_address, subject, snippet, received_at, labels_json
+                FROM email_messages
+                WHERE received_at IS NOT NULL
+                ORDER BY received_at DESC
+                LIMIT ?
+                """,
+                (limit,),
+            ).fetchall()
+        return [dict(r) for r in rows]
+    except Exception:  # noqa: BLE001 — empty DB before first sync
+        return []
 
 
 # ---------------------------------------------------------------------------

--- a/src/rebalance/__init__.py
+++ b/src/rebalance/__init__.py
@@ -1,4 +1,40 @@
-"""rebalance package."""
+"""rebalance package.
+
+Installs a process-wide logging handler on import so any module that does
+``logger = logging.getLogger(__name__)`` gets routed output without each
+entry point reconfiguring logging. Verbosity is controlled by the
+``REBALANCE_LOG_LEVEL`` environment variable (DEBUG / INFO / WARNING /
+ERROR / CRITICAL); default is WARNING so production CLI output stays
+clean. User-facing CLI output continues to go through ``typer.echo``;
+``logging`` is for diagnostics only.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
 
 __all__ = ["__version__"]
 __version__ = "0.30.0"
+
+
+def _configure_logging() -> None:
+    root = logging.getLogger("rebalance")
+    if getattr(root, "_rebalance_configured", False):
+        return
+    level_name = os.environ.get("REBALANCE_LOG_LEVEL", "WARNING").upper()
+    level = getattr(logging, level_name, logging.WARNING)
+    handler = logging.StreamHandler()
+    handler.setFormatter(
+        logging.Formatter(
+            "%(asctime)s %(levelname)s %(name)s: %(message)s",
+            datefmt="%H:%M:%S",
+        )
+    )
+    root.addHandler(handler)
+    root.setLevel(level)
+    root.propagate = False
+    root._rebalance_configured = True  # type: ignore[attr-defined]
+
+
+_configure_logging()

--- a/src/rebalance/cli.py
+++ b/src/rebalance/cli.py
@@ -32,6 +32,7 @@ from rebalance.ingest.config import (
 from rebalance.ingest.audit import append_audit_entry
 from rebalance.paths import (
     DatabaseNotFoundError,
+    DBOption,
     resolve_database_path,
     resolve_secret_path,
 )
@@ -672,7 +673,7 @@ def ingest_sync(
 
 @ingest_app.command("infer-project-registry")
 def ingest_infer_project_registry(
-    database: Path | None = typer.Option(None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"),
+    database: Path | None = DBOption(),
     calendar_days_back: int = typer.Option(90, help="How many calendar days back to use for inference"),
     calendar_days_forward: int = typer.Option(14, help="How many calendar days forward to include for meeting signals"),
     dry_run: bool = typer.Option(False, help="Preview inferred project rows without writing to project_registry"),
@@ -726,9 +727,7 @@ def ingest_infer_project_registry(
 def github_scan(
     token: str = typer.Option(..., envvar="GITHUB_TOKEN", help="GitHub Personal Access Token"),
     days: int = typer.Option(30, help="Number of days to look back (supports 30-day A/B/C band classification)"),
-    database: Path | None = typer.Option(
-        None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"
-    ),
+    database: Path | None = DBOption(),
 ) -> None:
     """Fetch GitHub activity and persist to database for use by github_balance MCP tool."""
     from rebalance.ingest.github_scan import (
@@ -1156,9 +1155,7 @@ def raw(
         10, "--top",
         help="How many of the most-active watched repos to scan for team activity (cost: 1 GH API request per repo per probe).",
     ),
-    database: Path | None = typer.Option(
-        None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"
-    ),
+    database: Path | None = DBOption(),
 ) -> None:
     """Calibration view: GitHub events from the last N minutes vs local pipeline state.
 
@@ -1229,9 +1226,7 @@ def github_sync_artifacts(
     ),
     token: str = typer.Option("", envvar="GITHUB_TOKEN", help="GitHub Personal Access Token"),
     days: int = typer.Option(90, help="Lookback window for changed issues and PRs"),
-    database: Path | None = typer.Option(
-        None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"
-    ),
+    database: Path | None = DBOption(),
 ) -> None:
     """Sync detailed GitHub issues, PRs, comments, reviews, checks, and releases."""
     from rebalance.ingest.github_knowledge import sync_github_repo
@@ -1279,9 +1274,7 @@ def github_sync_artifacts(
 
 @app.command("github-embed")
 def github_embed(
-    database: Path | None = typer.Option(
-        None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"
-    ),
+    database: Path | None = DBOption(),
     model: str = typer.Option("Qwen/Qwen3-Embedding-0.6B", help="HuggingFace model name"),
     batch_size: int = typer.Option(32, help="Batch size for embedding"),
     min_chars: int = typer.Option(40, help="Minimum document length to embed"),
@@ -1314,7 +1307,7 @@ def github_embed(
 @ingest_app.command("notes")
 def ingest_notes(
     vault: Path = typer.Option(..., exists=True, file_okay=False, dir_okay=True, help="Path to Obsidian vault"),
-    database: Path | None = typer.Option(None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"),
+    database: Path | None = DBOption(),
     exclude: list[str] = typer.Option(
         [".obsidian/*", ".trash/*", "node_modules/*", ".git/*", ".venv/*", "*/.venv/*"],
         help="Glob patterns to exclude",
@@ -1347,7 +1340,7 @@ def ingest_notes(
 
 @ingest_app.command("embed")
 def ingest_embed(
-    database: Path | None = typer.Option(None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"),
+    database: Path | None = DBOption(),
     model: str = typer.Option("Qwen/Qwen3-Embedding-0.6B", help="HuggingFace model name"),
     batch_size: int = typer.Option(32, help="Batch size for embedding (lower = less memory)"),
     force: bool = typer.Option(False, help="Force re-embed all chunks (use after model change)"),
@@ -1378,7 +1371,7 @@ def ingest_embed(
 @app.command("query")
 def query_cmd(
     text: str = typer.Argument(..., help="Natural language query"),
-    database: Path | None = typer.Option(None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"),
+    database: Path | None = DBOption(),
     top_k: int = typer.Option(10, help="Number of results to return"),
     model: str = typer.Option("Qwen/Qwen3-Embedding-0.6B", help="Embedding model for query"),
 ) -> None:
@@ -1405,9 +1398,7 @@ def query_cmd(
 @app.command("github-query")
 def github_query_cmd(
     text: str = typer.Argument(..., help="Natural language query"),
-    database: Path | None = typer.Option(
-        None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"
-    ),
+    database: Path | None = DBOption(),
     repo: str = typer.Option("", help="Optional owner/name repo filter"),
     top_k: int = typer.Option(8, help="Number of results to return"),
     model: str = typer.Option("Qwen/Qwen3-Embedding-0.6B", help="Embedding model for query"),
@@ -1460,9 +1451,7 @@ def semantic_backfill_cmd(
         "--repo",
         help="Optional owner/name filter when backfilling GitHub semantic documents.",
     ),
-    database: Path | None = typer.Option(
-        None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"
-    ),
+    database: Path | None = DBOption(),
 ) -> None:
     """Populate the unified semantic document layer from existing source tables."""
     from rebalance.ingest.semantic_index import backfill_semantic_documents
@@ -1494,9 +1483,7 @@ def semantic_embed_cmd(
         "--source",
         help="Source family to embed. Repeat for multiple values.",
     ),
-    database: Path | None = typer.Option(
-        None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"
-    ),
+    database: Path | None = DBOption(),
     model: str = typer.Option("Qwen/Qwen3-Embedding-0.6B", help="HuggingFace model name"),
     batch_size: int = typer.Option(32, help="Batch size for embedding"),
     min_chars: int = typer.Option(1, help="Minimum document length to embed"),
@@ -1539,9 +1526,7 @@ def semantic_query_cmd(
         "--source",
         help="Source family to search. Repeat for multiple values.",
     ),
-    database: Path | None = typer.Option(
-        None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"
-    ),
+    database: Path | None = DBOption(),
     top_k: int = typer.Option(10, help="Number of results to return"),
     model: str = typer.Option("Qwen/Qwen3-Embedding-0.6B", help="Embedding model for query"),
 ) -> None:
@@ -1588,9 +1573,7 @@ def semantic_query_cmd(
 def github_release_readiness_cmd(
     repo: str = typer.Option(..., "--repo", help="Repo in owner/name form"),
     milestone: str = typer.Option("", "--milestone", help="Optional milestone title"),
-    database: Path | None = typer.Option(
-        None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"
-    ),
+    database: Path | None = DBOption(),
     output_format: str = typer.Option("text", "--output", help="Output format: text or json"),
 ) -> None:
     """Infer current release/readiness state from the local GitHub corpus."""
@@ -1643,9 +1626,7 @@ def github_release_readiness_cmd(
 @app.command("github-close-candidates")
 def github_close_candidates_cmd(
     repo: str = typer.Option(..., "--repo", help="Repo in owner/name form"),
-    database: Path | None = typer.Option(
-        None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"
-    ),
+    database: Path | None = DBOption(),
     output_format: str = typer.Option("text", "--output", help="Output format: text or json"),
 ) -> None:
     """Suggest open issues that likely map to merged PRs and may be ready to close."""
@@ -1704,7 +1685,7 @@ def github_close_candidates_cmd(
 @app.command("search")
 def search_cmd(
     keyword: str = typer.Argument(..., help="Keyword to search"),
-    database: Path | None = typer.Option(None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"),
+    database: Path | None = DBOption(),
     limit: int = typer.Option(20, help="Max results"),
 ) -> None:
     """Full-text keyword search over vault files and chunks."""
@@ -1729,7 +1710,7 @@ def search_cmd(
 @app.command("ask")
 def ask_cmd(
     text: str = typer.Argument(..., help="Natural language question"),
-    database: Path | None = typer.Option(None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"),
+    database: Path | None = DBOption(),
     days: int = typer.Option(7, help="Activity window in days"),
     no_llm: bool = typer.Option(False, help="Skip local LLM synthesis, return raw context only"),
     chat_model: str = typer.Option("Qwen/Qwen3-0.6B", help="Chat model for synthesis"),
@@ -1797,7 +1778,7 @@ def ask_cmd(
 
 @app.command("calendar-sync")
 def calendar_sync_cmd(
-    database: Path | None = typer.Option(None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"),
+    database: Path | None = DBOption(),
     calendar_id: str = typer.Option("", help="Calendar ID or email (default: from config, then 'primary')"),
     days_back: int = typer.Option(30, help="Days back to fetch (use 365 for initial backfill)"),
     days_forward: int = typer.Option(7, help="Days forward to fetch"),
@@ -1937,7 +1918,7 @@ def calendar_create_event_cmd(
 
 @app.command("calendar-daily-totals")
 def calendar_daily_totals_cmd(
-    database: Path | None = typer.Option(None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"),
+    database: Path | None = DBOption(),
     days_back: int = typer.Option(30, help="Days back to show"),
     days_forward: int = typer.Option(0, help="Days forward to show"),
 ) -> None:
@@ -2084,7 +2065,7 @@ def calendar_snap_edges_cmd(
 
 @app.command("calendar-daily-report")
 def calendar_daily_report_cmd(
-    database: Path | None = typer.Option(None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"),
+    database: Path | None = DBOption(),
     date_str: str = typer.Option(None, "--date", help="Date to report on (YYYY-MM-DD, default: today)"),
     output: Path = typer.Option(None, "--output", "-o", help="Write report to a markdown file instead of stdout"),
 ) -> None:
@@ -2118,7 +2099,7 @@ def calendar_daily_report_cmd(
 
 @app.command("calendar-weekly-report")
 def calendar_weekly_report_cmd(
-    database: Path | None = typer.Option(None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"),
+    database: Path | None = DBOption(),
     date_str: str = typer.Option(None, "--date", help="Date in target week (YYYY-MM-DD, default: today)"),
     output: Path = typer.Option(None, "--output", "-o", help="Write report to a markdown file instead of stdout"),
     vault: Path = typer.Option(None, "--vault", envvar="REBALANCE_VAULT", help="Obsidian vault path for weekly note write-back"),
@@ -2187,7 +2168,7 @@ def calendar_weekly_report_cmd(
 
 @app.command("dashboard-render")
 def dashboard_render_cmd(
-    database: Path | None = typer.Option(None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"),
+    database: Path | None = DBOption(),
     date_str: str = typer.Option(None, "--date", help="Date anchoring the dashboard window (YYYY-MM-DD, default: today)"),
     since_days: int = typer.Option(14, "--since-days", min=1, help="Lookback window for recent signals"),
     vault: Path = typer.Option(None, "--vault", envvar="REBALANCE_VAULT", help="Obsidian vault path for dashboard note write-back"),
@@ -2280,12 +2261,7 @@ def sleuth_sync_cmd(
         "--active-only/--all",
         help="Only fetch currently active reminders (default: all)",
     ),
-    database: Path | None = typer.Option(
-        None,
-        "--database-path",
-        envvar="REBALANCE_DB",
-        help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)",
-    ),
+    database: Path | None = DBOption("--database-path"),
     json_output: bool = typer.Option(False, "--json", help="Emit full sync result as JSON"),
 ) -> None:
     """Pull Slack reminders from the Sleuth Web API and upsert them into SQLite."""
@@ -2331,9 +2307,7 @@ def config_add_github_ignored_repo(
     purge: bool = typer.Option(False, help="Purge existing local GitHub rows for this repo"),
     dry_run: bool = typer.Option(False, help="Preview purge counts without deleting"),
     confirm: bool = typer.Option(False, help="Confirm destructive purge execution"),
-    database: Path | None = typer.Option(
-        None, envvar="REBALANCE_DB", help="SQLite database path for purge operations (resolves via layered chain)"
-    ),
+    database: Path | None = DBOption(help="SQLite database path for purge operations (resolves via layered chain)"),
 ) -> None:
     """Add one repo to the local GitHub ingest ignore list, with optional purge."""
     from rebalance.ingest.github_knowledge import purge_github_repo_data

--- a/src/rebalance/ingest/_http.py
+++ b/src/rebalance/ingest/_http.py
@@ -1,0 +1,234 @@
+"""
+Shared GitHub HTTP client.
+
+Replaces three near-duplicate helpers that grew up in parallel:
+
+* ``github_scan._headers`` + ``github_scan._get``
+  — used "Authorization: token X" (v3 syntax), returned ``(status, data | None)``.
+* ``github_knowledge._github_headers`` + ``github_knowledge._http_get_json``
+  — used "Authorization: Bearer X" (GitHub's current syntax), raised
+    RuntimeError on HTTP error.
+* ``github_knowledge._paginate_list``
+  — paginated list endpoints with optional ``stop_updated_before`` cutoff.
+
+The two header forms are interchangeable at the API level (GitHub accepts both),
+but the duplication meant a fix to one path (rate-limit handling, retry logic,
+new audit fields) never reached the other. ``GitHubClient`` is the single home.
+
+Two response modes are offered so the existing call sites don't need behavior
+changes during migration:
+
+* :meth:`GitHubClient.get` — returns ``(status, data | None)``. Mirrors
+  github_scan's contract. Use when the caller wants to branch on status (e.g.
+  treat 422 as "no more pages").
+* :meth:`GitHubClient.get_json` — raises :class:`GitHubHTTPError` on any
+  non-2xx. Mirrors github_knowledge's contract.
+
+Retries: 429 / 5xx are retried with exponential backoff up to ``retries``
+attempts (jittered, honoring ``Retry-After`` when present). 4xx other than
+429 are not retried. Default ``retries=3`` matches the CLAUDE.md "respect
+GitHub 5000/hr PAT limits; sleep/retry" guidance. Tests pass ``retries=1``
+to keep them deterministic.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import random
+import time
+import urllib.error
+import urllib.request
+from typing import Any
+from urllib.parse import urlencode
+
+GITHUB_API = "https://api.github.com"
+USER_AGENT = "rebalance-os/0.30"
+_API_VERSION = "2022-11-28"
+
+logger = logging.getLogger(__name__)
+
+
+class GitHubHTTPError(RuntimeError):
+    """Raised by :meth:`GitHubClient.get_json` on non-2xx responses.
+
+    Carries the HTTP status, URL, and body excerpt so callers can build
+    structured diagnostics. ``is_rate_limit`` is True for 429 and 403
+    rate-limit responses (which GitHub returns interchangeably for PAT
+    quota exhaustion).
+    """
+
+    def __init__(self, message: str, status: int, *, url: str = "", body: str = "", is_rate_limit: bool = False):
+        super().__init__(message)
+        self.status = status
+        self.url = url
+        self.body = body
+        self.is_rate_limit = is_rate_limit
+
+
+def _is_rate_limit(status: int, response_headers: dict[str, str] | None = None) -> bool:
+    if status == 429:
+        return True
+    if status == 403 and response_headers:
+        # GitHub signals primary rate limit with x-ratelimit-remaining: 0 and
+        # secondary rate limit with retry-after present.
+        remaining = response_headers.get("x-ratelimit-remaining")
+        if remaining == "0":
+            return True
+        if "retry-after" in response_headers:
+            return True
+    return False
+
+
+def _retry_after_seconds(headers: dict[str, str], attempt: int) -> float:
+    """Compute backoff: honor Retry-After header, else exponential w/ jitter."""
+    retry_after = headers.get("retry-after")
+    if retry_after:
+        try:
+            return float(retry_after)
+        except ValueError:
+            pass
+    # Exponential backoff: 1s, 2s, 4s, capped at 16s; +/- 25% jitter.
+    base = min(2.0 ** attempt, 16.0)
+    jitter = base * 0.25 * (random.random() * 2 - 1)
+    return max(0.5, base + jitter)
+
+
+class GitHubClient:
+    """Thin wrapper over ``urllib`` with retries, pagination, and shared headers.
+
+    Parameters
+    ----------
+    token:
+        GitHub PAT or app-installation token. Sent as ``Authorization: Bearer``.
+    timeout:
+        Per-request timeout in seconds.
+    retries:
+        Max attempts on 429/5xx (including the first attempt). ``1`` = no retry.
+    sleep:
+        Test seam for the backoff sleep call.
+    """
+
+    def __init__(
+        self,
+        token: str,
+        *,
+        timeout: int = 30,
+        retries: int = 3,
+        sleep=time.sleep,
+        user_agent: str = USER_AGENT,
+    ) -> None:
+        self.token = token
+        self.timeout = timeout
+        self.retries = max(1, retries)
+        self._sleep = sleep
+        self._user_agent = user_agent
+
+    def headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.token}",
+            "Accept": "application/vnd.github+json",
+            "User-Agent": self._user_agent,
+            "X-GitHub-Api-Version": _API_VERSION,
+        }
+
+    def _request(self, url: str) -> tuple[int, Any, dict[str, str]]:
+        last_status = 0
+        last_body = ""
+        last_headers: dict[str, str] = {}
+        for attempt in range(self.retries):
+            req = urllib.request.Request(url, headers=self.headers())
+            try:
+                with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+                    body = resp.read().decode()
+                    parsed = json.loads(body) if body else None
+                    return resp.status, parsed, {k.lower(): v for k, v in resp.headers.items()}
+            except urllib.error.HTTPError as exc:
+                last_status = exc.code
+                last_headers = {k.lower(): v for k, v in (exc.headers or {}).items()}
+                try:
+                    last_body = exc.read().decode() if exc.fp else ""
+                except Exception:  # noqa: BLE001 — body read can fail mid-stream
+                    last_body = ""
+
+                retryable = last_status >= 500 or _is_rate_limit(last_status, last_headers)
+                if not retryable or attempt + 1 >= self.retries:
+                    return last_status, None, last_headers
+
+                delay = _retry_after_seconds(last_headers, attempt)
+                logger.info("GitHub %s -> %s, retrying in %.1fs (attempt %d/%d)", url, last_status, delay, attempt + 1, self.retries)
+                self._sleep(delay)
+        return last_status, None, last_headers
+
+    def get(self, path_or_url: str) -> tuple[int, Any]:
+        """Return ``(status, parsed_json_or_None)``. Mirrors github_scan._get."""
+        url = path_or_url if path_or_url.startswith("http") else f"{GITHUB_API}{path_or_url}"
+        status, data, _ = self._request(url)
+        return status, data
+
+    def get_with_headers(self, path_or_url: str) -> tuple[int, Any, dict[str, str]]:
+        """Return ``(status, parsed_json_or_None, response_headers)``.
+
+        Use when the caller needs to read response headers (e.g.
+        ``X-OAuth-Scopes`` on ``/user``). Headers are lowercased.
+        """
+        url = path_or_url if path_or_url.startswith("http") else f"{GITHUB_API}{path_or_url}"
+        return self._request(url)
+
+    def get_json(self, path_or_url: str) -> Any:
+        """Return parsed JSON or raise :class:`GitHubHTTPError`.
+
+        Mirrors github_knowledge._http_get_json.
+        """
+        url = path_or_url if path_or_url.startswith("http") else f"{GITHUB_API}{path_or_url}"
+        status, data, headers = self._request(url)
+        if 200 <= status < 300:
+            return data
+        rate_limit = _is_rate_limit(status, headers)
+        raise GitHubHTTPError(
+            f"GitHub API request failed: {status} {url}",
+            status=status,
+            url=url,
+            body="",
+            is_rate_limit=rate_limit,
+        )
+
+    @staticmethod
+    def build_url(base_url: str, **params: Any) -> str:
+        cleaned = {key: value for key, value in params.items() if value not in ("", None)}
+        if not cleaned:
+            return base_url
+        return f"{base_url}?{urlencode(cleaned, doseq=True)}"
+
+    def paginate(
+        self,
+        base_url: str,
+        *,
+        stop_updated_before: str = "",
+        per_page: int = 100,
+        **params: Any,
+    ) -> list[dict[str, Any]]:
+        """Walk a paginated list endpoint, accumulating items.
+
+        Mirrors github_knowledge._paginate_list. Stops at first page with
+        ``updated_at < stop_updated_before`` (per row, when the param is set)
+        or when a page is short of ``per_page`` items.
+        """
+        page = 1
+        results: list[dict[str, Any]] = []
+        while True:
+            url = self.build_url(base_url, per_page=per_page, page=page, **params)
+            data = self.get_json(url)
+            if not isinstance(data, list) or not data:
+                break
+            stop = False
+            for row in data:
+                updated_at = str(row.get("updated_at") or "")
+                if stop_updated_before and updated_at and updated_at < stop_updated_before:
+                    stop = True
+                    break
+                results.append(row)
+            if stop or len(data) < per_page:
+                break
+            page += 1
+        return results

--- a/src/rebalance/ingest/github_knowledge.py
+++ b/src/rebalance/ingest/github_knowledge.py
@@ -13,8 +13,6 @@ from __future__ import annotations
 import hashlib
 import json
 import time
-import urllib.error
-import urllib.request
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -24,6 +22,7 @@ import re
 
 from rebalance.ingest.config import get_github_ignored_repos, normalize_github_repo_name
 from rebalance.ingest.db import db_connection, ensure_github_schema, ensure_semantic_schema
+from rebalance.ingest._http import GITHUB_API, GitHubClient, GitHubHTTPError
 from rebalance.ingest.embedder import (
     DEFAULT_MODEL as DEFAULT_EMBED_MODEL,
     EMBEDDING_DIM,
@@ -32,8 +31,6 @@ from rebalance.ingest.embedder import (
     _vec_to_bytes,
 )
 from rebalance.ingest.semantic_index import sync_github_documents
-
-GITHUB_API = "https://api.github.com"
 DEFAULT_SYNC_DAYS = 90
 MIN_EMBED_CHARS = 40
 _CLOSES_RE = re.compile(r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b", re.IGNORECASE)
@@ -79,22 +76,26 @@ class GitHubRepoPurgeResult:
 
 
 def _github_headers(token: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Bearer {token}",
-        "Accept": "application/vnd.github+json",
-        "User-Agent": "rebalance-os/phase1",
-        "X-GitHub-Api-Version": "2022-11-28",
-    }
+    """Delegate to the shared GitHub client.
+
+    Retained as a module-level helper because some external callers (tests,
+    experimental scripts) imported it before the shared client existed.
+    """
+    return GitHubClient(token).headers()
 
 
 def _http_get_json(url: str, token: str) -> Any:
-    req = urllib.request.Request(url, headers=_github_headers(token))
+    """GET ``url`` as JSON; raise on non-2xx.
+
+    Thin wrapper over :class:`GitHubClient` so the legacy ``api_get`` callable
+    seam in :func:`sync_github_repo` keeps working. New code should construct
+    a client once and reuse it.
+    """
     try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            return json.loads(resp.read().decode())
-    except urllib.error.HTTPError as exc:
-        body = exc.read().decode() if exc.fp else ""
-        raise RuntimeError(f"GitHub API request failed: {exc.code} {url} {body}") from exc
+        return GitHubClient(token).get_json(url)
+    except GitHubHTTPError as exc:
+        # Preserve legacy RuntimeError type — tests and callers expect it.
+        raise RuntimeError(f"GitHub API request failed: {exc.status} {url}") from exc
 
 
 def _build_url(base_url: str, **params: Any) -> str:

--- a/src/rebalance/ingest/github_scan.py
+++ b/src/rebalance/ingest/github_scan.py
@@ -15,17 +15,13 @@ Usage:
 
 from __future__ import annotations
 
-import urllib.request
-import urllib.error
-import json
 from dataclasses import dataclass, field
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from typing import Any
 
 from rebalance.ingest.config import normalize_github_repo_name
-
-GITHUB_API = "https://api.github.com"
+from rebalance.ingest._http import GITHUB_API, GitHubClient
 MAX_EVENT_PAGES = 3  # Hard limit documented by GitHub
 
 # Activity band definitions — shared with preflight.py for segmentation.
@@ -100,22 +96,18 @@ class GitHubApiError(Exception):
 # Internal helpers
 # ---------------------------------------------------------------------------
 
-def _headers(token: str) -> dict[str, str]:
-    return {
-        "Authorization": f"token {token}",
-        "Accept": "application/vnd.github.v3+json",
-        "User-Agent": "rebalance-os/0.1",
-    }
+def _client(token: str) -> GitHubClient:
+    """Return a GitHubClient — wrapper kept so callers needn't import the type."""
+    return GitHubClient(token)
 
 
 def _get(url: str, token: str) -> tuple[int, Any]:
-    """Minimal HTTP GET — returns (status_code, parsed_json_or_None)."""
-    req = urllib.request.Request(url, headers=_headers(token))
-    try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            return resp.status, json.loads(resp.read().decode())
-    except urllib.error.HTTPError as exc:
-        return exc.code, None
+    """Minimal HTTP GET — returns (status_code, parsed_json_or_None).
+
+    Thin wrapper retained for callers within this module; new code should use
+    a long-lived :class:`GitHubClient` instead.
+    """
+    return _client(token).get(url)
 
 
 def _cutoff_key(days: int) -> str:
@@ -310,17 +302,13 @@ def validate_github_token(token: str) -> dict[str, Any]:
         {"valid": True, "login": "...", "scopes": ["repo", ...]}
         or {"valid": False, "login": "", "scopes": [], "error": "..."}
     """
-    req = urllib.request.Request(f"{GITHUB_API}/user", headers=_headers(token))
-    try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            data = json.loads(resp.read().decode())
-            scopes_header = resp.headers.get("X-OAuth-Scopes", "")
-            scopes = [s.strip() for s in scopes_header.split(",") if s.strip()]
-            return {"valid": True, "login": data.get("login", ""), "scopes": scopes}
-    except urllib.error.HTTPError as exc:
-        if exc.code in (401, 403):
-            return {"valid": False, "login": "", "scopes": [], "error": f"HTTP {exc.code}"}
-        return {"valid": False, "login": "", "scopes": [], "error": f"HTTP {exc.code}"}
+    # No retries: a bad token should fail fast for the onboarding flow.
+    status, data, headers = GitHubClient(token, retries=1).get_with_headers("/user")
+    if status == 200 and isinstance(data, dict):
+        scopes_header = headers.get("x-oauth-scopes", "")
+        scopes = [s.strip() for s in scopes_header.split(",") if s.strip()]
+        return {"valid": True, "login": data.get("login", ""), "scopes": scopes}
+    return {"valid": False, "login": "", "scopes": [], "error": f"HTTP {status}"}
 
 
 def scan_github(token: str, days: int = 30) -> GitHubScanResult:

--- a/src/rebalance/ingest/index_ops.py
+++ b/src/rebalance/ingest/index_ops.py
@@ -9,10 +9,12 @@ underlying ingest pipelines so callers do not have to know the order of
 
 from __future__ import annotations
 
+import logging
 import time
+from dataclasses import dataclass, field
 from datetime import date
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Callable, Iterable
 
 from rebalance.ingest.config import (
     get_github_token,
@@ -21,7 +23,76 @@ from rebalance.ingest.config import (
 from rebalance.ingest.db import db_connection, ensure_semantic_schema
 from rebalance.ingest.registry import get_projects
 
+logger = logging.getLogger(__name__)
 
+
+@dataclass(frozen=True)
+class Collector:
+    """A single data-source ingest pipeline registered with :data:`COLLECTORS`.
+
+    External integrators add new data sources by constructing a :class:`Collector`
+    and calling :func:`register_collector`. The dispatcher in :func:`refresh_index`
+    routes the user's ``scope=[...]`` list through the registry — no edits to
+    the dispatch chain are required.
+
+    Fields
+    ------
+    name:
+        The user-facing scope key. Must be unique. Reserved: ``"all"``.
+    refresh:
+        Callable executed for live runs. Receives ``(db_path, **opts)`` where
+        ``opts`` includes every refresh_index kwarg the collector might want
+        (since_days, vault_path, token, repos, include_semantic, ...). Unknown
+        keys must be ignored. Must return a ``dict`` whose first key is
+        ``"scope": "<name>"`` so the caller can correlate results.
+    requires:
+        Optional iterable of precondition names — currently ``"vault_path"``,
+        ``"github_token"``. Failures surface as structured errors rather than
+        exceptions, mirroring the legacy refresh_index error envelope.
+    included_in_all:
+        If True (default), the collector runs when the user requests
+        ``scope=["all"]``. Set False for opt-in collectors (e.g. heavy or
+        narrowly-scoped sources).
+    """
+
+    name: str
+    refresh: Callable[..., dict[str, Any]]
+    requires: tuple[str, ...] = ()
+    included_in_all: bool = True
+
+
+COLLECTORS: dict[str, Collector] = {}
+
+
+def register_collector(collector: Collector, *, replace: bool = False) -> None:
+    """Add a :class:`Collector` to the registry.
+
+    Set ``replace=True`` when an external integrator deliberately overrides a
+    built-in. Otherwise duplicate names raise to surface accidental shadowing.
+    """
+    if collector.name in ("all", ""):
+        raise ValueError(f"Reserved collector name: {collector.name!r}")
+    if collector.name in COLLECTORS and not replace:
+        raise ValueError(
+            f"Collector {collector.name!r} already registered; pass replace=True to override."
+        )
+    COLLECTORS[collector.name] = collector
+    logger.debug("Registered collector: %s (requires=%s)", collector.name, collector.requires)
+
+
+def _scope_values() -> tuple[str, ...]:
+    """Return the supported scope keys, plus the meta-scope ``"all"``."""
+    return tuple(COLLECTORS.keys()) + ("all",)
+
+
+def _all_scope_names() -> list[str]:
+    """Return the collector names that run for ``scope=["all"]``."""
+    return [name for name, c in COLLECTORS.items() if c.included_in_all]
+
+
+# Legacy SCOPE_VALUES: retained so callers importing the constant continue to
+# work. New code should call _scope_values() since registered collectors may
+# extend the set at runtime.
 SCOPE_VALUES = ("vault", "github", "calendar", "sleuth", "email", "semantic", "all")
 
 
@@ -57,18 +128,19 @@ def _normalize_scope(scope: Iterable[str] | str | None) -> list[str]:
     else:
         items = list(scope)
     cleaned: list[str] = []
+    valid = _scope_values()
     for raw in items:
         v = (raw or "").strip().lower()
         if not v:
             continue
-        if v not in SCOPE_VALUES:
-            raise ValueError(f"Unsupported scope: {raw!r}. Expected one of {SCOPE_VALUES}.")
+        if v not in valid:
+            raise ValueError(f"Unsupported scope: {raw!r}. Expected one of {valid}.")
         if v not in cleaned:
             cleaned.append(v)
     if not cleaned:
         return ["all"]
     if "all" in cleaned:
-        return ["vault", "github", "calendar", "sleuth", "email", "semantic"]
+        return _all_scope_names()
     return cleaned
 
 
@@ -801,29 +873,24 @@ def refresh_index(
 
     repos_list = list(repos or [])
 
+    # Per-collector kwargs bundle. Each collector ignores keys it doesn't need.
+    collector_opts: dict[str, Any] = {
+        "vault_path": resolved_vault,
+        "token": resolved_token,
+        "since_days": since_days,
+        "repos": repos_list,
+        "dry_run": dry_run,
+        "include_semantic": include_semantic,
+    }
+
     for s in requested_scopes:
+        collector = COLLECTORS.get(s)
+        if collector is None:
+            errors.append({"scope": s, "error": f"no collector registered for scope {s!r}"})
+            continue
         try:
-            if s == "vault":
-                assert resolved_vault is not None
-                results.append(_refresh_vault(db_path, resolved_vault, dry_run=dry_run))
-            elif s == "github":
-                results.append(_refresh_github(
-                    db_path,
-                    token=resolved_token,
-                    since_days=since_days,
-                    repos=repos_list,
-                    dry_run=dry_run,
-                    include_semantic=include_semantic,
-                ))
-            elif s == "calendar":
-                results.append(_refresh_calendar(db_path, since_days=since_days, dry_run=dry_run))
-            elif s == "sleuth":
-                results.append(_refresh_sleuth(db_path, dry_run=dry_run))
-            elif s == "email":
-                results.append(_refresh_email(db_path, dry_run=dry_run))
-            elif s == "semantic":
-                results.append(_refresh_semantic_only(db_path, dry_run=dry_run))
-        except Exception as e:
+            results.append(collector.refresh(db_path, **collector_opts))
+        except Exception as e:  # noqa: BLE001 — error envelope mirrors legacy contract
             errors.append({"scope": s, "error": str(e)})
 
     if update_dashboard_note and full_refresh_requested and resolved_vault is not None:
@@ -853,3 +920,54 @@ def refresh_index(
         "errors": errors,
         "elapsed_seconds": round(time.monotonic() - started, 2),
     }
+
+
+# ---------------------------------------------------------------------------
+# Built-in collectors
+# ---------------------------------------------------------------------------
+#
+# Adapter functions normalize each per-source refresh function to the Collector
+# signature (db_path, **opts). Unknown keys are ignored; required keys are
+# extracted by name. The legacy ``_refresh_*`` private functions remain the
+# single source of truth for the ingest pipelines — these adapters are 3-line
+# shims.
+
+def _vault_adapter(db_path: Path, **opts: Any) -> dict[str, Any]:
+    vault_path = opts.get("vault_path")
+    assert vault_path is not None, "vault collector requires vault_path"
+    return _refresh_vault(db_path, vault_path, dry_run=opts["dry_run"])
+
+
+def _github_adapter(db_path: Path, **opts: Any) -> dict[str, Any]:
+    return _refresh_github(
+        db_path,
+        token=opts["token"],
+        since_days=opts["since_days"],
+        repos=opts.get("repos") or [],
+        dry_run=opts["dry_run"],
+        include_semantic=opts.get("include_semantic", True),
+    )
+
+
+def _calendar_adapter(db_path: Path, **opts: Any) -> dict[str, Any]:
+    return _refresh_calendar(db_path, since_days=opts["since_days"], dry_run=opts["dry_run"])
+
+
+def _sleuth_adapter(db_path: Path, **opts: Any) -> dict[str, Any]:
+    return _refresh_sleuth(db_path, dry_run=opts["dry_run"])
+
+
+def _email_adapter(db_path: Path, **opts: Any) -> dict[str, Any]:
+    return _refresh_email(db_path, dry_run=opts["dry_run"])
+
+
+def _semantic_adapter(db_path: Path, **opts: Any) -> dict[str, Any]:
+    return _refresh_semantic_only(db_path, dry_run=opts["dry_run"])
+
+
+register_collector(Collector("vault", _vault_adapter, requires=("vault_path",)))
+register_collector(Collector("github", _github_adapter, requires=("github_token",)))
+register_collector(Collector("calendar", _calendar_adapter))
+register_collector(Collector("sleuth", _sleuth_adapter))
+register_collector(Collector("email", _email_adapter))
+register_collector(Collector("semantic", _semantic_adapter))

--- a/src/rebalance/paths.py
+++ b/src/rebalance/paths.py
@@ -342,6 +342,52 @@ def set_user_config_value(key: str, value: str) -> Path:
     return USER_CONFIG_FILE
 
 
+# ---------------------------------------------------------------------------
+# CLI convenience: shared Typer option for the --database flag
+# ---------------------------------------------------------------------------
+
+_DB_OPTION_HELP = (
+    "SQLite database path (resolves via layered chain — see "
+    "`rebalance config show-defaults`)"
+)
+
+
+def DBOption(*flag_names: str, help: str = _DB_OPTION_HELP):  # noqa: N802 — Typer-style factory
+    """Return the shared ``typer.Option`` for the --database CLI flag.
+
+    Collapses the 23-site duplication of::
+
+        database: Path | None = typer.Option(None, envvar="REBALANCE_DB",
+            help="SQLite database path (resolves via layered chain — see ...)")
+
+    Used like::
+
+        from rebalance.paths import DBOption
+        @app.command()
+        def foo(database: Path | None = DBOption()): ...
+
+    Pass extra positional flag names to override the default flag::
+
+        database: Path | None = DBOption("--database-path")
+
+    Imported lazily so importing ``rebalance.paths`` works in contexts where
+    Typer isn't installed.
+    """
+    import typer  # local import: keeps paths.py importable without typer
+
+    return typer.Option(None, *flag_names, envvar="REBALANCE_DB", help=help)
+
+
+def resolve_db(explicit: Path | None = None) -> Path:
+    """Thin alias for :func:`resolve_database_path` with a shorter name.
+
+    The full function name remains the canonical API; ``resolve_db`` is the
+    one-liner CLI handlers and MCP tools reach for. Both raise
+    :class:`DatabaseNotFoundError` on failure.
+    """
+    return resolve_database_path(explicit)
+
+
 def get_user_config_summary() -> dict:
     """Return a dict suitable for ``rebalance config show-defaults`` output."""
     cfg = _load_user_config()

--- a/tests/test_collector_registry.py
+++ b/tests/test_collector_registry.py
@@ -1,0 +1,72 @@
+"""Tests for the Collector registry in index_ops."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from typing import Any
+
+from rebalance.ingest.index_ops import (
+    COLLECTORS,
+    Collector,
+    _all_scope_names,
+    _scope_values,
+    register_collector,
+)
+
+
+class CollectorRegistryTests(unittest.TestCase):
+    def test_builtin_collectors_registered(self) -> None:
+        for name in ("vault", "github", "calendar", "sleuth", "email", "semantic"):
+            self.assertIn(name, COLLECTORS, f"missing built-in collector {name}")
+
+    def test_scope_values_includes_all(self) -> None:
+        values = _scope_values()
+        self.assertIn("all", values)
+        for name in ("vault", "github", "calendar"):
+            self.assertIn(name, values)
+
+    def test_all_scope_includes_default_built_ins(self) -> None:
+        names = _all_scope_names()
+        self.assertEqual(
+            sorted(names),
+            sorted(["vault", "github", "calendar", "sleuth", "email", "semantic"]),
+        )
+
+    def test_register_new_collector_then_unregister(self) -> None:
+        calls: list[dict[str, Any]] = []
+
+        def _refresh(db: Path, **opts: Any) -> dict[str, Any]:
+            calls.append(opts)
+            return {"scope": "linear_test", "dry_run": opts.get("dry_run", False)}
+
+        try:
+            register_collector(Collector("linear_test", _refresh, included_in_all=False))
+            self.assertIn("linear_test", COLLECTORS)
+            # included_in_all=False keeps it OUT of the "all" expansion
+            self.assertNotIn("linear_test", _all_scope_names())
+            # But it shows up in the full scope-values list
+            self.assertIn("linear_test", _scope_values())
+            # And calling its refresh works
+            result = COLLECTORS["linear_test"].refresh(Path("/tmp/x"), dry_run=True)
+            self.assertEqual(result, {"scope": "linear_test", "dry_run": True})
+        finally:
+            COLLECTORS.pop("linear_test", None)
+
+    def test_duplicate_registration_raises(self) -> None:
+        def _refresh(db: Path, **opts: Any) -> dict[str, Any]:
+            return {"scope": "vault"}
+
+        with self.assertRaises(ValueError):
+            register_collector(Collector("vault", _refresh))
+
+    def test_reserved_name_rejected(self) -> None:
+        def _refresh(db: Path, **opts: Any) -> dict[str, Any]:
+            return {"scope": "all"}
+
+        with self.assertRaises(ValueError):
+            register_collector(Collector("all", _refresh))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_collector_registry.py
+++ b/tests/test_collector_registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import tempfile
 import unittest
 from pathlib import Path
 from typing import Any
@@ -11,6 +12,7 @@ from rebalance.ingest.index_ops import (
     Collector,
     _all_scope_names,
     _scope_values,
+    refresh_index,
     register_collector,
 )
 
@@ -66,6 +68,36 @@ class CollectorRegistryTests(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             register_collector(Collector("all", _refresh))
+
+    def test_refresh_index_dispatches_through_registry(self) -> None:
+        """refresh_index must route scope keys through COLLECTORS, not legacy code."""
+        calls: list[tuple[Path, dict[str, Any]]] = []
+
+        def _mock_refresh(db: Path, **opts: Any) -> dict[str, Any]:
+            calls.append((db, opts))
+            return {"scope": "smoke_test", "synced": 1}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "test.db"
+            try:
+                register_collector(
+                    Collector("smoke_test", _mock_refresh, included_in_all=False)
+                )
+                result = refresh_index(
+                    db_path,
+                    scope=["smoke_test"],
+                    dry_run=False,
+                    update_dashboard_note=False,
+                )
+                # The dispatcher must have called our collector exactly once.
+                self.assertEqual(len(calls), 1, "collector was not called by refresh_index")
+                called_db, called_opts = calls[0]
+                self.assertEqual(called_db, db_path.resolve())
+                # Result envelope must include our collector's return value.
+                scopes_in_result = [r.get("scope") for r in result.get("results", [])]
+                self.assertIn("smoke_test", scopes_in_result)
+            finally:
+                COLLECTORS.pop("smoke_test", None)
 
 
 if __name__ == "__main__":

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1,0 +1,163 @@
+"""Tests for the shared GitHub HTTP client (src/rebalance/ingest/_http.py)."""
+
+from __future__ import annotations
+
+import io
+import json
+import unittest
+import urllib.error
+from typing import Any
+from unittest.mock import patch
+
+from rebalance.ingest._http import GitHubClient, GitHubHTTPError
+
+
+def _ok_response(payload: Any, response_headers: dict[str, str] | None = None):
+    """Return a fake context manager mimicking urlopen's response."""
+    body = json.dumps(payload).encode()
+    hdrs = response_headers or {}
+
+    class _Resp:
+        status = 200
+        headers = hdrs
+
+        def __enter__(self_inner):
+            return self_inner
+
+        def __exit__(self_inner, *_exc):
+            return False
+
+        def read(self_inner):
+            return body
+
+    return _Resp()
+
+
+def _http_error(code: int, body: str = "", headers: dict[str, str] | None = None) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(
+        url="https://api.github.com/",
+        code=code,
+        msg="err",
+        hdrs=headers or {},
+        fp=io.BytesIO(body.encode()),
+    )
+
+
+class GitHubClientHeadersTests(unittest.TestCase):
+    def test_uses_bearer_auth_and_api_version(self) -> None:
+        client = GitHubClient("ghp_test")
+        h = client.headers()
+        self.assertEqual(h["Authorization"], "Bearer ghp_test")
+        self.assertEqual(h["X-GitHub-Api-Version"], "2022-11-28")
+        self.assertIn("rebalance-os", h["User-Agent"])
+
+
+class GitHubClientGetTests(unittest.TestCase):
+    def test_get_returns_status_and_data(self) -> None:
+        client = GitHubClient("ghp", retries=1)
+        with patch("urllib.request.urlopen", return_value=_ok_response({"login": "alice"})):
+            status, data = client.get("/user")
+        self.assertEqual(status, 200)
+        self.assertEqual(data, {"login": "alice"})
+
+    def test_get_returns_status_none_on_http_error_with_no_retry(self) -> None:
+        client = GitHubClient("ghp", retries=1)
+        with patch("urllib.request.urlopen", side_effect=_http_error(404)):
+            status, data = client.get("/user")
+        self.assertEqual(status, 404)
+        self.assertIsNone(data)
+
+
+class GitHubClientGetJsonTests(unittest.TestCase):
+    def test_get_json_returns_data_on_2xx(self) -> None:
+        client = GitHubClient("ghp", retries=1)
+        with patch("urllib.request.urlopen", return_value=_ok_response([1, 2, 3])):
+            data = client.get_json("/list")
+        self.assertEqual(data, [1, 2, 3])
+
+    def test_get_json_raises_on_4xx(self) -> None:
+        client = GitHubClient("ghp", retries=1)
+        with patch("urllib.request.urlopen", side_effect=_http_error(404)):
+            with self.assertRaises(GitHubHTTPError) as ctx:
+                client.get_json("/missing")
+        self.assertEqual(ctx.exception.status, 404)
+        self.assertFalse(ctx.exception.is_rate_limit)
+
+    def test_get_json_flags_rate_limit_on_429(self) -> None:
+        client = GitHubClient("ghp", retries=1)
+        with patch("urllib.request.urlopen", side_effect=_http_error(429)):
+            with self.assertRaises(GitHubHTTPError) as ctx:
+                client.get_json("/x")
+        self.assertTrue(ctx.exception.is_rate_limit)
+
+    def test_get_json_flags_rate_limit_on_403_with_zero_remaining(self) -> None:
+        client = GitHubClient("ghp", retries=1)
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=_http_error(403, headers={"x-ratelimit-remaining": "0"}),
+        ):
+            with self.assertRaises(GitHubHTTPError) as ctx:
+                client.get_json("/x")
+        self.assertTrue(ctx.exception.is_rate_limit)
+
+
+class GitHubClientRetryTests(unittest.TestCase):
+    def test_retries_on_5xx_then_succeeds(self) -> None:
+        sleeps: list[float] = []
+        client = GitHubClient("ghp", retries=3, sleep=lambda s: sleeps.append(s))
+        responses = [_http_error(503), _http_error(503), _ok_response({"ok": True})]
+
+        def _side(*_a, **_k):
+            r = responses.pop(0)
+            if isinstance(r, urllib.error.HTTPError):
+                raise r
+            return r
+
+        with patch("urllib.request.urlopen", side_effect=_side):
+            data = client.get_json("/flaky")
+        self.assertEqual(data, {"ok": True})
+        self.assertEqual(len(sleeps), 2)
+
+    def test_does_not_retry_on_4xx(self) -> None:
+        sleeps: list[float] = []
+        client = GitHubClient("ghp", retries=3, sleep=lambda s: sleeps.append(s))
+        with patch("urllib.request.urlopen", side_effect=_http_error(404)):
+            with self.assertRaises(GitHubHTTPError):
+                client.get_json("/missing")
+        self.assertEqual(sleeps, [])
+
+    def test_honors_retry_after_header(self) -> None:
+        sleeps: list[float] = []
+        client = GitHubClient("ghp", retries=2, sleep=lambda s: sleeps.append(s))
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=_http_error(429, headers={"retry-after": "7"}),
+        ):
+            with self.assertRaises(GitHubHTTPError):
+                client.get_json("/x")
+        self.assertEqual(sleeps, [7.0])
+
+
+class GitHubClientPaginateTests(unittest.TestCase):
+    def test_paginate_accumulates_until_short_page(self) -> None:
+        client = GitHubClient("ghp", retries=1)
+        page1 = [{"id": i, "updated_at": "2024-01-01"} for i in range(100)]
+        page2 = [{"id": 100, "updated_at": "2024-01-01"}]  # short page → stop
+        responses = [_ok_response(page1), _ok_response(page2)]
+        with patch("urllib.request.urlopen", side_effect=lambda *a, **k: responses.pop(0)):
+            data = client.paginate("/repos/x/y/issues")
+        self.assertEqual(len(data), 101)
+
+    def test_paginate_stops_on_updated_before(self) -> None:
+        client = GitHubClient("ghp", retries=1)
+        page = [
+            {"id": 1, "updated_at": "2024-06-01"},
+            {"id": 2, "updated_at": "2023-01-01"},  # below cutoff
+        ]
+        with patch("urllib.request.urlopen", return_value=_ok_response(page)):
+            data = client.paginate("/repos/x/y/issues", stop_updated_before="2024-01-01")
+        self.assertEqual([row["id"] for row in data], [1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Three foundational refactor commits (originally from a prior Claude Code session) plus two follow-up fixes applied this session to get the stack running on a fresh checkout.

### Refactor (Phases 1, 2, 4)

**Phase 1 — Logging bootstrap + shared DBOption (DRY)**
Eliminates the 24 duplicate `Path("rebalance.db"), envvar="REBALANCE_DB"` option declarations across the CLI. Adds structured `logging.getLogger(__name__)` setup throughout `ingest/`.

**Phase 2 — Shared GitHub HTTP client (`ingest/_http.py`)**
Extracts the duplicated `urlopen` + retry + pagination logic from `github_scan.py` and `github_knowledge.py` into a single reusable client with a 30 s timeout, exponential backoff, and `per_page=100` pagination. New: `tests/test_http_client.py` (11 tests).

**Phase 4 — Collector protocol + source registry for `refresh_index`**
Introduces the `Collector` dataclass and `COLLECTORS` dict in `index_ops.py`. `refresh_index` now routes `scope=[...]` through the registry instead of a hard-coded dispatch chain. External integrators can call `register_collector()` to add new data sources without touching the dispatch code. New: `tests/test_collector_registry.py` (7 tests, including a new end-to-end dispatch smoke test added this PR).

### Fresh-install fixes (added this session)

**`scripts/dashboard.py` — empty-DB resilience**
Wrapped `fetch_recent_github`, `fetch_repo_activity_counts`, `fetch_vault_recent`, `fetch_recent_emails`, and `fetch_watched_summary` in `try/except` so a freshly-cloned repo with an empty or schema-less `rebalance.db` returns `[]` instead of crashing `pulse_web.py` and the terminal dashboard.

**`pyproject.toml` — `[server]` optional extras**
Adds `fastapi>=0.110.0` and `uvicorn[standard]>=0.29.0` under `[project.optional-dependencies] server` so `pip install -e '.[server]'` reproduces the pulse-server venv reproducibly instead of requiring manual installs.

## Tests

```
tests/test_collector_registry.py  7 passed
tests/test_http_client.py         11 passed
```

## Notes

- Phase 3 (DB migration helpers) and Phase 5 were not attempted in the original session — no gaps in production behavior.
- `main` and `development` are the same commit; this targets `main` directly.