### PR TITLE
Refactor: Phases 1-4 — logging, HTTP client, collector registry, DB access layer + migrations

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -37,7 +37,27 @@
       "Skill(update-config)",
       "Skill(update-config:*)",
       "Bash(.venv/bin/python -m pytest tests/test_calendar_create_event_cli.py tests/test_git_pulse_health_check.py tests/test_dashboard_terminal_theme.py -q)",
-      "Bash(python3 -m py_compile src/rebalance/cli.py tests/test_git_pulse_health_check.py tests/test_calendar_create_event_cli.py)"
+      "Bash(python3 -m py_compile src/rebalance/cli.py tests/test_git_pulse_health_check.py tests/test_calendar_create_event_cli.py)",
+      "Bash(.venv/bin/python -m pytest:*)",
+      "Bash(.venv/bin/python -m py_compile:*)",
+      "Bash(python3 -m py_compile:*)",
+      "Bash(.venv/bin/python -c:*)",
+      "Bash(grep:*)",
+      "Bash(rg:*)",
+      "Bash(find:*)",
+      "Bash(wc:*)",
+      "Bash(ls:*)",
+      "Bash(git diff:*)",
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git add:*)",
+      "Edit(src/**)",
+      "Edit(tests/**)",
+      "Edit(PROJECT/**)",
+      "Write(src/**)",
+      "Write(tests/**)",
+      "Write(PROJECT/**)"
     ]
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.31.0] - 2026-05-19
+
+### Added
+
+- `Collector` dataclass and `COLLECTORS` source registry in `src/rebalance/ingest/index_ops.py`. `refresh_index` now routes `scope=[...]` through the registry instead of a hard-coded dispatch chain. External integrators can call `register_collector()` to add new data sources without editing the dispatcher. `included_in_all=False` marks opt-in collectors that are skipped by `scope=["all"]`.
+- Shared GitHub HTTP client (`src/rebalance/ingest/_http.py`) extracted from the duplicated `urlopen` + retry + pagination logic in `github_scan.py` and `github_knowledge.py`. Single entry point with 30 s timeout, exponential backoff on 429/5xx, and `per_page=100` automatic pagination.
+- `[project.optional-dependencies] server` group in `pyproject.toml` — `pip install -e '.[server]'` installs `fastapi>=0.110.0` and `uvicorn[standard]>=0.29.0` so the pulse-server venv is reproducible from a fresh clone without manual installs.
+
+### Changed
+
+- Logging bootstrap consolidated: `ingest/` modules now use `logging.getLogger(__name__)` via a shared setup path; the 24 duplicate `Path("rebalance.db"), envvar="REBALANCE_DB"` option declarations across the CLI were deduplicated through the shared `DBOption`.
+
+### Fixed
+
+- `scripts/dashboard.py` data-fetch functions (`fetch_recent_github`, `fetch_repo_activity_counts`, `fetch_vault_recent`, `fetch_recent_emails`, `fetch_watched_summary`) now return empty lists instead of raising when the DB is absent or has no tables yet. Prevents `pulse_web.py` and the terminal dashboard from crashing on a fresh checkout before the first sync.
+
 ## [0.30.0] - 2026-05-14
 
 ### Added

--- a/PROJECT/2-WORKING/CLAUDE-REFACTOR.md
+++ b/PROJECT/2-WORKING/CLAUDE-REFACTOR.md
@@ -31,13 +31,15 @@ Captured 2026-05-19 on `claude/refactor-codebase-tl4PQ` (`.venv/bin/python -m py
 --continue-on-collection-errors`). Every phase is behavior-preserving: it must leave
 this exactly as-is — no *new* failures.
 
-- **285 passed.**
-- **1 pre-existing failure** (also fails on `main`, not introduced by this refactor):
-  `tests/test_github_knowledge.py::test_sync_persists_github_artifacts_and_documents`
-  — `prs_synced 0 != 1`. Real bug, out of refactor scope; triage separately.
-- **1 pre-existing collection error**: `tests/test_pulse_sleuth_scope.py` — `pulse.py`
-  imports `requests`, which is **not** a declared dependency in `pyproject.toml`.
-  Undeclared-dependency bug → folded into Phase 10.
+- **285 passed** at capture. Now **290 passed** — Phase 3b added 4 migration tests
+  and the `prs_synced` failure below was fixed (1 more test now runs green).
+- ~~**1 pre-existing failure**: `test_github_knowledge::test_sync_persists_…` —
+  `prs_synced 0 != 1`.~~ **Resolved** — it was a time-fragile fixture (a hardcoded
+  April-2026 PR date drifted past the 30-day cutoff), not a product bug. The fixture
+  date is now computed relative to now.
+- **1 pre-existing collection error** *(still open)*: `tests/test_pulse_sleuth_scope.py`
+  — `pulse.py` imports `requests`, which is **not** a declared dependency in
+  `pyproject.toml`. Undeclared-dependency bug → Phase 10.
 
 Acceptance for every phase: run the full suite, diff against this baseline, and confirm
 no row moved except intentionally.
@@ -145,9 +147,9 @@ no row moved except intentionally.
 - [ ] Add / pin lockfile
 - [ ] Declare `requests` in `pyproject.toml` (or remove the import from `pulse.py`) —
       see Baseline. This currently breaks `test_pulse_sleuth_scope.py` collection.
-- [ ] Fix `tests/test_github_knowledge.py::test_sync_persists_github_artifacts_and_documents`
-      — `prs_synced 0 != 1`. Pre-existing on `main`, independent of this refactor;
-      triage whether the bug is in PR sync logic or a stale fixture.
+- [x] Fix `tests/test_github_knowledge.py::test_sync_persists_github_artifacts_and_documents`
+      — `prs_synced 0 != 1`. **Done** — it was a stale (time-fragile) fixture, not a
+      PR-sync bug; the PR-summary date is now computed relative to now.
 - [ ] Audit and update docs for accuracy post-refactor
 
 ---

--- a/PROJECT/2-WORKING/CLAUDE-REFACTOR.md
+++ b/PROJECT/2-WORKING/CLAUDE-REFACTOR.md
@@ -3,9 +3,8 @@ title: Rebalance-OS Codebase Refactor
 status: in-progress
 updated: 2026-05-20
 branch: claude/refactor-codebase-tl4PQ
-phases_done: 1, 2, 4
-phases_in_progress: 3a (3 of 5 steps done — github_knowledge.py + semantic_index.py eviction remain)
-phases_pending: 3b, 6, 5, 7, 9, 10
+phases_done: 1, 2, 3, 4
+phases_pending: 6, 5, 7, 9, 10
 phases_skipped: 8
 ---
 
@@ -47,9 +46,10 @@ no row moved except intentionally.
 
 ## Phase 3a — Raw-SQL eviction + schema decomposition
 
-> Highest leverage, lowest glamour. Foundation for phases 5 and 6 — skipping this means
-> inheriting the raw-SQL sprawl in both. **Do this first.** Pure mechanical /
-> behavior-preserving work; fully covered by the existing suite.
+> ✅ **Done.** `cli.py`, `github_knowledge.py`, and `semantic_index.py` all hold
+> zero raw SQL; persistence lives entirely in the `db/` package. Highest leverage,
+> lowest glamour — the foundation for phases 5 and 6. Behavior-preserving throughout;
+> full suite held at baseline across all four steps.
 
 - [x] Split the ~312-line `ensure_github_schema` into per-table-group helpers
       (`activity` / `repo` / `artifact` / `knowledge`). Public `ensure_github_schema()`
@@ -66,25 +66,31 @@ no row moved except intentionally.
       `purge_github_repo_data` count/delete helpers. `github_items` uses named-parameter
       binding, killing the fragile `tuple(item_record.values())` dependency.
       `github_knowledge.py` now has zero raw SQL. *(commit `49c6266`)*
-- [ ] **NEXT — Step C:** Pull raw SQL out of `src/rebalance/ingest/semantic_index.py`
-      (23 statements) into a new `db/semantic.py`.
+- [x] **Step C:** Pull raw SQL out of `src/rebalance/ingest/semantic_index.py`
+      (23 statements) into a new `db/semantic.py` (19 helpers). `semantic_index.py`
+      now has zero raw SQL; the duplicate `delete_semantic_rows_for_docs` was
+      removed from `db/github.py` in favour of the canonical `db/semantic.py`
+      helper. *(commit `c9bea2d`)*
 
 ---
 
 ## Phase 3b — schema_version + migrations
 
-> Depends on 3a. **Not mechanical** — this is a design decision and must be settled
-> before any code is written.
+> ✅ **Done** *(commit `c02f88d`)*.
 
-- [ ] **Decide the migration model first.** The DB has no `schema_version` mechanism
-      today; schema is created entirely by seven idempotent `ensure_*_schema`
-      (`CREATE TABLE IF NOT EXISTS`) functions plus `ON CONFLICT REPLACE` upserts. That
-      *is* the current de-facto migration layer. Resolve explicitly: do the `ensure_*`
-      functions **stay alongside** numbered migrations, or get **replaced** by them?
-      Leaving both is the failure mode. Also pick: hand-rolled runner vs. a library
-      (e.g. `yoyo`).
-- [ ] Add a `schema_version` table + `migrations/` directory so external tools reading
-      `rebalance.db` don't break silently on column changes.
+**Decided model** (documented in `db/migrations/README.md`):
+
+- **Version 1 is the baseline** — everything the `ensure_*_schema` functions create.
+- The `ensure_*_schema` functions **stay** (not replaced by numbered migrations), so
+  all 40+ call sites are untouched. `schema.py` is frozen at the baseline; every
+  change from v2 onward is a forward-only `NNNN_*.sql` file in `db/migrations/`.
+- **Hand-rolled runner** — no new dependency; `rebalance.db` is a single local cache.
+
+- [x] Migration model decided and documented (see above).
+- [x] Added `schema_version` table, `db/migrate.py` runner (`run_migrations`,
+      `current_schema_version`, `discover_migrations`), `db/migrations/` with README,
+      and wheel `package-data` for the `.sql` files. `run_migrations` runs at the
+      start of every non-dry-run `refresh_index()`. 4 tests in `test_db_migrations.py`.
 
 ---
 

--- a/PROJECT/2-WORKING/CLAUDE-REFACTOR.md
+++ b/PROJECT/2-WORKING/CLAUDE-REFACTOR.md
@@ -1,0 +1,153 @@
+---
+title: Rebalance-OS Codebase Refactor
+status: in-progress
+updated: 2026-05-19
+branch: claude/refactor-codebase-tl4PQ
+phases_done: 1, 2, 4
+phases_pending: 3a, 3b, 6, 5, 7, 9, 10
+phases_skipped: 8
+---
+
+# Rebalance-OS Codebase Refactor
+
+## Table of Contents
+
+- [Baseline & acceptance bar](#baseline--acceptance-bar)
+- [Phase 3a — Raw-SQL eviction + schema decomposition](#phase-3a--raw-sql-eviction--schema-decomposition)
+- [Phase 3b — schema_version + migrations](#phase-3b--schema_version--migrations)
+- [Phase 6 — MCP server registry + Pydantic response models](#phase-6--mcp-server-registry--pydantic-response-models)
+- [Phase 5 — CLI decomposition](#phase-5--cli-decomposition)
+- [Phase 7 — Config + secrets consolidation](#phase-7--config--secrets-consolidation)
+- [Phase 9 — Scripts + experimental triage](#phase-9--scripts--experimental-triage)
+- [Phase 10 — Docs + manifest + lockfile reconcile](#phase-10--docs--manifest--lockfile-reconcile)
+- [Phase 8 — Scheduler template consolidation *(skippable)*](#phase-8--scheduler-template-consolidation-skippable)
+- [Deferred micro-cleanups (P1/P2 tail)](#deferred-micro-cleanups-p1p2-tail)
+
+---
+
+## Baseline & acceptance bar
+
+Captured 2026-05-19 on `claude/refactor-codebase-tl4PQ` (`.venv/bin/python -m pytest -q
+--continue-on-collection-errors`). Every phase is behavior-preserving: it must leave
+this exactly as-is — no *new* failures.
+
+- **285 passed.**
+- **1 pre-existing failure** (also fails on `main`, not introduced by this refactor):
+  `tests/test_github_knowledge.py::test_sync_persists_github_artifacts_and_documents`
+  — `prs_synced 0 != 1`. Real bug, out of refactor scope; triage separately.
+- **1 pre-existing collection error**: `tests/test_pulse_sleuth_scope.py` — `pulse.py`
+  imports `requests`, which is **not** a declared dependency in `pyproject.toml`.
+  Undeclared-dependency bug → folded into Phase 10.
+
+Acceptance for every phase: run the full suite, diff against this baseline, and confirm
+no row moved except intentionally.
+
+---
+
+## Phase 3a — Raw-SQL eviction + schema decomposition
+
+> Highest leverage, lowest glamour. Foundation for phases 5 and 6 — skipping this means
+> inheriting the raw-SQL sprawl in both. **Do this first.** Pure mechanical /
+> behavior-preserving work; fully covered by the existing suite.
+
+- [ ] Split the ~312-line `ensure_github_schema` in `src/rebalance/ingest/db.py` into
+      per-table-group helpers (`activity` / `repo` / `artifact` / `knowledge`). Public
+      `ensure_github_schema()` stays as the unchanged entry point that calls them.
+- [ ] Pull raw SQL out of `src/rebalance/cli.py` (`_raw_*` helpers) into typed `db.py`
+      helpers.
+- [ ] Pull raw SQL out of `src/rebalance/ingest/github_knowledge.py` into typed `db.py`
+      helpers. **Note:** this file is 1,177 lines — the largest non-CLI module in the
+      repo. SQL eviction is the 3a scope; flag whether a broader decomposition belongs
+      in its own phase.
+- [ ] Pull raw SQL out of `src/rebalance/ingest/semantic_index.py` into typed `db.py`
+      helpers.
+
+---
+
+## Phase 3b — schema_version + migrations
+
+> Depends on 3a. **Not mechanical** — this is a design decision and must be settled
+> before any code is written.
+
+- [ ] **Decide the migration model first.** The DB has no `schema_version` mechanism
+      today; schema is created entirely by seven idempotent `ensure_*_schema`
+      (`CREATE TABLE IF NOT EXISTS`) functions plus `ON CONFLICT REPLACE` upserts. That
+      *is* the current de-facto migration layer. Resolve explicitly: do the `ensure_*`
+      functions **stay alongside** numbered migrations, or get **replaced** by them?
+      Leaving both is the failure mode. Also pick: hand-rolled runner vs. a library
+      (e.g. `yoyo`).
+- [ ] Add a `schema_version` table + `migrations/` directory so external tools reading
+      `rebalance.db` don't break silently on column changes.
+
+---
+
+## Phase 6 — MCP server registry + Pydantic response models
+
+> Primary external-facing API — agents (Claude, Codex, Gemini) hit this surface
+> directly. Unblocks clean tool additions without merge conflicts. Do before CLI
+> decomposition.
+
+- [ ] Split the 826-line `create_server()` god-function (`src/rebalance/mcp_server.py`,
+      25 inline `@mcp.tool()` defs) into an `mcp/` package with a tool registry.
+- [ ] Add typed Pydantic response models.
+- [ ] Wire new response models to all existing MCP tools.
+- [ ] **Reconsider `response_version`.** A version field on every response is
+      speculative churn unless there is a concrete breaking-change roadmap. Typed models
+      alone deliver ~90% of the value. Add the field only if a real consumer needs it.
+
+---
+
+## Phase 5 — CLI decomposition
+
+- [ ] Split `cli.py` (~2,626 lines) into a `cli/` package — one subcommand group per
+      file (`refresh.py`, `github.py`, `calendar.py`, `semantic.py`, `raw.py`, etc.)
+- [ ] Shrink the 186-line `refresh_cmd` by delegating to `refresh_index()`
+
+---
+
+## Phase 7 — Config + secrets consolidation
+
+- [ ] Route all credential reads through `config.py`
+- [ ] Add `rebalance config doctor` command
+
+---
+
+## Phase 9 — Scripts + experimental triage
+
+- [ ] Deduplicate `scripts/dashboard.py` ↔ `scripts/pulse_web.py` *(fetch guards in
+      `dashboard.py` already fixed — remaining: shared fetch module)*
+- [ ] Promote `git-pulse` to first-class module. It is **actively maintained** (renamed
+      from the old `git-history` spike, functional: hourly launchd collector, health
+      checks, recap generation) — this is a promotion, not a rescue.
+- [ ] **Inventory experimental spikes before deleting anything.** Produce the list
+      first, confirm each is dead, *then* delete. Known dead-spike candidate so far:
+      `temp/bash_script_rag_spike.py` (note: `temp/` is gitignored, so the actual
+      delete surface may be thin).
+
+---
+
+## Phase 10 — Docs + manifest + lockfile reconcile
+
+- [ ] Reconcile `manifest.json` against installed package versions
+- [ ] Add / pin lockfile
+- [ ] Declare `requests` in `pyproject.toml` (or remove the import from `pulse.py`) —
+      see Baseline. This currently breaks `test_pulse_sleuth_scope.py` collection.
+- [ ] Audit and update docs for accuracy post-refactor
+
+---
+
+## Phase 8 — Scheduler template consolidation *(skippable)*
+
+> Only worth doing if adding a new scheduler. Don't schedule proactively.
+
+- [ ] Collapse 6 plist templates + 10 install scripts into one generator
+
+---
+
+## Deferred micro-cleanups (P1/P2 tail)
+
+> Moved out of Phase 3 — unrelated to DB work. Each is a small standalone commit; do
+> anytime, blocks nothing.
+
+- [ ] Sweep `print`/`echo` calls → `logger` *(deferred from Phase 1)*
+- [ ] Consolidate `_parse_iso` / `_truncate` time helpers *(deferred from Phase 2)*

--- a/PROJECT/2-WORKING/CLAUDE-REFACTOR.md
+++ b/PROJECT/2-WORKING/CLAUDE-REFACTOR.md
@@ -1,10 +1,11 @@
 ---
 title: Rebalance-OS Codebase Refactor
 status: in-progress
-updated: 2026-05-19
+updated: 2026-05-20
 branch: claude/refactor-codebase-tl4PQ
 phases_done: 1, 2, 4
-phases_pending: 3a, 3b, 6, 5, 7, 9, 10
+phases_in_progress: 3a (3 of 5 steps done — github_knowledge.py + semantic_index.py eviction remain)
+phases_pending: 3b, 6, 5, 7, 9, 10
 phases_skipped: 8
 ---
 
@@ -50,17 +51,24 @@ no row moved except intentionally.
 > inheriting the raw-SQL sprawl in both. **Do this first.** Pure mechanical /
 > behavior-preserving work; fully covered by the existing suite.
 
-- [ ] Split the ~312-line `ensure_github_schema` in `src/rebalance/ingest/db.py` into
-      per-table-group helpers (`activity` / `repo` / `artifact` / `knowledge`). Public
-      `ensure_github_schema()` stays as the unchanged entry point that calls them.
-- [ ] Pull raw SQL out of `src/rebalance/cli.py` (`_raw_*` helpers) into typed `db.py`
-      helpers.
-- [ ] Pull raw SQL out of `src/rebalance/ingest/github_knowledge.py` into typed `db.py`
-      helpers. **Note:** this file is 1,177 lines — the largest non-CLI module in the
-      repo. SQL eviction is the 3a scope; flag whether a broader decomposition belongs
-      in its own phase.
-- [ ] Pull raw SQL out of `src/rebalance/ingest/semantic_index.py` into typed `db.py`
-      helpers.
+- [x] Split the ~312-line `ensure_github_schema` into per-table-group helpers
+      (`activity` / `repo` / `artifact` / `knowledge`). Public `ensure_github_schema()`
+      stays as the unchanged entry point. *(commit `e7eb40b`)*
+- [x] Pull raw SQL out of `src/rebalance/cli.py` (`_raw_*` helpers) into typed db
+      helpers (`top_active_repos`, `repo_last_active`, `repo_meta_names`). `cli.py` now
+      has zero raw `sqlite3`. *(commit `e7eb40b`)*
+- [x] Convert the single `db.py` into a `db/` package — `connection.py` / `schema.py` /
+      `github.py`, with `db/__init__.py` re-exporting the full public API so all 40+
+      importers keep working unchanged. *(commit `bd330c0`)*
+- [ ] **NEXT — Step B:** Pull raw SQL out of `src/rebalance/ingest/github_knowledge.py`
+      (45 statements) into `db/github.py`. Plan: ~12 `upsert_*` helpers (one per
+      `github_*` table), `insert_document`, `delete_item_children`, plus the
+      `purge_github_repo_data` count/delete helpers. Use named-parameter binding for
+      `github_items` to kill the fragile `tuple(item_record.values())` ordering
+      dependency. **Note:** this file is 1,177 lines — largest non-CLI module; SQL
+      eviction is the 3a scope, broader decomposition is a separate phase.
+- [ ] **Step C:** Pull raw SQL out of `src/rebalance/ingest/semantic_index.py`
+      (23 statements) into a new `db/semantic.py`.
 
 ---
 

--- a/PROJECT/2-WORKING/CLAUDE-REFACTOR.md
+++ b/PROJECT/2-WORKING/CLAUDE-REFACTOR.md
@@ -65,7 +65,7 @@ no row moved except intentionally.
       `delete_item_children`, `search_github_documents`, the embed helpers, and the
       `purge_github_repo_data` count/delete helpers. `github_items` uses named-parameter
       binding, killing the fragile `tuple(item_record.values())` dependency.
-      `github_knowledge.py` now has zero raw SQL. *(commit `f9e7462`)*
+      `github_knowledge.py` now has zero raw SQL. *(commit `49c6266`)*
 - [ ] **NEXT — Step C:** Pull raw SQL out of `src/rebalance/ingest/semantic_index.py`
       (23 statements) into a new `db/semantic.py`.
 

--- a/PROJECT/2-WORKING/CLAUDE-REFACTOR.md
+++ b/PROJECT/2-WORKING/CLAUDE-REFACTOR.md
@@ -60,14 +60,13 @@ no row moved except intentionally.
 - [x] Convert the single `db.py` into a `db/` package — `connection.py` / `schema.py` /
       `github.py`, with `db/__init__.py` re-exporting the full public API so all 40+
       importers keep working unchanged. *(commit `bd330c0`)*
-- [ ] **NEXT — Step B:** Pull raw SQL out of `src/rebalance/ingest/github_knowledge.py`
-      (45 statements) into `db/github.py`. Plan: ~12 `upsert_*` helpers (one per
-      `github_*` table), `insert_document`, `delete_item_children`, plus the
-      `purge_github_repo_data` count/delete helpers. Use named-parameter binding for
-      `github_items` to kill the fragile `tuple(item_record.values())` ordering
-      dependency. **Note:** this file is 1,177 lines — largest non-CLI module; SQL
-      eviction is the 3a scope, broader decomposition is a separate phase.
-- [ ] **Step C:** Pull raw SQL out of `src/rebalance/ingest/semantic_index.py`
+- [x] **Step B:** Pull raw SQL out of `src/rebalance/ingest/github_knowledge.py`
+      (47 statements) into `db/github.py` — 10 `upsert_*` helpers, `insert_github_document`,
+      `delete_item_children`, `search_github_documents`, the embed helpers, and the
+      `purge_github_repo_data` count/delete helpers. `github_items` uses named-parameter
+      binding, killing the fragile `tuple(item_record.values())` dependency.
+      `github_knowledge.py` now has zero raw SQL. *(commit `f9e7462`)*
+- [ ] **NEXT — Step C:** Pull raw SQL out of `src/rebalance/ingest/semantic_index.py`
       (23 statements) into a new `db/semantic.py`.
 
 ---
@@ -140,6 +139,9 @@ no row moved except intentionally.
 - [ ] Add / pin lockfile
 - [ ] Declare `requests` in `pyproject.toml` (or remove the import from `pulse.py`) —
       see Baseline. This currently breaks `test_pulse_sleuth_scope.py` collection.
+- [ ] Fix `tests/test_github_knowledge.py::test_sync_persists_github_artifacts_and_documents`
+      — `prs_synced 0 != 1`. Pre-existing on `main`, independent of this refactor;
+      triage whether the bug is in PR sync logic or a stale fixture.
 - [ ] Audit and update docs for accuracy post-refactor
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,10 @@ calendar = [
 embeddings = [
   "mlx-embeddings>=0.1.0",
 ]
+server = [
+  "fastapi>=0.110.0",
+  "uvicorn[standard]>=0.29.0",
+]
 
 [project.scripts]
 rebalance = "rebalance.cli:app"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,7 @@ package-dir = {"" = "src"}
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools.package-data]
+# Ship SQL migration files inside the wheel so run_migrations() can find them.
+"rebalance.ingest.db" = ["migrations/*.sql"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rebalance-os"
-version = "0.30.0"
+version = "0.31.0"
 description = "Local-first workday operating system with MCP tools and Obsidian ingest"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/dashboard.py
+++ b/scripts/dashboard.py
@@ -309,23 +309,26 @@ def fetch_watched_summary(now: datetime) -> dict[str, Any]:
     fresh = stale = never = 0
     last_synced_overall: datetime | None = None
     if watched:
-        with db_connection(DB_PATH) as conn:
-            placeholders = ",".join("?" * len(watched))
-            rows = conn.execute(
-                f"""
-                SELECT repo_full_name, MAX(fetched_at) AS last_synced
-                FROM (
-                    SELECT repo_full_name, fetched_at FROM github_items
-                    UNION ALL
-                    SELECT repo_full_name, fetched_at FROM github_commits
-                    UNION ALL
-                    SELECT repo_full_name, fetched_at FROM github_repo_meta
-                )
-                WHERE LOWER(repo_full_name) IN ({placeholders})
-                GROUP BY LOWER(repo_full_name)
-                """,
-                tuple(r.lower() for r in watched),
-            ).fetchall()
+        try:
+            with db_connection(DB_PATH) as conn:
+                placeholders = ",".join("?" * len(watched))
+                rows = conn.execute(
+                    f"""
+                    SELECT repo_full_name, MAX(fetched_at) AS last_synced
+                    FROM (
+                        SELECT repo_full_name, fetched_at FROM github_items
+                        UNION ALL
+                        SELECT repo_full_name, fetched_at FROM github_commits
+                        UNION ALL
+                        SELECT repo_full_name, fetched_at FROM github_repo_meta
+                    )
+                    WHERE LOWER(repo_full_name) IN ({placeholders})
+                    GROUP BY LOWER(repo_full_name)
+                    """,
+                    tuple(r.lower() for r in watched),
+                ).fetchall()
+        except Exception:  # noqa: BLE001 — empty DB before first sync
+            rows = []
         seen = {r["repo_full_name"].lower(): r["last_synced"] for r in rows}
         for repo in watched:
             ts = seen.get(repo.lower())
@@ -362,33 +365,36 @@ def fetch_recent_github(limit: int = 9) -> list[dict[str, Any]]:
         ignored_clause = f"WHERE LOWER(repo_full_name) NOT IN ({placeholders})"
         params.extend(ignored)
 
-    with db_connection(DB_PATH) as conn:
-        rows = conn.execute(
-            f"""
-            SELECT kind, sub, repo_full_name, num, detail, ts, who, html_url FROM (
-                SELECT 'item' AS kind, item_type AS sub, repo_full_name,
-                       number AS num, title AS detail, updated_at AS ts,
-                       author_login AS who, html_url
-                FROM github_items
-                WHERE updated_at IS NOT NULL
-                UNION ALL
-                SELECT 'commit', '', repo_full_name, item_number, message,
-                       committed_at, author_login, html_url
-                FROM github_commits
-                WHERE committed_at IS NOT NULL
-                UNION ALL
-                SELECT 'comment', comment_type, repo_full_name, item_number,
-                       body, created_at, author_login, html_url
-                FROM github_comments
-                WHERE created_at IS NOT NULL
-            )
-            {ignored_clause}
-            ORDER BY ts DESC
-            LIMIT ?
-            """,
-            (*params, limit),
-        ).fetchall()
-    return [dict(r) for r in rows]
+    try:
+        with db_connection(DB_PATH) as conn:
+            rows = conn.execute(
+                f"""
+                SELECT kind, sub, repo_full_name, num, detail, ts, who, html_url FROM (
+                    SELECT 'item' AS kind, item_type AS sub, repo_full_name,
+                           number AS num, title AS detail, updated_at AS ts,
+                           author_login AS who, html_url
+                    FROM github_items
+                    WHERE updated_at IS NOT NULL
+                    UNION ALL
+                    SELECT 'commit', '', repo_full_name, item_number, message,
+                           committed_at, author_login, html_url
+                    FROM github_commits
+                    WHERE committed_at IS NOT NULL
+                    UNION ALL
+                    SELECT 'comment', comment_type, repo_full_name, item_number,
+                           body, created_at, author_login, html_url
+                    FROM github_comments
+                    WHERE created_at IS NOT NULL
+                )
+                {ignored_clause}
+                ORDER BY ts DESC
+                LIMIT ?
+                """,
+                (*params, limit),
+            ).fetchall()
+        return [dict(r) for r in rows]
+    except Exception:  # noqa: BLE001 — empty DB before first sync
+        return []
 
 
 def fetch_repo_activity_counts(days: int = 7, limit: int = 12) -> list[dict[str, Any]]:
@@ -401,45 +407,51 @@ def fetch_repo_activity_counts(days: int = 7, limit: int = 12) -> list[dict[str,
         ignored_clause = f"WHERE LOWER(repo_full_name) NOT IN ({placeholders})"
         params.extend(ignored)
     params.append(limit)
-    with db_connection(DB_PATH) as conn:
-        rows = conn.execute(
-            f"""
-            SELECT repo_full_name, COUNT(*) AS events FROM (
-                SELECT repo_full_name FROM github_items
-                  WHERE updated_at IS NOT NULL
-                    AND updated_at >= datetime('now', ?)
-                UNION ALL
-                SELECT repo_full_name FROM github_commits
-                  WHERE committed_at IS NOT NULL
-                    AND committed_at >= datetime('now', ?)
-                UNION ALL
-                SELECT repo_full_name FROM github_comments
-                  WHERE created_at IS NOT NULL
-                    AND created_at >= datetime('now', ?)
-            )
-            {ignored_clause}
-            GROUP BY repo_full_name
-            ORDER BY events DESC
-            LIMIT ?
-            """,
-            tuple(params),
-        ).fetchall()
-    return [dict(r) for r in rows]
+    try:
+        with db_connection(DB_PATH) as conn:
+            rows = conn.execute(
+                f"""
+                SELECT repo_full_name, COUNT(*) AS events FROM (
+                    SELECT repo_full_name FROM github_items
+                      WHERE updated_at IS NOT NULL
+                        AND updated_at >= datetime('now', ?)
+                    UNION ALL
+                    SELECT repo_full_name FROM github_commits
+                      WHERE committed_at IS NOT NULL
+                        AND committed_at >= datetime('now', ?)
+                    UNION ALL
+                    SELECT repo_full_name FROM github_comments
+                      WHERE created_at IS NOT NULL
+                        AND created_at >= datetime('now', ?)
+                )
+                {ignored_clause}
+                GROUP BY repo_full_name
+                ORDER BY events DESC
+                LIMIT ?
+                """,
+                tuple(params),
+            ).fetchall()
+        return [dict(r) for r in rows]
+    except Exception:  # noqa: BLE001 — empty DB before first sync
+        return []
 
 
 def fetch_vault_recent(limit: int = 6) -> list[dict[str, Any]]:
-    with db_connection(DB_PATH) as conn:
-        rows = conn.execute(
-            """
-            SELECT title, rel_path, last_modified
-            FROM vault_files
-            WHERE last_modified IS NOT NULL
-            ORDER BY last_modified DESC
-            LIMIT ?
-            """,
-            (limit,),
-        ).fetchall()
-    return [dict(r) for r in rows]
+    try:
+        with db_connection(DB_PATH) as conn:
+            rows = conn.execute(
+                """
+                SELECT title, rel_path, last_modified
+                FROM vault_files
+                WHERE last_modified IS NOT NULL
+                ORDER BY last_modified DESC
+                LIMIT ?
+                """,
+                (limit,),
+            ).fetchall()
+        return [dict(r) for r in rows]
+    except Exception:  # noqa: BLE001 — empty DB before first sync
+        return []
 
 
 def fetch_calendar_upcoming(now: datetime, limit: int = 4) -> list[dict[str, Any]]:
@@ -538,18 +550,21 @@ def fetch_sleuth_due(limit: int = 4) -> list[dict[str, Any]]:
 
 
 def fetch_recent_emails(limit: int = 30) -> list[dict[str, Any]]:
-    with db_connection(DB_PATH) as conn:
-        rows = conn.execute(
-            """
-            SELECT message_id, thread_id, from_name, from_address, subject, snippet, received_at, labels_json
-            FROM email_messages
-            WHERE received_at IS NOT NULL
-            ORDER BY received_at DESC
-            LIMIT ?
-            """,
-            (limit,),
-        ).fetchall()
-    return [dict(r) for r in rows]
+    try:
+        with db_connection(DB_PATH) as conn:
+            rows = conn.execute(
+                """
+                SELECT message_id, thread_id, from_name, from_address, subject, snippet, received_at, labels_json
+                FROM email_messages
+                WHERE received_at IS NOT NULL
+                ORDER BY received_at DESC
+                LIMIT ?
+                """,
+                (limit,),
+            ).fetchall()
+        return [dict(r) for r in rows]
+    except Exception:  # noqa: BLE001 — empty DB before first sync
+        return []
 
 
 # ---------------------------------------------------------------------------

--- a/src/rebalance/__init__.py
+++ b/src/rebalance/__init__.py
@@ -1,4 +1,40 @@
-"""rebalance package."""
+"""rebalance package.
+
+Installs a process-wide logging handler on import so any module that does
+``logger = logging.getLogger(__name__)`` gets routed output without each
+entry point reconfiguring logging. Verbosity is controlled by the
+``REBALANCE_LOG_LEVEL`` environment variable (DEBUG / INFO / WARNING /
+ERROR / CRITICAL); default is WARNING so production CLI output stays
+clean. User-facing CLI output continues to go through ``typer.echo``;
+``logging`` is for diagnostics only.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
 
 __all__ = ["__version__"]
 __version__ = "0.30.0"
+
+
+def _configure_logging() -> None:
+    root = logging.getLogger("rebalance")
+    if getattr(root, "_rebalance_configured", False):
+        return
+    level_name = os.environ.get("REBALANCE_LOG_LEVEL", "WARNING").upper()
+    level = getattr(logging, level_name, logging.WARNING)
+    handler = logging.StreamHandler()
+    handler.setFormatter(
+        logging.Formatter(
+            "%(asctime)s %(levelname)s %(name)s: %(message)s",
+            datefmt="%H:%M:%S",
+        )
+    )
+    root.addHandler(handler)
+    root.setLevel(level)
+    root.propagate = False
+    root._rebalance_configured = True  # type: ignore[attr-defined]
+
+
+_configure_logging()

--- a/src/rebalance/cli.py
+++ b/src/rebalance/cli.py
@@ -32,6 +32,7 @@ from rebalance.ingest.config import (
 from rebalance.ingest.audit import append_audit_entry
 from rebalance.paths import (
     DatabaseNotFoundError,
+    DBOption,
     resolve_database_path,
     resolve_secret_path,
 )
@@ -672,7 +673,7 @@ def ingest_sync(
 
 @ingest_app.command("infer-project-registry")
 def ingest_infer_project_registry(
-    database: Path | None = typer.Option(None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"),
+    database: Path | None = DBOption(),
     calendar_days_back: int = typer.Option(90, help="How many calendar days back to use for inference"),
     calendar_days_forward: int = typer.Option(14, help="How many calendar days forward to include for meeting signals"),
     dry_run: bool = typer.Option(False, help="Preview inferred project rows without writing to project_registry"),
@@ -726,9 +727,7 @@ def ingest_infer_project_registry(
 def github_scan(
     token: str = typer.Option(..., envvar="GITHUB_TOKEN", help="GitHub Personal Access Token"),
     days: int = typer.Option(30, help="Number of days to look back (supports 30-day A/B/C band classification)"),
-    database: Path | None = typer.Option(
-        None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"
-    ),
+    database: Path | None = DBOption(),
 ) -> None:
     """Fetch GitHub activity and persist to database for use by github_balance MCP tool."""
     from rebalance.ingest.github_scan import (
@@ -1156,9 +1155,7 @@ def raw(
         10, "--top",
         help="How many of the most-active watched repos to scan for team activity (cost: 1 GH API request per repo per probe).",
     ),
-    database: Path | None = typer.Option(
-        None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"
-    ),
+    database: Path | None = DBOption(),
 ) -> None:
     """Calibration view: GitHub events from the last N minutes vs local pipeline state.
 
@@ -1229,9 +1226,7 @@ def github_sync_artifacts(
     ),
     token: str = typer.Option("", envvar="GITHUB_TOKEN", help="GitHub Personal Access Token"),
     days: int = typer.Option(90, help="Lookback window for changed issues and PRs"),
-    database: Path | None = typer.Option(
-        None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"
-    ),
+    database: Path | None = DBOption(),
 ) -> None:
     """Sync detailed GitHub issues, PRs, comments, reviews, checks, and releases."""
     from rebalance.ingest.github_knowledge import sync_github_repo
@@ -1279,9 +1274,7 @@ def github_sync_artifacts(
 
 @app.command("github-embed")
 def github_embed(
-    database: Path | None = typer.Option(
-        None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"
-    ),
+    database: Path | None = DBOption(),
     model: str = typer.Option("Qwen/Qwen3-Embedding-0.6B", help="HuggingFace model name"),
     batch_size: int = typer.Option(32, help="Batch size for embedding"),
     min_chars: int = typer.Option(40, help="Minimum document length to embed"),
@@ -1314,7 +1307,7 @@ def github_embed(
 @ingest_app.command("notes")
 def ingest_notes(
     vault: Path = typer.Option(..., exists=True, file_okay=False, dir_okay=True, help="Path to Obsidian vault"),
-    database: Path | None = typer.Option(None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"),
+    database: Path | None = DBOption(),
     exclude: list[str] = typer.Option(
         [".obsidian/*", ".trash/*", "node_modules/*", ".git/*", ".venv/*", "*/.venv/*"],
         help="Glob patterns to exclude",
@@ -1347,7 +1340,7 @@ def ingest_notes(
 
 @ingest_app.command("embed")
 def ingest_embed(
-    database: Path | None = typer.Option(None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"),
+    database: Path | None = DBOption(),
     model: str = typer.Option("Qwen/Qwen3-Embedding-0.6B", help="HuggingFace model name"),
     batch_size: int = typer.Option(32, help="Batch size for embedding (lower = less memory)"),
     force: bool = typer.Option(False, help="Force re-embed all chunks (use after model change)"),
@@ -1378,7 +1371,7 @@ def ingest_embed(
 @app.command("query")
 def query_cmd(
     text: str = typer.Argument(..., help="Natural language query"),
-    database: Path | None = typer.Option(None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"),
+    database: Path | None = DBOption(),
     top_k: int = typer.Option(10, help="Number of results to return"),
     model: str = typer.Option("Qwen/Qwen3-Embedding-0.6B", help="Embedding model for query"),
 ) -> None:
@@ -1405,9 +1398,7 @@ def query_cmd(
 @app.command("github-query")
 def github_query_cmd(
     text: str = typer.Argument(..., help="Natural language query"),
-    database: Path | None = typer.Option(
-        None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"
-    ),
+    database: Path | None = DBOption(),
     repo: str = typer.Option("", help="Optional owner/name repo filter"),
     top_k: int = typer.Option(8, help="Number of results to return"),
     model: str = typer.Option("Qwen/Qwen3-Embedding-0.6B", help="Embedding model for query"),
@@ -1460,9 +1451,7 @@ def semantic_backfill_cmd(
         "--repo",
         help="Optional owner/name filter when backfilling GitHub semantic documents.",
     ),
-    database: Path | None = typer.Option(
-        None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"
-    ),
+    database: Path | None = DBOption(),
 ) -> None:
     """Populate the unified semantic document layer from existing source tables."""
     from rebalance.ingest.semantic_index import backfill_semantic_documents
@@ -1494,9 +1483,7 @@ def semantic_embed_cmd(
         "--source",
         help="Source family to embed. Repeat for multiple values.",
     ),
-    database: Path | None = typer.Option(
-        None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"
-    ),
+    database: Path | None = DBOption(),
     model: str = typer.Option("Qwen/Qwen3-Embedding-0.6B", help="HuggingFace model name"),
     batch_size: int = typer.Option(32, help="Batch size for embedding"),
     min_chars: int = typer.Option(1, help="Minimum document length to embed"),
@@ -1539,9 +1526,7 @@ def semantic_query_cmd(
         "--source",
         help="Source family to search. Repeat for multiple values.",
     ),
-    database: Path | None = typer.Option(
-        None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"
-    ),
+    database: Path | None = DBOption(),
     top_k: int = typer.Option(10, help="Number of results to return"),
     model: str = typer.Option("Qwen/Qwen3-Embedding-0.6B", help="Embedding model for query"),
 ) -> None:
@@ -1588,9 +1573,7 @@ def semantic_query_cmd(
 def github_release_readiness_cmd(
     repo: str = typer.Option(..., "--repo", help="Repo in owner/name form"),
     milestone: str = typer.Option("", "--milestone", help="Optional milestone title"),
-    database: Path | None = typer.Option(
-        None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"
-    ),
+    database: Path | None = DBOption(),
     output_format: str = typer.Option("text", "--output", help="Output format: text or json"),
 ) -> None:
     """Infer current release/readiness state from the local GitHub corpus."""
@@ -1643,9 +1626,7 @@ def github_release_readiness_cmd(
 @app.command("github-close-candidates")
 def github_close_candidates_cmd(
     repo: str = typer.Option(..., "--repo", help="Repo in owner/name form"),
-    database: Path | None = typer.Option(
-        None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"
-    ),
+    database: Path | None = DBOption(),
     output_format: str = typer.Option("text", "--output", help="Output format: text or json"),
 ) -> None:
     """Suggest open issues that likely map to merged PRs and may be ready to close."""
@@ -1704,7 +1685,7 @@ def github_close_candidates_cmd(
 @app.command("search")
 def search_cmd(
     keyword: str = typer.Argument(..., help="Keyword to search"),
-    database: Path | None = typer.Option(None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"),
+    database: Path | None = DBOption(),
     limit: int = typer.Option(20, help="Max results"),
 ) -> None:
     """Full-text keyword search over vault files and chunks."""
@@ -1729,7 +1710,7 @@ def search_cmd(
 @app.command("ask")
 def ask_cmd(
     text: str = typer.Argument(..., help="Natural language question"),
-    database: Path | None = typer.Option(None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"),
+    database: Path | None = DBOption(),
     days: int = typer.Option(7, help="Activity window in days"),
     no_llm: bool = typer.Option(False, help="Skip local LLM synthesis, return raw context only"),
     chat_model: str = typer.Option("Qwen/Qwen3-0.6B", help="Chat model for synthesis"),
@@ -1797,7 +1778,7 @@ def ask_cmd(
 
 @app.command("calendar-sync")
 def calendar_sync_cmd(
-    database: Path | None = typer.Option(None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"),
+    database: Path | None = DBOption(),
     calendar_id: str = typer.Option("", help="Calendar ID or email (default: from config, then 'primary')"),
     days_back: int = typer.Option(30, help="Days back to fetch (use 365 for initial backfill)"),
     days_forward: int = typer.Option(7, help="Days forward to fetch"),
@@ -1937,7 +1918,7 @@ def calendar_create_event_cmd(
 
 @app.command("calendar-daily-totals")
 def calendar_daily_totals_cmd(
-    database: Path | None = typer.Option(None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"),
+    database: Path | None = DBOption(),
     days_back: int = typer.Option(30, help="Days back to show"),
     days_forward: int = typer.Option(0, help="Days forward to show"),
 ) -> None:
@@ -2084,7 +2065,7 @@ def calendar_snap_edges_cmd(
 
 @app.command("calendar-daily-report")
 def calendar_daily_report_cmd(
-    database: Path | None = typer.Option(None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"),
+    database: Path | None = DBOption(),
     date_str: str = typer.Option(None, "--date", help="Date to report on (YYYY-MM-DD, default: today)"),
     output: Path = typer.Option(None, "--output", "-o", help="Write report to a markdown file instead of stdout"),
 ) -> None:
@@ -2118,7 +2099,7 @@ def calendar_daily_report_cmd(
 
 @app.command("calendar-weekly-report")
 def calendar_weekly_report_cmd(
-    database: Path | None = typer.Option(None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"),
+    database: Path | None = DBOption(),
     date_str: str = typer.Option(None, "--date", help="Date in target week (YYYY-MM-DD, default: today)"),
     output: Path = typer.Option(None, "--output", "-o", help="Write report to a markdown file instead of stdout"),
     vault: Path = typer.Option(None, "--vault", envvar="REBALANCE_VAULT", help="Obsidian vault path for weekly note write-back"),
@@ -2187,7 +2168,7 @@ def calendar_weekly_report_cmd(
 
 @app.command("dashboard-render")
 def dashboard_render_cmd(
-    database: Path | None = typer.Option(None, envvar="REBALANCE_DB", help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)"),
+    database: Path | None = DBOption(),
     date_str: str = typer.Option(None, "--date", help="Date anchoring the dashboard window (YYYY-MM-DD, default: today)"),
     since_days: int = typer.Option(14, "--since-days", min=1, help="Lookback window for recent signals"),
     vault: Path = typer.Option(None, "--vault", envvar="REBALANCE_VAULT", help="Obsidian vault path for dashboard note write-back"),
@@ -2280,12 +2261,7 @@ def sleuth_sync_cmd(
         "--active-only/--all",
         help="Only fetch currently active reminders (default: all)",
     ),
-    database: Path | None = typer.Option(
-        None,
-        "--database-path",
-        envvar="REBALANCE_DB",
-        help="SQLite database path (resolves via layered chain — see `rebalance config show-defaults`)",
-    ),
+    database: Path | None = DBOption("--database-path"),
     json_output: bool = typer.Option(False, "--json", help="Emit full sync result as JSON"),
 ) -> None:
     """Pull Slack reminders from the Sleuth Web API and upsert them into SQLite."""
@@ -2331,9 +2307,7 @@ def config_add_github_ignored_repo(
     purge: bool = typer.Option(False, help="Purge existing local GitHub rows for this repo"),
     dry_run: bool = typer.Option(False, help="Preview purge counts without deleting"),
     confirm: bool = typer.Option(False, help="Confirm destructive purge execution"),
-    database: Path | None = typer.Option(
-        None, envvar="REBALANCE_DB", help="SQLite database path for purge operations (resolves via layered chain)"
-    ),
+    database: Path | None = DBOption(help="SQLite database path for purge operations (resolves via layered chain)"),
 ) -> None:
     """Add one repo to the local GitHub ingest ignore list, with optional purge."""
     from rebalance.ingest.github_knowledge import purge_github_repo_data

--- a/src/rebalance/cli.py
+++ b/src/rebalance/cli.py
@@ -794,23 +794,9 @@ def _raw_summarize_event(event: dict[str, Any]) -> str:
 
 def _raw_get_top_active_repos(db_path: Path, top_n: int) -> list[str]:
     """Top N watched repos by 7-day activity score (commits + PRs + issues + comments + reviews)."""
-    import sqlite3 as _sqlite3
-    with _sqlite3.connect(db_path) as conn:
-        rows = conn.execute(
-            """
-            SELECT repo_full_name,
-                   SUM(commits) + SUM(prs_opened) + SUM(prs_merged) +
-                   SUM(issues_opened) + SUM(issue_comments) + SUM(reviews) AS score
-            FROM github_activity
-            WHERE scan_date >= date('now', '-7 days')
-            GROUP BY repo_full_name
-            HAVING score > 0
-            ORDER BY score DESC
-            LIMIT ?
-            """,
-            (top_n,),
-        ).fetchall()
-    return [r[0] for r in rows]
+    from rebalance.ingest.db import db_connection, top_active_repos
+    with db_connection(db_path) as conn:
+        return top_active_repos(conn, top_n)
 
 
 def _raw_fetch_repo_events(repo: str, token: str, per_page: int = 30) -> list[dict[str, Any]]:
@@ -832,7 +818,6 @@ def _raw_gather_team_activity(
     N minutes and excluding the current user (those are already in the user-activity
     section).
     """
-    import sqlite3 as _sqlite3
     from datetime import datetime, timedelta, timezone
 
     cutoff = datetime.now(timezone.utc) - timedelta(minutes=minutes)
@@ -840,16 +825,10 @@ def _raw_gather_team_activity(
 
     last_active_map: dict[str, datetime] = {}
     if top_repos:
-        placeholders = ",".join("?" * len(top_repos))
-        with _sqlite3.connect(db_path) as conn:
-            rows = conn.execute(
-                f"SELECT repo_full_name, MAX(last_active_at) FROM github_activity "
-                f"WHERE repo_full_name IN ({placeholders}) "
-                f"AND last_active_at IS NOT NULL "
-                f"GROUP BY repo_full_name",
-                top_repos,
-            ).fetchall()
-        for repo, ts in rows:
+        from rebalance.ingest.db import db_connection, repo_last_active
+        with db_connection(db_path) as conn:
+            last_active_raw = repo_last_active(conn, top_repos)
+        for repo, ts in last_active_raw.items():
             try:
                 last_active_map[repo] = datetime.fromisoformat(ts.replace("Z", "+00:00"))
             except (AttributeError, ValueError):
@@ -955,7 +934,6 @@ def _raw_gather_unwatched_active_repos(
 
 def _raw_gather_snapshot(login: str, token: str, db_path: Path, minutes: int, top_n: int) -> dict[str, Any]:
     """Fetch recent GH events and classify each against local pipeline state."""
-    import sqlite3 as _sqlite3
     from datetime import datetime, timedelta, timezone
 
     from rebalance.ingest.github_scan import _fetch_events
@@ -975,14 +953,12 @@ def _raw_gather_snapshot(login: str, token: str, db_path: Path, minutes: int, to
             recent.append((t, e))
     recent.sort(key=lambda x: x[0], reverse=True)
 
-    with _sqlite3.connect(db_path) as conn:
-        watched = {row[0] for row in conn.execute("SELECT repo_full_name FROM github_repo_meta")}
-        last_active_rows = conn.execute(
-            "SELECT repo_full_name, MAX(last_active_at) FROM github_activity "
-            "WHERE last_active_at IS NOT NULL GROUP BY repo_full_name"
-        ).fetchall()
+    from rebalance.ingest.db import db_connection, repo_last_active, repo_meta_names
+    with db_connection(db_path) as conn:
+        watched = repo_meta_names(conn)
+        last_active_raw = repo_last_active(conn)
     last_active_map: dict[str, datetime] = {}
-    for repo, ts in last_active_rows:
+    for repo, ts in last_active_raw.items():
         try:
             last_active_map[repo] = datetime.fromisoformat(ts.replace("Z", "+00:00"))
         except (AttributeError, ValueError):

--- a/src/rebalance/ingest/_http.py
+++ b/src/rebalance/ingest/_http.py
@@ -132,7 +132,7 @@ class GitHubClient:
             "X-GitHub-Api-Version": _API_VERSION,
         }
 
-    def _request(self, url: str) -> tuple[int, Any, dict[str, str]]:
+    def _request(self, url: str) -> tuple[int, Any, dict[str, str], str]:
         last_status = 0
         last_body = ""
         last_headers: dict[str, str] = {}
@@ -142,7 +142,7 @@ class GitHubClient:
                 with urllib.request.urlopen(req, timeout=self.timeout) as resp:
                     body = resp.read().decode()
                     parsed = json.loads(body) if body else None
-                    return resp.status, parsed, {k.lower(): v for k, v in resp.headers.items()}
+                    return resp.status, parsed, {k.lower(): v for k, v in resp.headers.items()}, ""
             except urllib.error.HTTPError as exc:
                 last_status = exc.code
                 last_headers = {k.lower(): v for k, v in (exc.headers or {}).items()}
@@ -153,17 +153,17 @@ class GitHubClient:
 
                 retryable = last_status >= 500 or _is_rate_limit(last_status, last_headers)
                 if not retryable or attempt + 1 >= self.retries:
-                    return last_status, None, last_headers
+                    return last_status, None, last_headers, last_body
 
                 delay = _retry_after_seconds(last_headers, attempt)
                 logger.info("GitHub %s -> %s, retrying in %.1fs (attempt %d/%d)", url, last_status, delay, attempt + 1, self.retries)
                 self._sleep(delay)
-        return last_status, None, last_headers
+        return last_status, None, last_headers, last_body
 
     def get(self, path_or_url: str) -> tuple[int, Any]:
         """Return ``(status, parsed_json_or_None)``. Mirrors github_scan._get."""
         url = path_or_url if path_or_url.startswith("http") else f"{GITHUB_API}{path_or_url}"
-        status, data, _ = self._request(url)
+        status, data, _, _body = self._request(url)
         return status, data
 
     def get_with_headers(self, path_or_url: str) -> tuple[int, Any, dict[str, str]]:
@@ -173,7 +173,8 @@ class GitHubClient:
         ``X-OAuth-Scopes`` on ``/user``). Headers are lowercased.
         """
         url = path_or_url if path_or_url.startswith("http") else f"{GITHUB_API}{path_or_url}"
-        return self._request(url)
+        status, data, headers, _body = self._request(url)
+        return status, data, headers
 
     def get_json(self, path_or_url: str) -> Any:
         """Return parsed JSON or raise :class:`GitHubHTTPError`.
@@ -181,7 +182,7 @@ class GitHubClient:
         Mirrors github_knowledge._http_get_json.
         """
         url = path_or_url if path_or_url.startswith("http") else f"{GITHUB_API}{path_or_url}"
-        status, data, headers = self._request(url)
+        status, data, headers, body = self._request(url)
         if 200 <= status < 300:
             return data
         rate_limit = _is_rate_limit(status, headers)
@@ -189,7 +190,7 @@ class GitHubClient:
             f"GitHub API request failed: {status} {url}",
             status=status,
             url=url,
-            body="",
+            body=body,
             is_rate_limit=rate_limit,
         )
 

--- a/src/rebalance/ingest/_http.py
+++ b/src/rebalance/ingest/_http.py
@@ -1,0 +1,234 @@
+"""
+Shared GitHub HTTP client.
+
+Replaces three near-duplicate helpers that grew up in parallel:
+
+* ``github_scan._headers`` + ``github_scan._get``
+  — used "Authorization: token X" (v3 syntax), returned ``(status, data | None)``.
+* ``github_knowledge._github_headers`` + ``github_knowledge._http_get_json``
+  — used "Authorization: Bearer X" (GitHub's current syntax), raised
+    RuntimeError on HTTP error.
+* ``github_knowledge._paginate_list``
+  — paginated list endpoints with optional ``stop_updated_before`` cutoff.
+
+The two header forms are interchangeable at the API level (GitHub accepts both),
+but the duplication meant a fix to one path (rate-limit handling, retry logic,
+new audit fields) never reached the other. ``GitHubClient`` is the single home.
+
+Two response modes are offered so the existing call sites don't need behavior
+changes during migration:
+
+* :meth:`GitHubClient.get` — returns ``(status, data | None)``. Mirrors
+  github_scan's contract. Use when the caller wants to branch on status (e.g.
+  treat 422 as "no more pages").
+* :meth:`GitHubClient.get_json` — raises :class:`GitHubHTTPError` on any
+  non-2xx. Mirrors github_knowledge's contract.
+
+Retries: 429 / 5xx are retried with exponential backoff up to ``retries``
+attempts (jittered, honoring ``Retry-After`` when present). 4xx other than
+429 are not retried. Default ``retries=3`` matches the CLAUDE.md "respect
+GitHub 5000/hr PAT limits; sleep/retry" guidance. Tests pass ``retries=1``
+to keep them deterministic.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import random
+import time
+import urllib.error
+import urllib.request
+from typing import Any
+from urllib.parse import urlencode
+
+GITHUB_API = "https://api.github.com"
+USER_AGENT = "rebalance-os/0.30"
+_API_VERSION = "2022-11-28"
+
+logger = logging.getLogger(__name__)
+
+
+class GitHubHTTPError(RuntimeError):
+    """Raised by :meth:`GitHubClient.get_json` on non-2xx responses.
+
+    Carries the HTTP status, URL, and body excerpt so callers can build
+    structured diagnostics. ``is_rate_limit`` is True for 429 and 403
+    rate-limit responses (which GitHub returns interchangeably for PAT
+    quota exhaustion).
+    """
+
+    def __init__(self, message: str, status: int, *, url: str = "", body: str = "", is_rate_limit: bool = False):
+        super().__init__(message)
+        self.status = status
+        self.url = url
+        self.body = body
+        self.is_rate_limit = is_rate_limit
+
+
+def _is_rate_limit(status: int, response_headers: dict[str, str] | None = None) -> bool:
+    if status == 429:
+        return True
+    if status == 403 and response_headers:
+        # GitHub signals primary rate limit with x-ratelimit-remaining: 0 and
+        # secondary rate limit with retry-after present.
+        remaining = response_headers.get("x-ratelimit-remaining")
+        if remaining == "0":
+            return True
+        if "retry-after" in response_headers:
+            return True
+    return False
+
+
+def _retry_after_seconds(headers: dict[str, str], attempt: int) -> float:
+    """Compute backoff: honor Retry-After header, else exponential w/ jitter."""
+    retry_after = headers.get("retry-after")
+    if retry_after:
+        try:
+            return float(retry_after)
+        except ValueError:
+            pass
+    # Exponential backoff: 1s, 2s, 4s, capped at 16s; +/- 25% jitter.
+    base = min(2.0 ** attempt, 16.0)
+    jitter = base * 0.25 * (random.random() * 2 - 1)
+    return max(0.5, base + jitter)
+
+
+class GitHubClient:
+    """Thin wrapper over ``urllib`` with retries, pagination, and shared headers.
+
+    Parameters
+    ----------
+    token:
+        GitHub PAT or app-installation token. Sent as ``Authorization: Bearer``.
+    timeout:
+        Per-request timeout in seconds.
+    retries:
+        Max attempts on 429/5xx (including the first attempt). ``1`` = no retry.
+    sleep:
+        Test seam for the backoff sleep call.
+    """
+
+    def __init__(
+        self,
+        token: str,
+        *,
+        timeout: int = 30,
+        retries: int = 3,
+        sleep=time.sleep,
+        user_agent: str = USER_AGENT,
+    ) -> None:
+        self.token = token
+        self.timeout = timeout
+        self.retries = max(1, retries)
+        self._sleep = sleep
+        self._user_agent = user_agent
+
+    def headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.token}",
+            "Accept": "application/vnd.github+json",
+            "User-Agent": self._user_agent,
+            "X-GitHub-Api-Version": _API_VERSION,
+        }
+
+    def _request(self, url: str) -> tuple[int, Any, dict[str, str]]:
+        last_status = 0
+        last_body = ""
+        last_headers: dict[str, str] = {}
+        for attempt in range(self.retries):
+            req = urllib.request.Request(url, headers=self.headers())
+            try:
+                with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+                    body = resp.read().decode()
+                    parsed = json.loads(body) if body else None
+                    return resp.status, parsed, {k.lower(): v for k, v in resp.headers.items()}
+            except urllib.error.HTTPError as exc:
+                last_status = exc.code
+                last_headers = {k.lower(): v for k, v in (exc.headers or {}).items()}
+                try:
+                    last_body = exc.read().decode() if exc.fp else ""
+                except Exception:  # noqa: BLE001 — body read can fail mid-stream
+                    last_body = ""
+
+                retryable = last_status >= 500 or _is_rate_limit(last_status, last_headers)
+                if not retryable or attempt + 1 >= self.retries:
+                    return last_status, None, last_headers
+
+                delay = _retry_after_seconds(last_headers, attempt)
+                logger.info("GitHub %s -> %s, retrying in %.1fs (attempt %d/%d)", url, last_status, delay, attempt + 1, self.retries)
+                self._sleep(delay)
+        return last_status, None, last_headers
+
+    def get(self, path_or_url: str) -> tuple[int, Any]:
+        """Return ``(status, parsed_json_or_None)``. Mirrors github_scan._get."""
+        url = path_or_url if path_or_url.startswith("http") else f"{GITHUB_API}{path_or_url}"
+        status, data, _ = self._request(url)
+        return status, data
+
+    def get_with_headers(self, path_or_url: str) -> tuple[int, Any, dict[str, str]]:
+        """Return ``(status, parsed_json_or_None, response_headers)``.
+
+        Use when the caller needs to read response headers (e.g.
+        ``X-OAuth-Scopes`` on ``/user``). Headers are lowercased.
+        """
+        url = path_or_url if path_or_url.startswith("http") else f"{GITHUB_API}{path_or_url}"
+        return self._request(url)
+
+    def get_json(self, path_or_url: str) -> Any:
+        """Return parsed JSON or raise :class:`GitHubHTTPError`.
+
+        Mirrors github_knowledge._http_get_json.
+        """
+        url = path_or_url if path_or_url.startswith("http") else f"{GITHUB_API}{path_or_url}"
+        status, data, headers = self._request(url)
+        if 200 <= status < 300:
+            return data
+        rate_limit = _is_rate_limit(status, headers)
+        raise GitHubHTTPError(
+            f"GitHub API request failed: {status} {url}",
+            status=status,
+            url=url,
+            body="",
+            is_rate_limit=rate_limit,
+        )
+
+    @staticmethod
+    def build_url(base_url: str, **params: Any) -> str:
+        cleaned = {key: value for key, value in params.items() if value not in ("", None)}
+        if not cleaned:
+            return base_url
+        return f"{base_url}?{urlencode(cleaned, doseq=True)}"
+
+    def paginate(
+        self,
+        base_url: str,
+        *,
+        stop_updated_before: str = "",
+        per_page: int = 100,
+        **params: Any,
+    ) -> list[dict[str, Any]]:
+        """Walk a paginated list endpoint, accumulating items.
+
+        Mirrors github_knowledge._paginate_list. Stops at first page with
+        ``updated_at < stop_updated_before`` (per row, when the param is set)
+        or when a page is short of ``per_page`` items.
+        """
+        page = 1
+        results: list[dict[str, Any]] = []
+        while True:
+            url = self.build_url(base_url, per_page=per_page, page=page, **params)
+            data = self.get_json(url)
+            if not isinstance(data, list) or not data:
+                break
+            stop = False
+            for row in data:
+                updated_at = str(row.get("updated_at") or "")
+                if stop_updated_before and updated_at and updated_at < stop_updated_before:
+                    stop = True
+                    break
+                results.append(row)
+            if stop or len(data) < per_page:
+                break
+            page += 1
+        return results

--- a/src/rebalance/ingest/db.py
+++ b/src/rebalance/ingest/db.py
@@ -278,8 +278,8 @@ def ensure_email_schema(conn: sqlite3.Connection) -> None:
 # ---------------------------------------------------------------------------
 
 
-def ensure_github_schema(conn: sqlite3.Connection) -> None:
-    """Create GitHub activity and local knowledge tables if they don't exist."""
+def _ensure_github_activity_schema(conn: sqlite3.Connection) -> None:
+    """Daily per-repo/login activity rollups (powers ``github_balance``)."""
     conn.execute("""
         CREATE TABLE IF NOT EXISTS github_activity (
             id              INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -298,6 +298,10 @@ def ensure_github_schema(conn: sqlite3.Connection) -> None:
             UNIQUE(login, repo_full_name, scan_date) ON CONFLICT REPLACE
         )
     """)
+
+
+def _ensure_github_repo_schema(conn: sqlite3.Connection) -> None:
+    """Repo-level metadata: labels, repo meta, push-discovery cache, branches."""
     conn.execute("""
         CREATE TABLE IF NOT EXISTS github_labels (
             id              INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -362,6 +366,9 @@ def ensure_github_schema(conn: sqlite3.Connection) -> None:
         "ON github_branches(repo_full_name)"
     )
 
+
+def _ensure_github_artifact_schema(conn: sqlite3.Connection) -> None:
+    """Issue/PR corpus: milestones, releases, items, comments, commits, checks, links."""
     conn.execute("""
         CREATE TABLE IF NOT EXISTS github_milestones (
             id              INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -544,6 +551,9 @@ def ensure_github_schema(conn: sqlite3.Connection) -> None:
         "ON github_links(repo_full_name, source_type, source_number)"
     )
 
+
+def _ensure_github_knowledge_schema(conn: sqlite3.Connection) -> None:
+    """Embeddable GitHub documents + their vector index."""
     conn.execute("""
         CREATE TABLE IF NOT EXISTS github_documents (
             id                  INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -582,7 +592,87 @@ def ensure_github_schema(conn: sqlite3.Connection) -> None:
             value   TEXT NOT NULL
         )
     """)
+
+
+def ensure_github_schema(conn: sqlite3.Connection) -> None:
+    """Create GitHub activity and local knowledge tables if they don't exist.
+
+    Decomposed into per-table-group helpers for readability; the public
+    contract is unchanged — every group is created, then committed once.
+    """
+    _ensure_github_activity_schema(conn)
+    _ensure_github_repo_schema(conn)
+    _ensure_github_artifact_schema(conn)
+    _ensure_github_knowledge_schema(conn)
     conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# GitHub activity queries (read helpers — keep DDL above, DML below)
+# ---------------------------------------------------------------------------
+
+
+def top_active_repos(
+    conn: sqlite3.Connection, top_n: int, since_days: int = 7
+) -> list[str]:
+    """Repo full-names ranked by recent activity score, highest first.
+
+    Score sums ``commits + prs_opened + prs_merged + issues_opened +
+    issue_comments + reviews`` over the trailing *since_days* window
+    (``github_activity.scan_date``). Repos with a zero score are excluded.
+    """
+    rows = conn.execute(
+        """
+        SELECT repo_full_name,
+               SUM(commits) + SUM(prs_opened) + SUM(prs_merged) +
+               SUM(issues_opened) + SUM(issue_comments) + SUM(reviews) AS score
+        FROM github_activity
+        WHERE scan_date >= date('now', ?)
+        GROUP BY repo_full_name
+        HAVING score > 0
+        ORDER BY score DESC
+        LIMIT ?
+        """,
+        (f"-{since_days} days", top_n),
+    ).fetchall()
+    return [r[0] for r in rows]
+
+
+def repo_last_active(
+    conn: sqlite3.Connection, repos: list[str] | None = None
+) -> dict[str, str]:
+    """Map of ``repo_full_name`` -> latest ``last_active_at`` (raw ISO string).
+
+    Pass *repos* to restrict to a subset; omit it for every repo. Repos with
+    no non-null ``last_active_at`` are omitted. Timestamp parsing is left to
+    the caller — this helper only touches the database.
+    """
+    if repos is not None:
+        if not repos:
+            return {}
+        placeholders = ",".join("?" * len(repos))
+        rows = conn.execute(
+            f"SELECT repo_full_name, MAX(last_active_at) FROM github_activity "
+            f"WHERE repo_full_name IN ({placeholders}) "
+            f"AND last_active_at IS NOT NULL "
+            f"GROUP BY repo_full_name",
+            list(repos),
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            "SELECT repo_full_name, MAX(last_active_at) FROM github_activity "
+            "WHERE last_active_at IS NOT NULL GROUP BY repo_full_name"
+        ).fetchall()
+    return {r[0]: r[1] for r in rows}
+
+
+def repo_meta_names(conn: sqlite3.Connection) -> set[str]:
+    """Set of ``repo_full_name`` values present in ``github_repo_meta``.
+
+    This is the canonical "fully synced" watched set — a repo only gets a
+    ``github_repo_meta`` row after a complete artifact sync.
+    """
+    return {r[0] for r in conn.execute("SELECT repo_full_name FROM github_repo_meta")}
 
 
 # ---------------------------------------------------------------------------

--- a/src/rebalance/ingest/db/__init__.py
+++ b/src/rebalance/ingest/db/__init__.py
@@ -1,0 +1,43 @@
+"""Shared database layer for rebalance.
+
+Connection factory, schema creation, and typed query helpers. The
+implementation is split into submodules:
+
+- ``connection`` — connection factory + ``db_connection`` context manager
+- ``schema``     — every ``CREATE TABLE`` statement, grouped by source
+- ``github``     — typed query helpers for the ``github_*`` tables
+
+Everything is re-exported here, so ``from rebalance.ingest.db import ...``
+keeps working unchanged regardless of which submodule a symbol lives in.
+"""
+
+from __future__ import annotations
+
+from rebalance.ingest.db.connection import db_connection, get_connection
+from rebalance.ingest.db.github import (
+    repo_last_active,
+    repo_meta_names,
+    top_active_repos,
+)
+from rebalance.ingest.db.schema import (
+    ensure_calendar_schema,
+    ensure_email_schema,
+    ensure_github_schema,
+    ensure_project_schema,
+    ensure_schema,
+    ensure_semantic_schema,
+)
+
+__all__ = [
+    "get_connection",
+    "db_connection",
+    "ensure_schema",
+    "ensure_semantic_schema",
+    "ensure_calendar_schema",
+    "ensure_email_schema",
+    "ensure_github_schema",
+    "ensure_project_schema",
+    "top_active_repos",
+    "repo_last_active",
+    "repo_meta_names",
+]

--- a/src/rebalance/ingest/db/__init__.py
+++ b/src/rebalance/ingest/db/__init__.py
@@ -6,9 +6,13 @@ implementation is split into submodules:
 - ``connection`` — connection factory + ``db_connection`` context manager
 - ``schema``     — every ``CREATE TABLE`` statement, grouped by source
 - ``github``     — typed query helpers for the ``github_*`` tables
+- ``semantic``   — typed query helpers for the semantic-index tables
 
-Everything is re-exported here, so ``from rebalance.ingest.db import ...``
-keeps working unchanged regardless of which submodule a symbol lives in.
+The connection / schema / github symbols are re-exported here, so
+``from rebalance.ingest.db import ...`` keeps working unchanged. The
+``github`` and ``semantic`` query helpers are also reachable as submodules
+(``from rebalance.ingest.db import github``) for callers that want the
+namespaced form.
 """
 
 from __future__ import annotations

--- a/src/rebalance/ingest/db/__init__.py
+++ b/src/rebalance/ingest/db/__init__.py
@@ -23,7 +23,10 @@ from rebalance.ingest.db.github import (
     repo_meta_names,
     top_active_repos,
 )
+from rebalance.ingest.db.migrate import current_schema_version, run_migrations
 from rebalance.ingest.db.schema import (
+    BASELINE_SCHEMA_VERSION,
+    ensure_baseline_schema,
     ensure_calendar_schema,
     ensure_email_schema,
     ensure_github_schema,
@@ -41,7 +44,11 @@ __all__ = [
     "ensure_email_schema",
     "ensure_github_schema",
     "ensure_project_schema",
+    "ensure_baseline_schema",
     "top_active_repos",
     "repo_last_active",
     "repo_meta_names",
+    "run_migrations",
+    "current_schema_version",
+    "BASELINE_SCHEMA_VERSION",
 ]

--- a/src/rebalance/ingest/db/connection.py
+++ b/src/rebalance/ingest/db/connection.py
@@ -1,0 +1,72 @@
+"""SQLite connection factory and context manager for rebalance.
+
+Opens connections with WAL mode, foreign keys, a generous busy timeout, and
+the sqlite-vec extension loaded when available.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Callable, Generator
+
+try:
+    import sqlite_vec
+except Exception:  # pragma: no cover - import guard for environments without sqlite-vec
+    sqlite_vec = None
+
+
+def get_connection(database_path: Path) -> sqlite3.Connection:
+    """Open a SQLite connection with WAL mode, foreign keys, and sqlite-vec loaded.
+
+    Note: sqlite-vec may not load on all Python builds (e.g., system Python without
+    extension support). The connection will still work for basic queries.
+    """
+    database_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(database_path))
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA foreign_keys=ON")
+    # Wait up to 30s for a writer slot before raising "database is locked".
+    # Background refreshes from the TUI can briefly overlap launchd jobs;
+    # without this they fail instantly. See git history for the 2026-05 incident.
+    conn.execute("PRAGMA busy_timeout=30000")
+
+    # Try to load sqlite-vec, but gracefully fall back if unavailable
+    try:
+        if sqlite_vec is not None and hasattr(conn, 'enable_load_extension'):
+            conn.enable_load_extension(True)
+            sqlite_vec.load(conn)
+            conn.enable_load_extension(False)
+    except (AttributeError, Exception):
+        # sqlite-vec not available on this Python build; continue without it
+        pass
+
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+@contextmanager
+def db_connection(
+    database_path: Path,
+    ensure_fn: Callable[[sqlite3.Connection], None] | None = None,
+) -> Generator[sqlite3.Connection, None, None]:
+    """Context-managed database connection with optional schema setup.
+
+    Usage::
+
+        with db_connection(db_path, ensure_schema) as conn:
+            rows = conn.execute("SELECT ...").fetchall()
+
+    The connection is always closed on exit — even if the caller raises.
+    Pass *ensure_fn* to guarantee a specific set of tables exists (e.g.
+    ``ensure_schema``, ``ensure_calendar_schema``).  Omit it when you only
+    need a bare connection.
+    """
+    conn = get_connection(database_path)
+    if ensure_fn is not None:
+        ensure_fn(conn)
+    try:
+        yield conn
+    finally:
+        conn.close()

--- a/src/rebalance/ingest/db/github.py
+++ b/src/rebalance/ingest/db/github.py
@@ -1,12 +1,20 @@
 """Typed query helpers for the ``github_*`` tables.
 
 These keep raw SQL out of the CLI and ingest modules — callers work with
-plain Python values and let this module own the column layout.
+plain Python values and let this module own the column layout. Upsert
+helpers take the value tuple in the documented column order (``github_items``
+takes a column-keyed dict, bound by name, since it has 35 columns).
 """
 
 from __future__ import annotations
 
 import sqlite3
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Activity queries
+# ---------------------------------------------------------------------------
 
 
 def top_active_repos(
@@ -70,3 +78,526 @@ def repo_meta_names(conn: sqlite3.Connection) -> set[str]:
     ``github_repo_meta`` row after a complete artifact sync.
     """
     return {r[0] for r in conn.execute("SELECT repo_full_name FROM github_repo_meta")}
+
+
+# ---------------------------------------------------------------------------
+# Artifact upserts — one helper per github_* table; this module owns the
+# column layout so ingest code never embeds INSERT SQL.
+# ---------------------------------------------------------------------------
+
+
+def upsert_repo_meta(conn: sqlite3.Connection, values: tuple) -> None:
+    """Insert-or-replace one ``github_repo_meta`` row.
+
+    *values*: repo_full_name, default_branch, pushed_at, updated_at,
+    open_issues_count, has_issues, has_projects, fetched_at.
+    """
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO github_repo_meta
+            (repo_full_name, default_branch, pushed_at, updated_at, open_issues_count,
+             has_issues, has_projects, fetched_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        values,
+    )
+
+
+def upsert_branch(conn: sqlite3.Connection, values: tuple) -> None:
+    """Insert-or-replace one ``github_branches`` row.
+
+    *values*: repo_full_name, name, head_sha, is_protected, is_default, fetched_at.
+    """
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO github_branches
+            (repo_full_name, name, head_sha, is_protected, is_default, fetched_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        values,
+    )
+
+
+def upsert_label(conn: sqlite3.Connection, values: tuple) -> None:
+    """Insert-or-replace one ``github_labels`` row.
+
+    *values*: repo_full_name, name, color, description, is_default.
+    """
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO github_labels
+            (repo_full_name, name, color, description, is_default)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        values,
+    )
+
+
+def upsert_milestone(conn: sqlite3.Connection, values: tuple) -> None:
+    """Insert-or-replace one ``github_milestones`` row.
+
+    *values*: repo_full_name, number, title, description, state, open_issues,
+    closed_issues, due_on, created_at, updated_at, closed_at, html_url.
+    """
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO github_milestones
+            (repo_full_name, number, title, description, state, open_issues,
+             closed_issues, due_on, created_at, updated_at, closed_at, html_url)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        values,
+    )
+
+
+def upsert_release(conn: sqlite3.Connection, values: tuple) -> None:
+    """Insert-or-replace one ``github_releases`` row.
+
+    *values*: repo_full_name, github_id, tag_name, name, target_commitish,
+    is_draft, is_prerelease, body, created_at, published_at, html_url.
+    """
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO github_releases
+            (repo_full_name, github_id, tag_name, name, target_commitish, is_draft,
+             is_prerelease, body, created_at, published_at, html_url)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        values,
+    )
+
+
+def upsert_item(conn: sqlite3.Connection, record: dict[str, Any]) -> None:
+    """Insert-or-replace one ``github_items`` row from a column-keyed dict.
+
+    Bound by name — *record* must carry every github_items column as a key.
+    Extra keys are ignored by sqlite3. Named binding (rather than positional)
+    removes any dependence on dict iteration order.
+    """
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO github_items
+            (repo_full_name, item_type, number, node_id, github_id, title, body, state,
+             state_reason, author_login, assignees_json, labels_json, milestone_number,
+             milestone_title, is_draft, is_merged, base_ref, head_ref, head_sha,
+             mergeable_state, review_decision, check_status, requested_reviewers_json,
+             comments_count, review_comments_count, commits_count, additions, deletions,
+             changed_files, html_url, created_at, updated_at, closed_at, merged_at, fetched_at)
+        VALUES (:repo_full_name, :item_type, :number, :node_id, :github_id, :title, :body,
+                :state, :state_reason, :author_login, :assignees_json, :labels_json,
+                :milestone_number, :milestone_title, :is_draft, :is_merged, :base_ref,
+                :head_ref, :head_sha, :mergeable_state, :review_decision, :check_status,
+                :requested_reviewers_json, :comments_count, :review_comments_count,
+                :commits_count, :additions, :deletions, :changed_files, :html_url,
+                :created_at, :updated_at, :closed_at, :merged_at, :fetched_at)
+        """,
+        record,
+    )
+
+
+def upsert_comment(conn: sqlite3.Connection, values: tuple) -> None:
+    """Insert-or-replace one ``github_comments`` row.
+
+    *values*: repo_full_name, item_type, item_number, comment_type,
+    github_comment_id, author_login, author_association, body, review_state,
+    in_reply_to_id, html_url, created_at, updated_at, fetched_at.
+    """
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO github_comments
+            (repo_full_name, item_type, item_number, comment_type, github_comment_id,
+             author_login, author_association, body, review_state, in_reply_to_id,
+             html_url, created_at, updated_at, fetched_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        values,
+    )
+
+
+def upsert_link(conn: sqlite3.Connection, values: tuple) -> None:
+    """Insert-or-replace one ``github_links`` row.
+
+    *values*: repo_full_name, source_type, source_number, target_type,
+    target_number, link_kind.
+    """
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO github_links
+            (repo_full_name, source_type, source_number, target_type, target_number, link_kind)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        values,
+    )
+
+
+def upsert_commit(conn: sqlite3.Connection, values: tuple) -> None:
+    """Insert-or-replace one ``github_commits`` row.
+
+    *values*: repo_full_name, item_type, item_number, sha, author_login,
+    message, committed_at, html_url, fetched_at.
+    """
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO github_commits
+            (repo_full_name, item_type, item_number, sha, author_login,
+             message, committed_at, html_url, fetched_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        values,
+    )
+
+
+def upsert_check_run(conn: sqlite3.Connection, values: tuple) -> None:
+    """Insert-or-replace one ``github_check_runs`` row.
+
+    *values*: repo_full_name, item_type, item_number, head_sha, name, status,
+    conclusion, details_url, started_at, completed_at, fetched_at.
+    """
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO github_check_runs
+            (repo_full_name, item_type, item_number, head_sha, name, status,
+             conclusion, details_url, started_at, completed_at, fetched_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        values,
+    )
+
+
+def delete_repo_table(
+    conn: sqlite3.Connection, table: str, repo_full_name: str
+) -> None:
+    """Delete every row of *table* for an exact ``repo_full_name`` match.
+
+    Used to clear branches/labels/milestones/releases before a fresh sync.
+    *table* must be a trusted constant — it is interpolated, not bound.
+    """
+    conn.execute(f"DELETE FROM {table} WHERE repo_full_name = ?", (repo_full_name,))
+
+
+# ---------------------------------------------------------------------------
+# Document corpus
+# ---------------------------------------------------------------------------
+
+
+def insert_github_document(
+    conn: sqlite3.Connection,
+    *,
+    repo_full_name: str,
+    source_type: str,
+    source_number: int,
+    doc_type: str,
+    source_key: str,
+    title: str,
+    body: str,
+    content_hash: str,
+    updated_at: str,
+    fetched_at: str,
+) -> int:
+    """Insert one ``github_documents`` row (``embedded_hash`` starts NULL).
+
+    Returns the new row id. Content hashing is the caller's job — pass the
+    precomputed *content_hash*.
+    """
+    conn.execute(
+        """
+        INSERT INTO github_documents
+            (repo_full_name, source_type, source_number, doc_type, source_key,
+             title, body, content_hash, embedded_hash, updated_at, fetched_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)
+        """,
+        (
+            repo_full_name,
+            source_type,
+            source_number,
+            doc_type,
+            source_key,
+            title,
+            body,
+            content_hash,
+            updated_at,
+            fetched_at,
+        ),
+    )
+    return int(conn.execute("SELECT last_insert_rowid()").fetchone()[0])
+
+
+def delete_item_children(
+    conn: sqlite3.Connection,
+    repo_full_name: str,
+    item_type: str,
+    item_number: int,
+) -> None:
+    """Delete one item's derived rows (documents, embeddings, comments,
+    commits, check runs, links) before the item is re-synced."""
+    doc_ids = [
+        row["id"]
+        for row in conn.execute(
+            """
+            SELECT id
+            FROM github_documents
+            WHERE repo_full_name = ? AND source_type = ? AND source_number = ?
+            """,
+            (repo_full_name, item_type, item_number),
+        ).fetchall()
+    ]
+    if doc_ids:
+        conn.executemany(
+            "DELETE FROM github_embeddings WHERE doc_id = ?",
+            [(doc_id,) for doc_id in doc_ids],
+        )
+    conn.execute(
+        """
+        DELETE FROM github_documents
+        WHERE repo_full_name = ? AND source_type = ? AND source_number = ?
+        """,
+        (repo_full_name, item_type, item_number),
+    )
+    conn.execute(
+        """
+        DELETE FROM github_comments
+        WHERE repo_full_name = ? AND item_type = ? AND item_number = ?
+        """,
+        (repo_full_name, item_type, item_number),
+    )
+    conn.execute(
+        """
+        DELETE FROM github_commits
+        WHERE repo_full_name = ? AND item_type = ? AND item_number = ?
+        """,
+        (repo_full_name, item_type, item_number),
+    )
+    conn.execute(
+        """
+        DELETE FROM github_check_runs
+        WHERE repo_full_name = ? AND item_type = ? AND item_number = ?
+        """,
+        (repo_full_name, item_type, item_number),
+    )
+    conn.execute(
+        """
+        DELETE FROM github_links
+        WHERE repo_full_name = ? AND source_type = ? AND source_number = ?
+        """,
+        (repo_full_name, item_type, item_number),
+    )
+
+
+def search_github_documents(
+    conn: sqlite3.Connection,
+    query_vec: bytes,
+    top_k: int,
+    repo_full_name: str = "",
+) -> list[sqlite3.Row]:
+    """Vector search over ``github_embeddings``, nearest first.
+
+    Returns raw rows joined to ``github_documents`` and (left) ``github_items``.
+    Pass *repo_full_name* to restrict results to a single repo.
+    """
+    repo = repo_full_name.strip()
+    base = """
+        SELECT
+            ge.doc_id,
+            ge.distance,
+            gd.repo_full_name,
+            gd.source_type,
+            gd.source_number,
+            gd.doc_type,
+            gd.title,
+            SUBSTR(gd.body, 1, 400) AS body_preview,
+            gi.state,
+            gi.milestone_title,
+            gi.labels_json,
+            gi.review_decision,
+            gi.check_status,
+            gi.html_url
+        FROM github_embeddings ge
+        JOIN github_documents gd ON gd.id = ge.doc_id
+        LEFT JOIN github_items gi
+          ON gi.repo_full_name = gd.repo_full_name
+         AND gi.item_type = gd.source_type
+         AND gi.number = gd.source_number
+        WHERE ge.embedding MATCH ? AND ge.k = ?{repo_clause}
+        ORDER BY ge.distance
+    """
+    if repo:
+        sql = base.format(repo_clause=" AND gd.repo_full_name = ?")
+        return conn.execute(sql, (query_vec, top_k, repo)).fetchall()
+    sql = base.format(repo_clause="")
+    return conn.execute(sql, (query_vec, top_k)).fetchall()
+
+
+# ---------------------------------------------------------------------------
+# Embeddings
+# ---------------------------------------------------------------------------
+
+
+def clear_github_embeddings(conn: sqlite3.Connection) -> None:
+    """Drop every row from ``github_embeddings`` (used by force-reembed)."""
+    conn.execute("DELETE FROM github_embeddings")
+
+
+def reset_github_embedded_hashes(conn: sqlite3.Connection) -> None:
+    """Null out every ``github_documents.embedded_hash`` (used by force-reembed)."""
+    conn.execute("UPDATE github_documents SET embedded_hash = NULL")
+
+
+def github_documents_pending_embed(
+    conn: sqlite3.Connection, min_chars: int
+) -> list[sqlite3.Row]:
+    """Rows (id, body, content_hash) for documents needing (re-)embedding.
+
+    A document qualifies when its body is at least *min_chars* long and its
+    ``embedded_hash`` is missing or stale relative to ``content_hash``.
+    """
+    return conn.execute(
+        """
+        SELECT id, body, content_hash
+        FROM github_documents
+        WHERE LENGTH(body) >= ?
+          AND (embedded_hash IS NULL OR embedded_hash != content_hash)
+        ORDER BY id
+        """,
+        (min_chars,),
+    ).fetchall()
+
+
+def count_embeddable_github_documents(
+    conn: sqlite3.Connection, min_chars: int
+) -> int:
+    """Count documents whose body is at least *min_chars* long."""
+    return conn.execute(
+        "SELECT COUNT(*) FROM github_documents WHERE LENGTH(body) >= ?",
+        (min_chars,),
+    ).fetchone()[0]
+
+
+def upsert_github_embedding(
+    conn: sqlite3.Connection, doc_id: int, embedding: bytes
+) -> None:
+    """Insert-or-replace one ``github_embeddings`` vector row."""
+    conn.execute(
+        "INSERT OR REPLACE INTO github_embeddings (doc_id, embedding) VALUES (?, ?)",
+        (doc_id, embedding),
+    )
+
+
+def mark_github_document_embedded(conn: sqlite3.Connection, doc_id: int) -> None:
+    """Mark a document fresh by copying ``content_hash`` into ``embedded_hash``."""
+    conn.execute(
+        "UPDATE github_documents SET embedded_hash = content_hash WHERE id = ?",
+        (doc_id,),
+    )
+
+
+def set_github_embedding_meta(
+    conn: sqlite3.Connection, key: str, value: str
+) -> None:
+    """Insert-or-replace one ``github_embedding_meta`` key/value row."""
+    conn.execute(
+        "INSERT OR REPLACE INTO github_embedding_meta (key, value) VALUES (?, ?)",
+        (key, value),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-repo purge
+# ---------------------------------------------------------------------------
+
+
+def count_repo_rows(
+    conn: sqlite3.Connection, table: str, repo_name_lower: str
+) -> int:
+    """Count rows of *table* for a case-insensitive ``repo_full_name`` match.
+
+    *table* must be a trusted constant — it is interpolated, not bound.
+    """
+    return conn.execute(
+        f"SELECT COUNT(*) FROM {table} WHERE LOWER(repo_full_name) = ?",
+        (repo_name_lower,),
+    ).fetchone()[0]
+
+
+def delete_repo_rows(
+    conn: sqlite3.Connection, table: str, repo_name_lower: str
+) -> None:
+    """Delete rows of *table* for a case-insensitive ``repo_full_name`` match.
+
+    *table* must be a trusted constant — it is interpolated, not bound.
+    """
+    conn.execute(
+        f"DELETE FROM {table} WHERE LOWER(repo_full_name) = ?",
+        (repo_name_lower,),
+    )
+
+
+def github_document_ids(
+    conn: sqlite3.Connection, repo_name_lower: str
+) -> list[int]:
+    """Ids of ``github_documents`` for a case-insensitive repo match."""
+    return [
+        int(row["id"])
+        for row in conn.execute(
+            "SELECT id FROM github_documents WHERE LOWER(repo_full_name) = ?",
+            (repo_name_lower,),
+        ).fetchall()
+    ]
+
+
+def semantic_doc_ids_for_github_repo(
+    conn: sqlite3.Connection, repo_name_lower: str
+) -> list[int]:
+    """Ids of ``semantic_documents`` projected from one GitHub repo's docs."""
+    return [
+        int(row["id"])
+        for row in conn.execute(
+            """
+            SELECT sd.id
+            FROM semantic_documents sd
+            JOIN github_documents gd ON gd.source_key = sd.source_pk
+            WHERE sd.source_type = 'github'
+              AND LOWER(gd.repo_full_name) = ?
+            """,
+            (repo_name_lower,),
+        ).fetchall()
+    ]
+
+
+def count_ids_in(
+    conn: sqlite3.Connection, table: str, id_column: str, ids: list[int]
+) -> int:
+    """Count rows of *table* whose *id_column* is in *ids* (0 for an empty list).
+
+    *table* and *id_column* must be trusted constants — interpolated, not bound.
+    """
+    if not ids:
+        return 0
+    placeholders = ", ".join("?" for _ in ids)
+    return conn.execute(
+        f"SELECT COUNT(*) FROM {table} WHERE {id_column} IN ({placeholders})",
+        list(ids),
+    ).fetchone()[0]
+
+
+def delete_github_embeddings_for_docs(
+    conn: sqlite3.Connection, doc_ids: list[int]
+) -> None:
+    """Delete ``github_embeddings`` rows for the given document ids."""
+    conn.executemany(
+        "DELETE FROM github_embeddings WHERE doc_id = ?",
+        [(doc_id,) for doc_id in doc_ids],
+    )
+
+
+def delete_semantic_rows_for_docs(
+    conn: sqlite3.Connection, semantic_doc_ids: list[int]
+) -> None:
+    """Delete ``semantic_embeddings`` + ``semantic_documents`` for the given ids."""
+    conn.executemany(
+        "DELETE FROM semantic_embeddings WHERE rowid = ?",
+        [(doc_id,) for doc_id in semantic_doc_ids],
+    )
+    conn.executemany(
+        "DELETE FROM semantic_documents WHERE id = ?",
+        [(doc_id,) for doc_id in semantic_doc_ids],
+    )

--- a/src/rebalance/ingest/db/github.py
+++ b/src/rebalance/ingest/db/github.py
@@ -587,17 +587,3 @@ def delete_github_embeddings_for_docs(
         "DELETE FROM github_embeddings WHERE doc_id = ?",
         [(doc_id,) for doc_id in doc_ids],
     )
-
-
-def delete_semantic_rows_for_docs(
-    conn: sqlite3.Connection, semantic_doc_ids: list[int]
-) -> None:
-    """Delete ``semantic_embeddings`` + ``semantic_documents`` for the given ids."""
-    conn.executemany(
-        "DELETE FROM semantic_embeddings WHERE rowid = ?",
-        [(doc_id,) for doc_id in semantic_doc_ids],
-    )
-    conn.executemany(
-        "DELETE FROM semantic_documents WHERE id = ?",
-        [(doc_id,) for doc_id in semantic_doc_ids],
-    )

--- a/src/rebalance/ingest/db/github.py
+++ b/src/rebalance/ingest/db/github.py
@@ -1,0 +1,72 @@
+"""Typed query helpers for the ``github_*`` tables.
+
+These keep raw SQL out of the CLI and ingest modules — callers work with
+plain Python values and let this module own the column layout.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+
+def top_active_repos(
+    conn: sqlite3.Connection, top_n: int, since_days: int = 7
+) -> list[str]:
+    """Repo full-names ranked by recent activity score, highest first.
+
+    Score sums ``commits + prs_opened + prs_merged + issues_opened +
+    issue_comments + reviews`` over the trailing *since_days* window
+    (``github_activity.scan_date``). Repos with a zero score are excluded.
+    """
+    rows = conn.execute(
+        """
+        SELECT repo_full_name,
+               SUM(commits) + SUM(prs_opened) + SUM(prs_merged) +
+               SUM(issues_opened) + SUM(issue_comments) + SUM(reviews) AS score
+        FROM github_activity
+        WHERE scan_date >= date('now', ?)
+        GROUP BY repo_full_name
+        HAVING score > 0
+        ORDER BY score DESC
+        LIMIT ?
+        """,
+        (f"-{since_days} days", top_n),
+    ).fetchall()
+    return [r[0] for r in rows]
+
+
+def repo_last_active(
+    conn: sqlite3.Connection, repos: list[str] | None = None
+) -> dict[str, str]:
+    """Map of ``repo_full_name`` -> latest ``last_active_at`` (raw ISO string).
+
+    Pass *repos* to restrict to a subset; omit it for every repo. Repos with
+    no non-null ``last_active_at`` are omitted. Timestamp parsing is left to
+    the caller — this helper only touches the database.
+    """
+    if repos is not None:
+        if not repos:
+            return {}
+        placeholders = ",".join("?" * len(repos))
+        rows = conn.execute(
+            f"SELECT repo_full_name, MAX(last_active_at) FROM github_activity "
+            f"WHERE repo_full_name IN ({placeholders}) "
+            f"AND last_active_at IS NOT NULL "
+            f"GROUP BY repo_full_name",
+            list(repos),
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            "SELECT repo_full_name, MAX(last_active_at) FROM github_activity "
+            "WHERE last_active_at IS NOT NULL GROUP BY repo_full_name"
+        ).fetchall()
+    return {r[0]: r[1] for r in rows}
+
+
+def repo_meta_names(conn: sqlite3.Connection) -> set[str]:
+    """Set of ``repo_full_name`` values present in ``github_repo_meta``.
+
+    This is the canonical "fully synced" watched set — a repo only gets a
+    ``github_repo_meta`` row after a complete artifact sync.
+    """
+    return {r[0] for r in conn.execute("SELECT repo_full_name FROM github_repo_meta")}

--- a/src/rebalance/ingest/db/migrate.py
+++ b/src/rebalance/ingest/db/migrate.py
@@ -1,0 +1,86 @@
+"""Forward-only schema migration runner.
+
+The baseline schema (version ``BASELINE_SCHEMA_VERSION``) is created by the
+``ensure_*_schema`` functions in :mod:`rebalance.ingest.db.schema`. Every schema
+change from the next version onward is a numbered SQL file in ``db/migrations/``
+(``NNNN_description.sql``); ``schema.py`` stays frozen at the baseline.
+
+:func:`run_migrations` stamps a database at the baseline version, then applies
+any migration files newer than the recorded version, in order. It is idempotent
+— a database already at the latest version is a cheap no-op.
+
+See ``db/migrations/README.md`` for the authoring discipline.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+from rebalance.ingest.db.schema import (
+    BASELINE_SCHEMA_VERSION,
+    ensure_baseline_schema,
+    ensure_schema_version_table,
+)
+
+MIGRATIONS_DIR = Path(__file__).parent / "migrations"
+
+
+def current_schema_version(conn: sqlite3.Connection) -> int:
+    """Return the highest recorded schema version, or 0 if none is recorded."""
+    row = conn.execute("SELECT MAX(version) FROM schema_version").fetchone()
+    return int(row[0]) if row and row[0] is not None else 0
+
+
+def discover_migrations() -> list[tuple[int, Path]]:
+    """Return ``(version, path)`` for every ``NNNN_*.sql`` file, ascending.
+
+    Files whose name does not start with an integer are ignored.
+    """
+    found: list[tuple[int, Path]] = []
+    if not MIGRATIONS_DIR.is_dir():
+        return found
+    for path in sorted(MIGRATIONS_DIR.glob("*.sql")):
+        prefix = path.name.split("_", 1)[0]
+        try:
+            version = int(prefix)
+        except ValueError:
+            continue
+        found.append((version, path))
+    found.sort()
+    return found
+
+
+def _stamp(conn: sqlite3.Connection, version: int) -> None:
+    conn.execute(
+        "INSERT OR IGNORE INTO schema_version (version, applied_at) VALUES (?, ?)",
+        (version, datetime.now(timezone.utc).isoformat()),
+    )
+
+
+def run_migrations(conn: sqlite3.Connection) -> int:
+    """Bring *conn*'s database up to the latest schema version; return that version.
+
+    Ensures the baseline schema exists first (so migrations always have their
+    tables), then applies migration files newer than the recorded version, in
+    order. A database with no ``schema_version`` row is treated as being at the
+    baseline — it is either a fresh install or one that predates migrations, and
+    both are at the baseline shape.
+    """
+    ensure_baseline_schema(conn)
+    ensure_schema_version_table(conn)
+    version = current_schema_version(conn)
+    if version == 0:
+        _stamp(conn, BASELINE_SCHEMA_VERSION)
+        version = BASELINE_SCHEMA_VERSION
+
+    for mig_version, path in discover_migrations():
+        if mig_version <= version:
+            continue
+        conn.executescript(path.read_text(encoding="utf-8"))
+        _stamp(conn, mig_version)
+        version = mig_version
+
+    conn.commit()
+    return version

--- a/src/rebalance/ingest/db/migrations/README.md
+++ b/src/rebalance/ingest/db/migrations/README.md
@@ -1,0 +1,54 @@
+# Schema migrations
+
+Forward-only SQL migrations for `rebalance.db`. The runner is
+[`db/migrate.py`](../migrate.py).
+
+## The model
+
+- **Version 1 is the baseline** — everything the `ensure_*_schema` functions in
+  [`db/schema.py`](../schema.py) create. Any database that has run those
+  functions is, by definition, at version 1.
+- **`schema.py` is frozen at the baseline.** Do **not** add columns or tables to
+  the `ensure_*_schema` functions for a schema change. They exist only to build
+  the version-1 baseline (and to keep fresh installs working).
+- **Every schema change from version 2 onward is a file in this directory.**
+
+This keeps fresh installs and existing databases on the same path: the baseline
+is created/assumed, then migrations `0002…N` are applied in order.
+
+## Adding a migration
+
+1. Create `NNNN_short_description.sql` here, where `NNNN` is the next integer
+   after the highest existing file, zero-padded to four digits (`0002`, `0003`, …).
+2. Write forward-only SQL. Be defensive — prefer `IF EXISTS` / `IF NOT EXISTS`
+   so a partially-applied run can be re-run safely.
+3. That's it. `run_migrations()` discovers the file, applies it once, and records
+   the new version in the `schema_version` table.
+
+Example — `0002_add_repo_topic.sql`:
+
+```sql
+ALTER TABLE github_repo_meta ADD COLUMN topics_json TEXT;
+```
+
+## When migrations run
+
+`run_migrations(conn)` is invoked automatically at the start of every
+non-dry-run `refresh_index()` call. Any new code path that opens the database
+before a refresh has happened should call it too:
+
+```python
+from rebalance.ingest.db import db_connection, run_migrations
+
+with db_connection(db_path) as conn:
+    run_migrations(conn)
+```
+
+The runner is idempotent — calling it on an already-current database is a cheap
+no-op.
+
+## Why forward-only, no down-migrations
+
+`rebalance.db` is a local derived cache that can be rebuilt from source
+(`refresh_index(scope=["all"])`). Rollback complexity is not worth it — if a
+migration is wrong, fix it forward with the next one.

--- a/src/rebalance/ingest/db/schema.py
+++ b/src/rebalance/ingest/db/schema.py
@@ -1,84 +1,14 @@
-"""
-Shared database layer for rebalance — connection factory, schema creation,
-sqlite-vec extension loading, and context managers.
+"""All CREATE TABLE statements for rebalance, grouped by source.
 
-All CREATE TABLE statements live here so the full DB shape is visible in
-one place.  Individual modules call the appropriate ensure_*_schema()
-function (or use the db_connection context manager) rather than carrying
+Keeping every DDL statement in one module means the full DB shape is visible
+in one place; individual modules call the appropriate ``ensure_*_schema()``
+function (or use the ``db_connection`` context manager) rather than carrying
 their own DDL.
 """
 
 from __future__ import annotations
 
 import sqlite3
-from contextlib import contextmanager
-from pathlib import Path
-from typing import Callable, Generator
-
-try:
-    import sqlite_vec
-except Exception:  # pragma: no cover - import guard for environments without sqlite-vec
-    sqlite_vec = None
-
-
-# ---------------------------------------------------------------------------
-# Connection factory
-# ---------------------------------------------------------------------------
-
-
-def get_connection(database_path: Path) -> sqlite3.Connection:
-    """Open a SQLite connection with WAL mode, foreign keys, and sqlite-vec loaded.
-
-    Note: sqlite-vec may not load on all Python builds (e.g., system Python without
-    extension support). The connection will still work for basic queries.
-    """
-    database_path.parent.mkdir(parents=True, exist_ok=True)
-    conn = sqlite3.connect(str(database_path))
-    conn.execute("PRAGMA journal_mode=WAL")
-    conn.execute("PRAGMA foreign_keys=ON")
-    # Wait up to 30s for a writer slot before raising "database is locked".
-    # Background refreshes from the TUI can briefly overlap launchd jobs;
-    # without this they fail instantly. See git history for the 2026-05 incident.
-    conn.execute("PRAGMA busy_timeout=30000")
-
-    # Try to load sqlite-vec, but gracefully fall back if unavailable
-    try:
-        if sqlite_vec is not None and hasattr(conn, 'enable_load_extension'):
-            conn.enable_load_extension(True)
-            sqlite_vec.load(conn)
-            conn.enable_load_extension(False)
-    except (AttributeError, Exception):
-        # sqlite-vec not available on this Python build; continue without it
-        pass
-
-    conn.row_factory = sqlite3.Row
-    return conn
-
-
-@contextmanager
-def db_connection(
-    database_path: Path,
-    ensure_fn: Callable[[sqlite3.Connection], None] | None = None,
-) -> Generator[sqlite3.Connection, None, None]:
-    """Context-managed database connection with optional schema setup.
-
-    Usage::
-
-        with db_connection(db_path, ensure_schema) as conn:
-            rows = conn.execute("SELECT ...").fetchall()
-
-    The connection is always closed on exit — even if the caller raises.
-    Pass *ensure_fn* to guarantee a specific set of tables exists (e.g.
-    ``ensure_schema``, ``ensure_calendar_schema``).  Omit it when you only
-    need a bare connection.
-    """
-    conn = get_connection(database_path)
-    if ensure_fn is not None:
-        ensure_fn(conn)
-    try:
-        yield conn
-    finally:
-        conn.close()
 
 
 # ---------------------------------------------------------------------------
@@ -605,74 +535,6 @@ def ensure_github_schema(conn: sqlite3.Connection) -> None:
     _ensure_github_artifact_schema(conn)
     _ensure_github_knowledge_schema(conn)
     conn.commit()
-
-
-# ---------------------------------------------------------------------------
-# GitHub activity queries (read helpers — keep DDL above, DML below)
-# ---------------------------------------------------------------------------
-
-
-def top_active_repos(
-    conn: sqlite3.Connection, top_n: int, since_days: int = 7
-) -> list[str]:
-    """Repo full-names ranked by recent activity score, highest first.
-
-    Score sums ``commits + prs_opened + prs_merged + issues_opened +
-    issue_comments + reviews`` over the trailing *since_days* window
-    (``github_activity.scan_date``). Repos with a zero score are excluded.
-    """
-    rows = conn.execute(
-        """
-        SELECT repo_full_name,
-               SUM(commits) + SUM(prs_opened) + SUM(prs_merged) +
-               SUM(issues_opened) + SUM(issue_comments) + SUM(reviews) AS score
-        FROM github_activity
-        WHERE scan_date >= date('now', ?)
-        GROUP BY repo_full_name
-        HAVING score > 0
-        ORDER BY score DESC
-        LIMIT ?
-        """,
-        (f"-{since_days} days", top_n),
-    ).fetchall()
-    return [r[0] for r in rows]
-
-
-def repo_last_active(
-    conn: sqlite3.Connection, repos: list[str] | None = None
-) -> dict[str, str]:
-    """Map of ``repo_full_name`` -> latest ``last_active_at`` (raw ISO string).
-
-    Pass *repos* to restrict to a subset; omit it for every repo. Repos with
-    no non-null ``last_active_at`` are omitted. Timestamp parsing is left to
-    the caller — this helper only touches the database.
-    """
-    if repos is not None:
-        if not repos:
-            return {}
-        placeholders = ",".join("?" * len(repos))
-        rows = conn.execute(
-            f"SELECT repo_full_name, MAX(last_active_at) FROM github_activity "
-            f"WHERE repo_full_name IN ({placeholders}) "
-            f"AND last_active_at IS NOT NULL "
-            f"GROUP BY repo_full_name",
-            list(repos),
-        ).fetchall()
-    else:
-        rows = conn.execute(
-            "SELECT repo_full_name, MAX(last_active_at) FROM github_activity "
-            "WHERE last_active_at IS NOT NULL GROUP BY repo_full_name"
-        ).fetchall()
-    return {r[0]: r[1] for r in rows}
-
-
-def repo_meta_names(conn: sqlite3.Connection) -> set[str]:
-    """Set of ``repo_full_name`` values present in ``github_repo_meta``.
-
-    This is the canonical "fully synced" watched set — a repo only gets a
-    ``github_repo_meta`` row after a complete artifact sync.
-    """
-    return {r[0] for r in conn.execute("SELECT repo_full_name FROM github_repo_meta")}
 
 
 # ---------------------------------------------------------------------------

--- a/src/rebalance/ingest/db/schema.py
+++ b/src/rebalance/ingest/db/schema.py
@@ -558,3 +558,47 @@ def ensure_project_schema(conn: sqlite3.Connection) -> None:
         )
     """)
     conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Schema versioning
+# ---------------------------------------------------------------------------
+
+# The baseline schema — everything the ensure_*_schema functions above create.
+# A database that has run those functions is, by definition, at this version.
+# Schema changes from here on are forward-only migration files in db/migrations/
+# (applied by db/migrate.py). This number never changes and the ensure_*_schema
+# functions stay frozen at the baseline — see db/migrations/README.md.
+BASELINE_SCHEMA_VERSION = 1
+
+
+def ensure_baseline_schema(conn: sqlite3.Connection) -> None:
+    """Create every baseline (version 1) table if it doesn't exist.
+
+    Runs all six ``ensure_*_schema`` functions — the full version-1 shape.
+    Idempotent; safe to call on an already-populated database. The migration
+    runner calls this first so that migrations always have their tables.
+    """
+    ensure_schema(conn)
+    ensure_semantic_schema(conn)
+    ensure_calendar_schema(conn)
+    ensure_email_schema(conn)
+    ensure_github_schema(conn)
+    ensure_project_schema(conn)
+
+
+def ensure_schema_version_table(conn: sqlite3.Connection) -> None:
+    """Create the ``schema_version`` ledger if it doesn't exist.
+
+    One row per applied version; the current version is ``MAX(version)``.
+    An empty table means no version has been recorded yet.
+    """
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS schema_version (
+            version    INTEGER PRIMARY KEY,
+            applied_at TEXT NOT NULL
+        )
+        """
+    )
+    conn.commit()

--- a/src/rebalance/ingest/db/semantic.py
+++ b/src/rebalance/ingest/db/semantic.py
@@ -1,0 +1,446 @@
+"""Typed query helpers for the unified semantic index tables.
+
+Keeps raw SQL out of ``semantic_index.py``: the document corpus
+(``semantic_documents``), its vector index (``semantic_embeddings``), and the
+source-table reads that feed the backfill. This module owns the column layout.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Sequence
+
+
+# ---------------------------------------------------------------------------
+# Document upsert
+# ---------------------------------------------------------------------------
+
+
+def find_semantic_document(
+    conn: sqlite3.Connection, source_type: str, source_pk: str
+) -> sqlite3.Row | None:
+    """Return the existing ``semantic_documents`` row for a source key, or None."""
+    return conn.execute(
+        """
+        SELECT id, source_table, doc_kind, title, body, content_hash, metadata_json, updated_at
+        FROM semantic_documents
+        WHERE source_type = ? AND source_pk = ?
+        """,
+        (source_type, source_pk),
+    ).fetchone()
+
+
+def insert_semantic_document(
+    conn: sqlite3.Connection,
+    *,
+    source_type: str,
+    source_table: str,
+    source_pk: str,
+    doc_kind: str,
+    title: str,
+    body: str,
+    content_hash: str,
+    metadata_json: str,
+    created_at: str,
+    updated_at: str,
+) -> int:
+    """Insert one ``semantic_documents`` row (embedding columns start NULL).
+
+    Returns the new row id.
+    """
+    conn.execute(
+        """
+        INSERT INTO semantic_documents
+            (source_type, source_table, source_pk, doc_kind, title, body, content_hash,
+             embedded_hash, embedded_model_version, embedded_at, metadata_json,
+             created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, ?, ?, ?)
+        """,
+        (
+            source_type,
+            source_table,
+            source_pk,
+            doc_kind,
+            title,
+            body,
+            content_hash,
+            metadata_json,
+            created_at,
+            updated_at,
+        ),
+    )
+    return int(conn.execute("SELECT last_insert_rowid()").fetchone()[0])
+
+
+def update_semantic_document(
+    conn: sqlite3.Connection,
+    doc_id: int,
+    *,
+    source_table: str,
+    doc_kind: str,
+    title: str,
+    body: str,
+    content_hash: str,
+    metadata_json: str,
+    updated_at: str,
+) -> None:
+    """Update the content columns of one ``semantic_documents`` row."""
+    conn.execute(
+        """
+        UPDATE semantic_documents
+        SET source_table = ?,
+            doc_kind = ?,
+            title = ?,
+            body = ?,
+            content_hash = ?,
+            metadata_json = ?,
+            updated_at = ?
+        WHERE id = ?
+        """,
+        (
+            source_table,
+            doc_kind,
+            title,
+            body,
+            content_hash,
+            metadata_json,
+            updated_at,
+            doc_id,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reconciliation
+# ---------------------------------------------------------------------------
+
+
+def semantic_documents_for_source(
+    conn: sqlite3.Connection, source_type: str, source_pk_prefix: str = ""
+) -> list[sqlite3.Row]:
+    """Rows (id, source_pk) for one source type, optionally prefix-scoped.
+
+    *source_pk_prefix* restricts to rows whose ``source_pk`` begins with it —
+    used to reconcile a single GitHub repo without touching other repos' rows.
+    """
+    if source_pk_prefix:
+        return conn.execute(
+            """
+            SELECT id, source_pk
+            FROM semantic_documents
+            WHERE source_type = ? AND SUBSTR(source_pk, 1, ?) = ?
+            """,
+            (source_type, len(source_pk_prefix), source_pk_prefix),
+        ).fetchall()
+    return conn.execute(
+        """
+        SELECT id, source_pk
+        FROM semantic_documents
+        WHERE source_type = ?
+        """,
+        (source_type,),
+    ).fetchall()
+
+
+def delete_semantic_documents(
+    conn: sqlite3.Connection, doc_ids: list[int]
+) -> None:
+    """Delete ``semantic_embeddings`` + ``semantic_documents`` rows for *doc_ids*."""
+    conn.executemany(
+        "DELETE FROM semantic_embeddings WHERE rowid = ?",
+        [(doc_id,) for doc_id in doc_ids],
+    )
+    conn.executemany(
+        "DELETE FROM semantic_documents WHERE id = ?",
+        [(doc_id,) for doc_id in doc_ids],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Source-table reads (backfill inputs)
+# ---------------------------------------------------------------------------
+
+
+def vault_chunks_for_semantic(conn: sqlite3.Connection) -> list[sqlite3.Row]:
+    """Every vault chunk joined to its file — the input for the vault backfill."""
+    return conn.execute(
+        """
+        SELECT
+            c.id,
+            c.file_id,
+            c.chunk_index,
+            c.heading,
+            c.heading_level,
+            c.body,
+            c.char_count,
+            c.content_hash,
+            vf.rel_path,
+            vf.title,
+            vf.tags_json,
+            vf.ingested_at,
+            vf.last_modified
+        FROM chunks c
+        JOIN vault_files vf ON vf.id = c.file_id
+        ORDER BY c.id
+        """
+    ).fetchall()
+
+
+def github_documents_for_semantic(
+    conn: sqlite3.Connection,
+    *,
+    normalized_repo: str = "",
+    ignored_repos: Sequence[str] = (),
+) -> list[sqlite3.Row]:
+    """GitHub documents joined to their item — the input for the GitHub backfill.
+
+    With *normalized_repo* set, restricts to that one repo. Otherwise excludes
+    every repo in *ignored_repos* (case-insensitive).
+    """
+    if normalized_repo:
+        where_sql = "WHERE LOWER(gd.repo_full_name) = ?"
+        params: tuple[str, ...] = (normalized_repo,)
+    else:
+        ignored_placeholders = ", ".join("?" for _ in ignored_repos)
+        if ignored_placeholders:
+            where_sql = f"WHERE LOWER(gd.repo_full_name) NOT IN ({ignored_placeholders})"
+            params = tuple(sorted(ignored_repos))
+        else:
+            where_sql = ""
+            params = ()
+
+    return conn.execute(
+        f"""
+        SELECT
+            gd.id,
+            gd.repo_full_name,
+            gd.source_type AS github_source_type,
+            gd.source_number,
+            gd.doc_type,
+            gd.source_key,
+            gd.title,
+            gd.body,
+            gd.content_hash,
+            gd.updated_at,
+            gd.fetched_at,
+            gi.state,
+            gi.milestone_title,
+            gi.labels_json,
+            gi.review_decision,
+            gi.check_status,
+            gi.html_url
+        FROM github_documents gd
+        LEFT JOIN github_items gi
+          ON gi.repo_full_name = gd.repo_full_name
+         AND gi.item_type = gd.source_type
+         AND gi.number = gd.source_number
+        {where_sql}
+        ORDER BY gd.id
+        """,
+        params,
+    ).fetchall()
+
+
+def email_messages_for_semantic(conn: sqlite3.Connection) -> list[sqlite3.Row]:
+    """Every email message, newest first — the input for the email backfill."""
+    return conn.execute(
+        """
+        SELECT message_id, thread_id, from_address, from_name, subject,
+               snippet, received_at, labels_json, synced_at
+        FROM email_messages
+        ORDER BY received_at DESC
+        """
+    ).fetchall()
+
+
+# ---------------------------------------------------------------------------
+# Embeddings
+# ---------------------------------------------------------------------------
+
+
+def clear_semantic_embeddings(conn: sqlite3.Connection) -> None:
+    """Drop every row from ``semantic_embeddings``."""
+    conn.execute("DELETE FROM semantic_embeddings")
+
+
+def reset_semantic_embedded_state(
+    conn: sqlite3.Connection, source_types: Sequence[str] | None = None
+) -> None:
+    """Null out the embedding bookkeeping columns on ``semantic_documents``.
+
+    Pass *source_types* to restrict the reset; omit it to reset every row.
+    """
+    if source_types is None:
+        conn.execute(
+            """
+            UPDATE semantic_documents
+            SET embedded_hash = NULL,
+                embedded_model_version = NULL,
+                embedded_at = NULL
+            """
+        )
+        return
+    placeholders = ", ".join("?" for _ in source_types)
+    conn.execute(
+        f"""
+        UPDATE semantic_documents
+        SET embedded_hash = NULL,
+            embedded_model_version = NULL,
+            embedded_at = NULL
+        WHERE source_type IN ({placeholders})
+        """,
+        list(source_types),
+    )
+
+
+def semantic_doc_ids_for_sources(
+    conn: sqlite3.Connection, source_types: Sequence[str]
+) -> list[int]:
+    """Ids of ``semantic_documents`` rows for the given source types."""
+    placeholders = ", ".join("?" for _ in source_types)
+    return [
+        int(row["id"])
+        for row in conn.execute(
+            f"""
+            SELECT id
+            FROM semantic_documents
+            WHERE source_type IN ({placeholders})
+            """,
+            list(source_types),
+        ).fetchall()
+    ]
+
+
+def delete_semantic_embeddings_for_docs(
+    conn: sqlite3.Connection, doc_ids: list[int]
+) -> None:
+    """Delete ``semantic_embeddings`` rows for the given document ids."""
+    conn.executemany(
+        "DELETE FROM semantic_embeddings WHERE rowid = ?",
+        [(doc_id,) for doc_id in doc_ids],
+    )
+
+
+def semantic_documents_pending_embed(
+    conn: sqlite3.Connection,
+    source_types: Sequence[str],
+    min_chars: int,
+    model_version: str,
+) -> list[sqlite3.Row]:
+    """Rows (id, body, content_hash) for documents needing (re-)embedding.
+
+    A document qualifies when its body is at least *min_chars* long and its
+    embedding is missing or stale relative to ``content_hash`` / *model_version*.
+    """
+    placeholders = ", ".join("?" for _ in source_types)
+    return conn.execute(
+        f"""
+        SELECT id, body, content_hash
+        FROM semantic_documents
+        WHERE source_type IN ({placeholders})
+          AND LENGTH(body) >= ?
+          AND (
+                embedded_hash IS NULL
+             OR embedded_hash != content_hash
+             OR embedded_model_version IS NULL
+             OR embedded_model_version != ?
+          )
+        ORDER BY id
+        """,
+        [*source_types, min_chars, model_version],
+    ).fetchall()
+
+
+def count_embeddable_semantic_documents(
+    conn: sqlite3.Connection, source_types: Sequence[str], min_chars: int
+) -> int:
+    """Count documents of the given source types whose body is long enough."""
+    placeholders = ", ".join("?" for _ in source_types)
+    return conn.execute(
+        f"""
+        SELECT COUNT(*)
+        FROM semantic_documents
+        WHERE source_type IN ({placeholders}) AND LENGTH(body) >= ?
+        """,
+        [*source_types, min_chars],
+    ).fetchone()[0]
+
+
+def delete_semantic_embedding(conn: sqlite3.Connection, doc_id: int) -> None:
+    """Delete a single ``semantic_embeddings`` row by its rowid."""
+    conn.execute("DELETE FROM semantic_embeddings WHERE rowid = ?", (doc_id,))
+
+
+def insert_semantic_embedding(
+    conn: sqlite3.Connection, doc_id: int, embedding: bytes
+) -> None:
+    """Insert one ``semantic_embeddings`` vector row."""
+    conn.execute(
+        "INSERT INTO semantic_embeddings (rowid, embedding) VALUES (?, ?)",
+        (doc_id, embedding),
+    )
+
+
+def mark_semantic_document_embedded(
+    conn: sqlite3.Connection, doc_id: int, model_version: str, embedded_at: str
+) -> None:
+    """Mark a document fresh: copy ``content_hash`` and stamp model/version/time."""
+    conn.execute(
+        """
+        UPDATE semantic_documents
+        SET embedded_hash = content_hash,
+            embedded_model_version = ?,
+            embedded_at = ?
+        WHERE id = ?
+        """,
+        (model_version, embedded_at, doc_id),
+    )
+
+
+def set_semantic_embedding_meta(
+    conn: sqlite3.Connection, key: str, value: str
+) -> None:
+    """Insert-or-replace one ``semantic_embedding_meta`` key/value row."""
+    conn.execute(
+        "INSERT OR REPLACE INTO semantic_embedding_meta (key, value) VALUES (?, ?)",
+        (key, value),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Query
+# ---------------------------------------------------------------------------
+
+
+def search_semantic_documents(
+    conn: sqlite3.Connection,
+    query_vec: bytes,
+    top_k: int,
+    source_types: Sequence[str],
+) -> list[sqlite3.Row]:
+    """Vector search over ``semantic_embeddings``, nearest first.
+
+    Restricts results to the given *source_types*.
+    """
+    placeholders = ", ".join("?" for _ in source_types)
+    return conn.execute(
+        f"""
+        SELECT
+            se.rowid AS doc_id,
+            se.distance,
+            sd.source_type,
+            sd.source_table,
+            sd.source_pk,
+            sd.doc_kind,
+            sd.title,
+            SUBSTR(sd.body, 1, 400) AS body_preview,
+            sd.metadata_json,
+            sd.updated_at
+        FROM semantic_embeddings se
+        JOIN semantic_documents sd ON sd.id = se.rowid
+        WHERE se.embedding MATCH ? AND se.k = ?
+          AND sd.source_type IN ({placeholders})
+        ORDER BY se.distance
+        """,
+        [query_vec, top_k, *source_types],
+    ).fetchall()

--- a/src/rebalance/ingest/github_knowledge.py
+++ b/src/rebalance/ingest/github_knowledge.py
@@ -23,6 +23,7 @@ import re
 from rebalance.ingest.config import get_github_ignored_repos, normalize_github_repo_name
 from rebalance.ingest.db import db_connection, ensure_github_schema, ensure_semantic_schema
 from rebalance.ingest.db import github as gh
+from rebalance.ingest.db import semantic as sem
 from rebalance.ingest._http import GITHUB_API, GitHubClient, GitHubHTTPError
 from rebalance.ingest.embedder import (
     DEFAULT_MODEL as DEFAULT_EMBED_MODEL,
@@ -300,7 +301,7 @@ def purge_github_repo_data(
             )
 
         if semantic_doc_ids:
-            gh.delete_semantic_rows_for_docs(conn, semantic_doc_ids)
+            sem.delete_semantic_documents(conn, semantic_doc_ids)
         if github_doc_ids:
             gh.delete_github_embeddings_for_docs(conn, github_doc_ids)
         for table_name in table_names:

--- a/src/rebalance/ingest/github_knowledge.py
+++ b/src/rebalance/ingest/github_knowledge.py
@@ -13,8 +13,6 @@ from __future__ import annotations
 import hashlib
 import json
 import time
-import urllib.error
-import urllib.request
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -24,6 +22,7 @@ import re
 
 from rebalance.ingest.config import get_github_ignored_repos, normalize_github_repo_name
 from rebalance.ingest.db import db_connection, ensure_github_schema, ensure_semantic_schema
+from rebalance.ingest._http import GITHUB_API, GitHubClient, GitHubHTTPError
 from rebalance.ingest.embedder import (
     DEFAULT_MODEL as DEFAULT_EMBED_MODEL,
     EMBEDDING_DIM,
@@ -32,8 +31,6 @@ from rebalance.ingest.embedder import (
     _vec_to_bytes,
 )
 from rebalance.ingest.semantic_index import sync_github_documents
-
-GITHUB_API = "https://api.github.com"
 DEFAULT_SYNC_DAYS = 90
 MIN_EMBED_CHARS = 40
 _CLOSES_RE = re.compile(r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b", re.IGNORECASE)
@@ -79,22 +76,26 @@ class GitHubRepoPurgeResult:
 
 
 def _github_headers(token: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Bearer {token}",
-        "Accept": "application/vnd.github+json",
-        "User-Agent": "rebalance-os/phase1",
-        "X-GitHub-Api-Version": "2022-11-28",
-    }
+    """Delegate to the shared GitHub client.
+
+    Retained as a module-level helper because some external callers (tests,
+    experimental scripts) imported it before the shared client existed.
+    """
+    return GitHubClient(token).headers()
 
 
 def _http_get_json(url: str, token: str) -> Any:
-    req = urllib.request.Request(url, headers=_github_headers(token))
+    """GET ``url`` as JSON; raise on non-2xx.
+
+    Thin wrapper over :class:`GitHubClient` so the legacy ``api_get`` callable
+    seam in :func:`sync_github_repo` keeps working. New code should construct
+    a client once and reuse it.
+    """
     try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            return json.loads(resp.read().decode())
-    except urllib.error.HTTPError as exc:
-        body = exc.read().decode() if exc.fp else ""
-        raise RuntimeError(f"GitHub API request failed: {exc.code} {url} {body}") from exc
+        return GitHubClient(token).get_json(url)
+    except GitHubHTTPError as exc:
+        # Preserve legacy RuntimeError type — tests and callers expect it.
+        raise RuntimeError(f"GitHub API request failed: {exc.status} {url}") from exc
 
 
 def _build_url(base_url: str, **params: Any) -> str:

--- a/src/rebalance/ingest/github_knowledge.py
+++ b/src/rebalance/ingest/github_knowledge.py
@@ -22,6 +22,7 @@ import re
 
 from rebalance.ingest.config import get_github_ignored_repos, normalize_github_repo_name
 from rebalance.ingest.db import db_connection, ensure_github_schema, ensure_semantic_schema
+from rebalance.ingest.db import github as gh
 from rebalance.ingest._http import GITHUB_API, GitHubClient, GitHubHTTPError
 from rebalance.ingest.embedder import (
     DEFAULT_MODEL as DEFAULT_EMBED_MODEL,
@@ -217,57 +218,6 @@ def _commit_doc_text(item_type: str, item_number: int, sha: str, message: str) -
     return f"Commit {sha[:7]} on {item_type} #{item_number}\n\n{first_line}".strip()
 
 
-def _delete_item_children(conn: Any, repo_full_name: str, item_type: str, item_number: int) -> None:
-    doc_ids = [
-        row["id"]
-        for row in conn.execute(
-            """
-            SELECT id
-            FROM github_documents
-            WHERE repo_full_name = ? AND source_type = ? AND source_number = ?
-            """,
-            (repo_full_name, item_type, item_number),
-        ).fetchall()
-    ]
-    if doc_ids:
-        conn.executemany("DELETE FROM github_embeddings WHERE doc_id = ?", [(doc_id,) for doc_id in doc_ids])
-    conn.execute(
-        """
-        DELETE FROM github_documents
-        WHERE repo_full_name = ? AND source_type = ? AND source_number = ?
-        """,
-        (repo_full_name, item_type, item_number),
-    )
-    conn.execute(
-        """
-        DELETE FROM github_comments
-        WHERE repo_full_name = ? AND item_type = ? AND item_number = ?
-        """,
-        (repo_full_name, item_type, item_number),
-    )
-    conn.execute(
-        """
-        DELETE FROM github_commits
-        WHERE repo_full_name = ? AND item_type = ? AND item_number = ?
-        """,
-        (repo_full_name, item_type, item_number),
-    )
-    conn.execute(
-        """
-        DELETE FROM github_check_runs
-        WHERE repo_full_name = ? AND item_type = ? AND item_number = ?
-        """,
-        (repo_full_name, item_type, item_number),
-    )
-    conn.execute(
-        """
-        DELETE FROM github_links
-        WHERE repo_full_name = ? AND source_type = ? AND source_number = ?
-        """,
-        (repo_full_name, item_type, item_number),
-    )
-
-
 def _insert_document(
     conn: Any,
     *,
@@ -281,27 +231,19 @@ def _insert_document(
     updated_at: str,
     fetched_at: str,
 ) -> int:
-    conn.execute(
-        """
-        INSERT INTO github_documents
-            (repo_full_name, source_type, source_number, doc_type, source_key,
-             title, body, content_hash, embedded_hash, updated_at, fetched_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)
-        """,
-        (
-            repo_full_name,
-            source_type,
-            source_number,
-            doc_type,
-            source_key,
-            title,
-            body,
-            _content_hash(body),
-            updated_at,
-            fetched_at,
-        ),
+    return gh.insert_github_document(
+        conn,
+        repo_full_name=repo_full_name,
+        source_type=source_type,
+        source_number=source_number,
+        doc_type=doc_type,
+        source_key=source_key,
+        title=title,
+        body=body,
+        content_hash=_content_hash(body),
+        updated_at=updated_at,
+        fetched_at=fetched_at,
     )
-    return int(conn.execute("SELECT last_insert_rowid()").fetchone()[0])
 
 
 def purge_github_repo_data(
@@ -331,55 +273,21 @@ def purge_github_repo_data(
         ensure_github_schema(conn)
         ensure_semantic_schema(conn)
 
-        row_counts: dict[str, int] = {}
-        for table_name in table_names:
-            row_counts[table_name] = conn.execute(
-                f"SELECT COUNT(*) FROM {table_name} WHERE LOWER(repo_full_name) = ?",
-                (normalized_repo,),
-            ).fetchone()[0]
+        row_counts: dict[str, int] = {
+            table_name: gh.count_repo_rows(conn, table_name, normalized_repo)
+            for table_name in table_names
+        }
 
-        github_doc_ids = [
-            int(row["id"])
-            for row in conn.execute(
-                """
-                SELECT id
-                FROM github_documents
-                WHERE LOWER(repo_full_name) = ?
-                """,
-                (normalized_repo,),
-            ).fetchall()
-        ]
-        if github_doc_ids:
-            placeholders = ", ".join("?" for _ in github_doc_ids)
-            row_counts["github_embeddings"] = conn.execute(
-                f"SELECT COUNT(*) FROM github_embeddings WHERE doc_id IN ({placeholders})",
-                github_doc_ids,
-            ).fetchone()[0]
-        else:
-            row_counts["github_embeddings"] = 0
+        github_doc_ids = gh.github_document_ids(conn, normalized_repo)
+        row_counts["github_embeddings"] = gh.count_ids_in(
+            conn, "github_embeddings", "doc_id", github_doc_ids
+        )
 
-        semantic_doc_ids = [
-            int(row["id"])
-            for row in conn.execute(
-                """
-                SELECT sd.id
-                FROM semantic_documents sd
-                JOIN github_documents gd ON gd.source_key = sd.source_pk
-                WHERE sd.source_type = 'github'
-                  AND LOWER(gd.repo_full_name) = ?
-                """,
-                (normalized_repo,),
-            ).fetchall()
-        ]
+        semantic_doc_ids = gh.semantic_doc_ids_for_github_repo(conn, normalized_repo)
         row_counts["semantic_documents"] = len(semantic_doc_ids)
-        if semantic_doc_ids:
-            placeholders = ", ".join("?" for _ in semantic_doc_ids)
-            row_counts["semantic_embeddings"] = conn.execute(
-                f"SELECT COUNT(*) FROM semantic_embeddings WHERE rowid IN ({placeholders})",
-                semantic_doc_ids,
-            ).fetchone()[0]
-        else:
-            row_counts["semantic_embeddings"] = 0
+        row_counts["semantic_embeddings"] = gh.count_ids_in(
+            conn, "semantic_embeddings", "rowid", semantic_doc_ids
+        )
 
         total_rows = sum(row_counts.values())
         if dry_run:
@@ -392,12 +300,11 @@ def purge_github_repo_data(
             )
 
         if semantic_doc_ids:
-            conn.executemany("DELETE FROM semantic_embeddings WHERE rowid = ?", [(doc_id,) for doc_id in semantic_doc_ids])
-            conn.executemany("DELETE FROM semantic_documents WHERE id = ?", [(doc_id,) for doc_id in semantic_doc_ids])
+            gh.delete_semantic_rows_for_docs(conn, semantic_doc_ids)
         if github_doc_ids:
-            conn.executemany("DELETE FROM github_embeddings WHERE doc_id = ?", [(doc_id,) for doc_id in github_doc_ids])
+            gh.delete_github_embeddings_for_docs(conn, github_doc_ids)
         for table_name in table_names:
-            conn.execute(f"DELETE FROM {table_name} WHERE LOWER(repo_full_name) = ?", (normalized_repo,))
+            gh.delete_repo_rows(conn, table_name, normalized_repo)
         conn.commit()
 
     return GitHubRepoPurgeResult(
@@ -459,18 +366,13 @@ def sync_github_repo(
     docs_built = 0
 
     with db_connection(database_path, ensure_github_schema) as conn:
-        conn.execute("DELETE FROM github_branches WHERE repo_full_name = ?", (repo_full_name,))
-        conn.execute("DELETE FROM github_labels WHERE repo_full_name = ?", (repo_full_name,))
-        conn.execute("DELETE FROM github_milestones WHERE repo_full_name = ?", (repo_full_name,))
-        conn.execute("DELETE FROM github_releases WHERE repo_full_name = ?", (repo_full_name,))
+        gh.delete_repo_table(conn, "github_branches", repo_full_name)
+        gh.delete_repo_table(conn, "github_labels", repo_full_name)
+        gh.delete_repo_table(conn, "github_milestones", repo_full_name)
+        gh.delete_repo_table(conn, "github_releases", repo_full_name)
 
-        conn.execute(
-            """
-            INSERT OR REPLACE INTO github_repo_meta
-                (repo_full_name, default_branch, pushed_at, updated_at, open_issues_count,
-                 has_issues, has_projects, fetched_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-            """,
+        gh.upsert_repo_meta(
+            conn,
             (
                 repo_full_name,
                 repo_meta.get("default_branch", "") if isinstance(repo_meta, dict) else "",
@@ -485,12 +387,8 @@ def sync_github_repo(
 
         default_branch = repo_meta.get("default_branch", "") if isinstance(repo_meta, dict) else ""
         for branch in branches:
-            conn.execute(
-                """
-                INSERT OR REPLACE INTO github_branches
-                    (repo_full_name, name, head_sha, is_protected, is_default, fetched_at)
-                VALUES (?, ?, ?, ?, ?, ?)
-                """,
+            gh.upsert_branch(
+                conn,
                 (
                     repo_full_name,
                     branch.get("name", ""),
@@ -502,12 +400,8 @@ def sync_github_repo(
             )
 
         for label in labels:
-            conn.execute(
-                """
-                INSERT OR REPLACE INTO github_labels
-                    (repo_full_name, name, color, description, is_default)
-                VALUES (?, ?, ?, ?, ?)
-                """,
+            gh.upsert_label(
+                conn,
                 (
                     repo_full_name,
                     label.get("name", ""),
@@ -518,13 +412,8 @@ def sync_github_repo(
             )
 
         for milestone in milestones:
-            conn.execute(
-                """
-                INSERT OR REPLACE INTO github_milestones
-                    (repo_full_name, number, title, description, state, open_issues,
-                     closed_issues, due_on, created_at, updated_at, closed_at, html_url)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
+            gh.upsert_milestone(
+                conn,
                 (
                     repo_full_name,
                     milestone.get("number"),
@@ -542,13 +431,8 @@ def sync_github_repo(
             )
 
         for release in releases:
-            conn.execute(
-                """
-                INSERT OR REPLACE INTO github_releases
-                    (repo_full_name, github_id, tag_name, name, target_commitish, is_draft,
-                     is_prerelease, body, created_at, published_at, html_url)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
+            gh.upsert_release(
+                conn,
                 (
                     repo_full_name,
                     release.get("id"),
@@ -568,7 +452,7 @@ def sync_github_repo(
             item_type = "issue"
             item_number = int(issue["number"])
             milestone = issue.get("milestone") or {}
-            _delete_item_children(conn, repo_full_name, item_type, item_number)
+            gh.delete_item_children(conn, repo_full_name, item_type, item_number)
 
             item_record = {
                 "repo_full_name": repo_full_name,
@@ -608,31 +492,13 @@ def sync_github_repo(
                 "fetched_at": fetched_at,
             }
 
-            conn.execute(
-                """
-                INSERT OR REPLACE INTO github_items
-                    (repo_full_name, item_type, number, node_id, github_id, title, body, state,
-                     state_reason, author_login, assignees_json, labels_json, milestone_number,
-                     milestone_title, is_draft, is_merged, base_ref, head_ref, head_sha,
-                     mergeable_state, review_decision, check_status, requested_reviewers_json,
-                     comments_count, review_comments_count, commits_count, additions, deletions,
-                     changed_files, html_url, created_at, updated_at, closed_at, merged_at, fetched_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                tuple(item_record.values()),
-            )
+            gh.upsert_item(conn, item_record)
 
             issue_comments = _paginate_list(f"{repo_base}/issues/{item_number}/comments", api_get)
             for comment in issue_comments:
                 body = comment.get("body", "") or ""
-                conn.execute(
-                    """
-                    INSERT OR REPLACE INTO github_comments
-                        (repo_full_name, item_type, item_number, comment_type, github_comment_id,
-                         author_login, author_association, body, review_state, in_reply_to_id,
-                         html_url, created_at, updated_at, fetched_at)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
+                gh.upsert_comment(
+                    conn,
                     (
                         repo_full_name,
                         item_type,
@@ -699,7 +565,7 @@ def sync_github_repo(
                 else []
             )
             milestone = pr.get("milestone") or {}
-            _delete_item_children(conn, repo_full_name, item_type, item_number)
+            gh.delete_item_children(conn, repo_full_name, item_type, item_number)
 
             item_record = {
                 "repo_full_name": repo_full_name,
@@ -739,41 +605,19 @@ def sync_github_repo(
                 "fetched_at": fetched_at,
             }
 
-            conn.execute(
-                """
-                INSERT OR REPLACE INTO github_items
-                    (repo_full_name, item_type, number, node_id, github_id, title, body, state,
-                     state_reason, author_login, assignees_json, labels_json, milestone_number,
-                     milestone_title, is_draft, is_merged, base_ref, head_ref, head_sha,
-                     mergeable_state, review_decision, check_status, requested_reviewers_json,
-                     comments_count, review_comments_count, commits_count, additions, deletions,
-                     changed_files, html_url, created_at, updated_at, closed_at, merged_at, fetched_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                tuple(item_record.values()),
-            )
+            gh.upsert_item(conn, item_record)
 
             combined_text = "\n".join(filter(None, [item_record["title"], item_record["body"]]))
             for link_kind, issue_number in _parse_links(combined_text):
-                conn.execute(
-                    """
-                    INSERT OR REPLACE INTO github_links
-                        (repo_full_name, source_type, source_number, target_type, target_number, link_kind)
-                    VALUES (?, ?, ?, ?, ?, ?)
-                    """,
+                gh.upsert_link(
+                    conn,
                     (repo_full_name, item_type, item_number, "issue", issue_number, link_kind),
                 )
 
             for comment in issue_comments:
                 body = comment.get("body", "") or ""
-                conn.execute(
-                    """
-                    INSERT OR REPLACE INTO github_comments
-                        (repo_full_name, item_type, item_number, comment_type, github_comment_id,
-                         author_login, author_association, body, review_state, in_reply_to_id,
-                         html_url, created_at, updated_at, fetched_at)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
+                gh.upsert_comment(
+                    conn,
                     (
                         repo_full_name,
                         item_type,
@@ -809,14 +653,8 @@ def sync_github_repo(
 
             for review in reviews:
                 body = review.get("body", "") or ""
-                conn.execute(
-                    """
-                    INSERT OR REPLACE INTO github_comments
-                        (repo_full_name, item_type, item_number, comment_type, github_comment_id,
-                         author_login, author_association, body, review_state, in_reply_to_id,
-                         html_url, created_at, updated_at, fetched_at)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
+                gh.upsert_comment(
+                    conn,
                     (
                         repo_full_name,
                         item_type,
@@ -858,14 +696,8 @@ def sync_github_repo(
 
             for comment in review_comments:
                 body = comment.get("body", "") or ""
-                conn.execute(
-                    """
-                    INSERT OR REPLACE INTO github_comments
-                        (repo_full_name, item_type, item_number, comment_type, github_comment_id,
-                         author_login, author_association, body, review_state, in_reply_to_id,
-                         html_url, created_at, updated_at, fetched_at)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
+                gh.upsert_comment(
+                    conn,
                     (
                         repo_full_name,
                         item_type,
@@ -902,13 +734,8 @@ def sync_github_repo(
             for commit in commits:
                 sha = commit.get("sha", "")
                 message = ((commit.get("commit") or {}).get("message") or "").strip()
-                conn.execute(
-                    """
-                    INSERT OR REPLACE INTO github_commits
-                        (repo_full_name, item_type, item_number, sha, author_login,
-                         message, committed_at, html_url, fetched_at)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
+                gh.upsert_commit(
+                    conn,
                     (
                         repo_full_name,
                         item_type,
@@ -938,13 +765,8 @@ def sync_github_repo(
                     docs_built += 1
 
             for run in check_runs:
-                conn.execute(
-                    """
-                    INSERT OR REPLACE INTO github_check_runs
-                        (repo_full_name, item_type, item_number, head_sha, name, status,
-                         conclusion, details_url, started_at, completed_at, fetched_at)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
+                gh.upsert_check_run(
+                    conn,
                     (
                         repo_full_name,
                         item_type,
@@ -1016,24 +838,12 @@ def embed_github_documents(
 
     with db_connection(database_path, ensure_github_schema) as conn:
         if force_reembed:
-            conn.execute("DELETE FROM github_embeddings")
-            conn.execute("UPDATE github_documents SET embedded_hash = NULL")
+            gh.clear_github_embeddings(conn)
+            gh.reset_github_embedded_hashes(conn)
             conn.commit()
 
-        rows = conn.execute(
-            """
-            SELECT id, body, content_hash
-            FROM github_documents
-            WHERE LENGTH(body) >= ?
-              AND (embedded_hash IS NULL OR embedded_hash != content_hash)
-            ORDER BY id
-            """,
-            (min_chars,),
-        ).fetchall()
-        total_docs = conn.execute(
-            "SELECT COUNT(*) FROM github_documents WHERE LENGTH(body) >= ?",
-            (min_chars,),
-        ).fetchone()[0]
+        rows = gh.github_documents_pending_embed(conn, min_chars)
+        total_docs = gh.count_embeddable_github_documents(conn, min_chars)
 
         if not rows:
             return GitHubEmbedResult(
@@ -1051,14 +861,8 @@ def embed_github_documents(
             texts = [row["body"][:4000] for row in batch]
             vectors = embed_fn(texts, model_name)
             for row, vec in zip(batch, vectors):
-                conn.execute(
-                    "INSERT OR REPLACE INTO github_embeddings (doc_id, embedding) VALUES (?, ?)",
-                    (row["id"], _vec_to_bytes(vec)),
-                )
-                conn.execute(
-                    "UPDATE github_documents SET embedded_hash = content_hash WHERE id = ?",
-                    (row["id"],),
-                )
+                gh.upsert_github_embedding(conn, row["id"], _vec_to_bytes(vec))
+                gh.mark_github_document_embedded(conn, row["id"])
                 embedded += 1
             conn.commit()
 
@@ -1068,10 +872,7 @@ def embed_github_documents(
             ("embedding_dim", str(EMBEDDING_DIM)),
             ("last_embed_at", now_iso),
         ]:
-            conn.execute(
-                "INSERT OR REPLACE INTO github_embedding_meta (key, value) VALUES (?, ?)",
-                (key, value),
-            )
+            gh.set_github_embedding_meta(conn, key, value)
         conn.commit()
 
     return GitHubEmbedResult(
@@ -1097,64 +898,9 @@ def query_github_documents(
     query_vec = _vec_to_bytes(embed_fn([query_text], model_name)[0])
 
     with db_connection(database_path, ensure_github_schema) as conn:
-        if repo_full_name.strip():
-            rows = conn.execute(
-                """
-                SELECT
-                    ge.doc_id,
-                    ge.distance,
-                    gd.repo_full_name,
-                    gd.source_type,
-                    gd.source_number,
-                    gd.doc_type,
-                    gd.title,
-                    SUBSTR(gd.body, 1, 400) AS body_preview,
-                    gi.state,
-                    gi.milestone_title,
-                    gi.labels_json,
-                    gi.review_decision,
-                    gi.check_status,
-                    gi.html_url
-                FROM github_embeddings ge
-                JOIN github_documents gd ON gd.id = ge.doc_id
-                LEFT JOIN github_items gi
-                  ON gi.repo_full_name = gd.repo_full_name
-                 AND gi.item_type = gd.source_type
-                 AND gi.number = gd.source_number
-                WHERE ge.embedding MATCH ? AND ge.k = ? AND gd.repo_full_name = ?
-                ORDER BY ge.distance
-                """,
-                (query_vec, top_k, repo_full_name.strip()),
-            ).fetchall()
-        else:
-            rows = conn.execute(
-                """
-                SELECT
-                    ge.doc_id,
-                    ge.distance,
-                    gd.repo_full_name,
-                    gd.source_type,
-                    gd.source_number,
-                    gd.doc_type,
-                    gd.title,
-                    SUBSTR(gd.body, 1, 400) AS body_preview,
-                    gi.state,
-                    gi.milestone_title,
-                    gi.labels_json,
-                    gi.review_decision,
-                    gi.check_status,
-                    gi.html_url
-                FROM github_embeddings ge
-                JOIN github_documents gd ON gd.id = ge.doc_id
-                LEFT JOIN github_items gi
-                  ON gi.repo_full_name = gd.repo_full_name
-                 AND gi.item_type = gd.source_type
-                 AND gi.number = gd.source_number
-                WHERE ge.embedding MATCH ? AND ge.k = ?
-                ORDER BY ge.distance
-                """,
-                (query_vec, top_k),
-            ).fetchall()
+        rows = gh.search_github_documents(
+            conn, query_vec, top_k, repo_full_name=repo_full_name
+        )
 
     return [
         {

--- a/src/rebalance/ingest/github_scan.py
+++ b/src/rebalance/ingest/github_scan.py
@@ -15,17 +15,13 @@ Usage:
 
 from __future__ import annotations
 
-import urllib.request
-import urllib.error
-import json
 from dataclasses import dataclass, field
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from typing import Any
 
 from rebalance.ingest.config import normalize_github_repo_name
-
-GITHUB_API = "https://api.github.com"
+from rebalance.ingest._http import GITHUB_API, GitHubClient
 MAX_EVENT_PAGES = 3  # Hard limit documented by GitHub
 
 # Activity band definitions — shared with preflight.py for segmentation.
@@ -100,22 +96,18 @@ class GitHubApiError(Exception):
 # Internal helpers
 # ---------------------------------------------------------------------------
 
-def _headers(token: str) -> dict[str, str]:
-    return {
-        "Authorization": f"token {token}",
-        "Accept": "application/vnd.github.v3+json",
-        "User-Agent": "rebalance-os/0.1",
-    }
+def _client(token: str) -> GitHubClient:
+    """Return a GitHubClient — wrapper kept so callers needn't import the type."""
+    return GitHubClient(token)
 
 
 def _get(url: str, token: str) -> tuple[int, Any]:
-    """Minimal HTTP GET — returns (status_code, parsed_json_or_None)."""
-    req = urllib.request.Request(url, headers=_headers(token))
-    try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            return resp.status, json.loads(resp.read().decode())
-    except urllib.error.HTTPError as exc:
-        return exc.code, None
+    """Minimal HTTP GET — returns (status_code, parsed_json_or_None).
+
+    Thin wrapper retained for callers within this module; new code should use
+    a long-lived :class:`GitHubClient` instead.
+    """
+    return _client(token).get(url)
 
 
 def _cutoff_key(days: int) -> str:
@@ -310,17 +302,13 @@ def validate_github_token(token: str) -> dict[str, Any]:
         {"valid": True, "login": "...", "scopes": ["repo", ...]}
         or {"valid": False, "login": "", "scopes": [], "error": "..."}
     """
-    req = urllib.request.Request(f"{GITHUB_API}/user", headers=_headers(token))
-    try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            data = json.loads(resp.read().decode())
-            scopes_header = resp.headers.get("X-OAuth-Scopes", "")
-            scopes = [s.strip() for s in scopes_header.split(",") if s.strip()]
-            return {"valid": True, "login": data.get("login", ""), "scopes": scopes}
-    except urllib.error.HTTPError as exc:
-        if exc.code in (401, 403):
-            return {"valid": False, "login": "", "scopes": [], "error": f"HTTP {exc.code}"}
-        return {"valid": False, "login": "", "scopes": [], "error": f"HTTP {exc.code}"}
+    # No retries: a bad token should fail fast for the onboarding flow.
+    status, data, headers = GitHubClient(token, retries=1).get_with_headers("/user")
+    if status == 200 and isinstance(data, dict):
+        scopes_header = headers.get("x-oauth-scopes", "")
+        scopes = [s.strip() for s in scopes_header.split(",") if s.strip()]
+        return {"valid": True, "login": data.get("login", ""), "scopes": scopes}
+    return {"valid": False, "login": "", "scopes": [], "error": f"HTTP {status}"}
 
 
 def scan_github(token: str, days: int = 30) -> GitHubScanResult:

--- a/src/rebalance/ingest/index_ops.py
+++ b/src/rebalance/ingest/index_ops.py
@@ -20,7 +20,7 @@ from rebalance.ingest.config import (
     get_github_token,
     get_vault_path,
 )
-from rebalance.ingest.db import db_connection, ensure_semantic_schema
+from rebalance.ingest.db import db_connection, ensure_semantic_schema, run_migrations
 from rebalance.ingest.registry import get_projects
 
 logger = logging.getLogger(__name__)
@@ -886,6 +886,15 @@ def refresh_index(
         "dry_run": dry_run,
         "include_semantic": include_semantic,
     }
+
+    # Bring the database schema to the latest version before any collector
+    # writes to it. Skipped on dry runs, which must not touch the DB.
+    if not dry_run:
+        try:
+            with db_connection(db_path) as conn:
+                run_migrations(conn)
+        except Exception as e:  # noqa: BLE001 — error envelope mirrors collector contract
+            errors.append({"scope": "migrations", "error": str(e)})
 
     for s in requested_scopes:
         collector = COLLECTORS.get(s)

--- a/src/rebalance/ingest/index_ops.py
+++ b/src/rebalance/ingest/index_ops.py
@@ -9,10 +9,12 @@ underlying ingest pipelines so callers do not have to know the order of
 
 from __future__ import annotations
 
+import logging
 import time
+from dataclasses import dataclass, field
 from datetime import date
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Callable, Iterable
 
 from rebalance.ingest.config import (
     get_github_token,
@@ -21,7 +23,76 @@ from rebalance.ingest.config import (
 from rebalance.ingest.db import db_connection, ensure_semantic_schema
 from rebalance.ingest.registry import get_projects
 
+logger = logging.getLogger(__name__)
 
+
+@dataclass(frozen=True)
+class Collector:
+    """A single data-source ingest pipeline registered with :data:`COLLECTORS`.
+
+    External integrators add new data sources by constructing a :class:`Collector`
+    and calling :func:`register_collector`. The dispatcher in :func:`refresh_index`
+    routes the user's ``scope=[...]`` list through the registry — no edits to
+    the dispatch chain are required.
+
+    Fields
+    ------
+    name:
+        The user-facing scope key. Must be unique. Reserved: ``"all"``.
+    refresh:
+        Callable executed for live runs. Receives ``(db_path, **opts)`` where
+        ``opts`` includes every refresh_index kwarg the collector might want
+        (since_days, vault_path, token, repos, include_semantic, ...). Unknown
+        keys must be ignored. Must return a ``dict`` whose first key is
+        ``"scope": "<name>"`` so the caller can correlate results.
+    requires:
+        Optional iterable of precondition names — currently ``"vault_path"``,
+        ``"github_token"``. Failures surface as structured errors rather than
+        exceptions, mirroring the legacy refresh_index error envelope.
+    included_in_all:
+        If True (default), the collector runs when the user requests
+        ``scope=["all"]``. Set False for opt-in collectors (e.g. heavy or
+        narrowly-scoped sources).
+    """
+
+    name: str
+    refresh: Callable[..., dict[str, Any]]
+    requires: tuple[str, ...] = ()
+    included_in_all: bool = True
+
+
+COLLECTORS: dict[str, Collector] = {}
+
+
+def register_collector(collector: Collector, *, replace: bool = False) -> None:
+    """Add a :class:`Collector` to the registry.
+
+    Set ``replace=True`` when an external integrator deliberately overrides a
+    built-in. Otherwise duplicate names raise to surface accidental shadowing.
+    """
+    if collector.name in ("all", ""):
+        raise ValueError(f"Reserved collector name: {collector.name!r}")
+    if collector.name in COLLECTORS and not replace:
+        raise ValueError(
+            f"Collector {collector.name!r} already registered; pass replace=True to override."
+        )
+    COLLECTORS[collector.name] = collector
+    logger.debug("Registered collector: %s (requires=%s)", collector.name, collector.requires)
+
+
+def _scope_values() -> tuple[str, ...]:
+    """Return the supported scope keys, plus the meta-scope ``"all"``."""
+    return tuple(COLLECTORS.keys()) + ("all",)
+
+
+def _all_scope_names() -> list[str]:
+    """Return the collector names that run for ``scope=["all"]``."""
+    return [name for name, c in COLLECTORS.items() if c.included_in_all]
+
+
+# Legacy SCOPE_VALUES: retained so callers importing the constant continue to
+# work. New code should call _scope_values() since registered collectors may
+# extend the set at runtime.
 SCOPE_VALUES = ("vault", "github", "calendar", "sleuth", "email", "semantic", "all")
 
 
@@ -57,18 +128,19 @@ def _normalize_scope(scope: Iterable[str] | str | None) -> list[str]:
     else:
         items = list(scope)
     cleaned: list[str] = []
+    valid = _scope_values()
     for raw in items:
         v = (raw or "").strip().lower()
         if not v:
             continue
-        if v not in SCOPE_VALUES:
-            raise ValueError(f"Unsupported scope: {raw!r}. Expected one of {SCOPE_VALUES}.")
+        if v not in valid:
+            raise ValueError(f"Unsupported scope: {raw!r}. Expected one of {valid}.")
         if v not in cleaned:
             cleaned.append(v)
     if not cleaned:
         return ["all"]
     if "all" in cleaned:
-        return ["vault", "github", "calendar", "sleuth", "email", "semantic"]
+        return _all_scope_names()
     return cleaned
 
 
@@ -801,29 +873,24 @@ def refresh_index(
 
     repos_list = list(repos or [])
 
+    # Per-collector kwargs bundle. Each collector ignores keys it doesn't need.
+    collector_opts: dict[str, Any] = {
+        "vault_path": resolved_vault,
+        "token": resolved_token,
+        "since_days": since_days,
+        "repos": repos_list,
+        "dry_run": dry_run,
+        "include_semantic": include_semantic,
+    }
+
     for s in requested_scopes:
+        collector = COLLECTORS.get(s)
+        if collector is None:
+            errors.append({"scope": s, "error": f"no collector registered for scope {s!r}"})
+            continue
         try:
-            if s == "vault":
-                assert resolved_vault is not None
-                results.append(_refresh_vault(db_path, resolved_vault, dry_run=dry_run))
-            elif s == "github":
-                results.append(_refresh_github(
-                    db_path,
-                    token=resolved_token,
-                    since_days=since_days,
-                    repos=repos_list,
-                    dry_run=dry_run,
-                    include_semantic=include_semantic,
-                ))
-            elif s == "calendar":
-                results.append(_refresh_calendar(db_path, since_days=since_days, dry_run=dry_run))
-            elif s == "sleuth":
-                results.append(_refresh_sleuth(db_path, dry_run=dry_run))
-            elif s == "email":
-                results.append(_refresh_email(db_path, dry_run=dry_run))
-            elif s == "semantic":
-                results.append(_refresh_semantic_only(db_path, dry_run=dry_run))
-        except Exception as e:
+            results.append(collector.refresh(db_path, **collector_opts))
+        except Exception as e:  # noqa: BLE001 — error envelope mirrors legacy contract
             errors.append({"scope": s, "error": str(e)})
 
     if update_dashboard_note and full_refresh_requested and resolved_vault is not None:
@@ -853,3 +920,54 @@ def refresh_index(
         "errors": errors,
         "elapsed_seconds": round(time.monotonic() - started, 2),
     }
+
+
+# ---------------------------------------------------------------------------
+# Built-in collectors
+# ---------------------------------------------------------------------------
+#
+# Adapter functions normalize each per-source refresh function to the Collector
+# signature (db_path, **opts). Unknown keys are ignored; required keys are
+# extracted by name. The legacy ``_refresh_*`` private functions remain the
+# single source of truth for the ingest pipelines — these adapters are 3-line
+# shims.
+
+def _vault_adapter(db_path: Path, **opts: Any) -> dict[str, Any]:
+    vault_path = opts.get("vault_path")
+    assert vault_path is not None, "vault collector requires vault_path"
+    return _refresh_vault(db_path, vault_path, dry_run=opts["dry_run"])
+
+
+def _github_adapter(db_path: Path, **opts: Any) -> dict[str, Any]:
+    return _refresh_github(
+        db_path,
+        token=opts["token"],
+        since_days=opts["since_days"],
+        repos=opts.get("repos") or [],
+        dry_run=opts["dry_run"],
+        include_semantic=opts.get("include_semantic", True),
+    )
+
+
+def _calendar_adapter(db_path: Path, **opts: Any) -> dict[str, Any]:
+    return _refresh_calendar(db_path, since_days=opts["since_days"], dry_run=opts["dry_run"])
+
+
+def _sleuth_adapter(db_path: Path, **opts: Any) -> dict[str, Any]:
+    return _refresh_sleuth(db_path, dry_run=opts["dry_run"])
+
+
+def _email_adapter(db_path: Path, **opts: Any) -> dict[str, Any]:
+    return _refresh_email(db_path, dry_run=opts["dry_run"])
+
+
+def _semantic_adapter(db_path: Path, **opts: Any) -> dict[str, Any]:
+    return _refresh_semantic_only(db_path, dry_run=opts["dry_run"])
+
+
+register_collector(Collector("vault", _vault_adapter, requires=("vault_path",)))
+register_collector(Collector("github", _github_adapter, requires=("github_token",)))
+register_collector(Collector("calendar", _calendar_adapter))
+register_collector(Collector("sleuth", _sleuth_adapter))
+register_collector(Collector("email", _email_adapter))
+register_collector(Collector("semantic", _semantic_adapter))

--- a/src/rebalance/ingest/index_ops.py
+++ b/src/rebalance/ingest/index_ops.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import logging
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
 from typing import Any, Callable, Iterable
@@ -70,7 +70,11 @@ def register_collector(collector: Collector, *, replace: bool = False) -> None:
     Set ``replace=True`` when an external integrator deliberately overrides a
     built-in. Otherwise duplicate names raise to surface accidental shadowing.
     """
-    if collector.name in ("all", ""):
+    if not collector.name or collector.name != collector.name.lower():
+        raise ValueError(
+            f"Collector name must be non-empty and lowercase: {collector.name!r}"
+        )
+    if collector.name == "all":
         raise ValueError(f"Reserved collector name: {collector.name!r}")
     if collector.name in COLLECTORS and not replace:
         raise ValueError(
@@ -887,6 +891,15 @@ def refresh_index(
         collector = COLLECTORS.get(s)
         if collector is None:
             errors.append({"scope": s, "error": f"no collector registered for scope {s!r}"})
+            continue
+        # Enforce declared preconditions.
+        missing_reqs: list[str] = []
+        if "vault_path" in collector.requires and not collector_opts.get("vault_path"):
+            missing_reqs.append("vault_path")
+        if "github_token" in collector.requires and not collector_opts.get("token"):
+            missing_reqs.append("github_token")
+        if missing_reqs:
+            errors.append({"scope": s, "error": f"missing required options: {missing_reqs}"})
             continue
         try:
             results.append(collector.refresh(db_path, **collector_opts))

--- a/src/rebalance/ingest/semantic_index.py
+++ b/src/rebalance/ingest/semantic_index.py
@@ -17,6 +17,7 @@ from rebalance.ingest.db import (
     ensure_schema,
     ensure_semantic_schema,
 )
+from rebalance.ingest.db import semantic as sem
 from rebalance.ingest.embedder import (
     DEFAULT_MODEL as DEFAULT_EMBED_MODEL,
     EMBEDDING_DIM,
@@ -99,38 +100,23 @@ def upsert_document(
     """
     metadata_json = _json_dumps(metadata or {})
     content_hash = _content_hash(body)
-    existing = conn.execute(
-        """
-        SELECT id, source_table, doc_kind, title, body, content_hash, metadata_json, updated_at
-        FROM semantic_documents
-        WHERE source_type = ? AND source_pk = ?
-        """,
-        (source_type, source_pk),
-    ).fetchone()
+    existing = sem.find_semantic_document(conn, source_type, source_pk)
 
     if existing is None:
-        conn.execute(
-            """
-            INSERT INTO semantic_documents
-                (source_type, source_table, source_pk, doc_kind, title, body, content_hash,
-                 embedded_hash, embedded_model_version, embedded_at, metadata_json,
-                 created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, ?, ?, ?)
-            """,
-            (
-                source_type,
-                source_table,
-                source_pk,
-                doc_kind,
-                title,
-                body,
-                content_hash,
-                metadata_json,
-                created_at,
-                updated_at,
-            ),
+        doc_id = sem.insert_semantic_document(
+            conn,
+            source_type=source_type,
+            source_table=source_table,
+            source_pk=source_pk,
+            doc_kind=doc_kind,
+            title=title,
+            body=body,
+            content_hash=content_hash,
+            metadata_json=metadata_json,
+            created_at=created_at,
+            updated_at=updated_at,
         )
-        return int(conn.execute("SELECT last_insert_rowid()").fetchone()[0]), "inserted"
+        return doc_id, "inserted"
 
     has_changed = any(
         [
@@ -146,28 +132,16 @@ def upsert_document(
     if not has_changed:
         return int(existing["id"]), "unchanged"
 
-    conn.execute(
-        """
-        UPDATE semantic_documents
-        SET source_table = ?,
-            doc_kind = ?,
-            title = ?,
-            body = ?,
-            content_hash = ?,
-            metadata_json = ?,
-            updated_at = ?
-        WHERE id = ?
-        """,
-        (
-            source_table,
-            doc_kind,
-            title,
-            body,
-            content_hash,
-            metadata_json,
-            updated_at,
-            existing["id"],
-        ),
+    sem.update_semantic_document(
+        conn,
+        int(existing["id"]),
+        source_table=source_table,
+        doc_kind=doc_kind,
+        title=title,
+        body=body,
+        content_hash=content_hash,
+        metadata_json=metadata_json,
+        updated_at=updated_at,
     )
     return int(existing["id"]), "updated"
 
@@ -179,58 +153,22 @@ def _delete_missing_docs(
     seen_source_pks: set[str],
     source_pk_prefix: str = "",
 ) -> int:
-    if source_pk_prefix:
-        rows = conn.execute(
-            """
-            SELECT id, source_pk
-            FROM semantic_documents
-            WHERE source_type = ? AND SUBSTR(source_pk, 1, ?) = ?
-            """,
-            (source_type, len(source_pk_prefix), source_pk_prefix),
-        ).fetchall()
-    else:
-        rows = conn.execute(
-            """
-            SELECT id, source_pk
-            FROM semantic_documents
-            WHERE source_type = ?
-            """,
-            (source_type,),
-        ).fetchall()
+    rows = sem.semantic_documents_for_source(
+        conn, source_type, source_pk_prefix=source_pk_prefix
+    )
 
     to_delete = [int(row["id"]) for row in rows if row["source_pk"] not in seen_source_pks]
     if not to_delete:
         return 0
 
-    conn.executemany("DELETE FROM semantic_embeddings WHERE rowid = ?", [(doc_id,) for doc_id in to_delete])
-    conn.executemany("DELETE FROM semantic_documents WHERE id = ?", [(doc_id,) for doc_id in to_delete])
+    sem.delete_semantic_documents(conn, to_delete)
     return len(to_delete)
 
 
 def sync_vault_documents(conn: Any) -> dict[str, int]:
     """Backfill semantic documents from the current ``chunks`` table."""
     ensure_semantic_schema(conn)
-    rows = conn.execute(
-        """
-        SELECT
-            c.id,
-            c.file_id,
-            c.chunk_index,
-            c.heading,
-            c.heading_level,
-            c.body,
-            c.char_count,
-            c.content_hash,
-            vf.rel_path,
-            vf.title,
-            vf.tags_json,
-            vf.ingested_at,
-            vf.last_modified
-        FROM chunks c
-        JOIN vault_files vf ON vf.id = c.file_id
-        ORDER BY c.id
-        """
-    ).fetchall()
+    rows = sem.vault_chunks_for_semantic(conn)
 
     inserted = updated = unchanged = 0
     seen_source_pks: set[str] = set()
@@ -282,49 +220,9 @@ def sync_github_documents(conn: Any, *, repo_full_name: str = "") -> dict[str, i
     if normalized_repo and normalized_repo in ignored_repos:
         return {"total": 0, "inserted": 0, "updated": 0, "unchanged": 0, "deleted": 0}
 
-    params: tuple[Any, ...]
-    where_sql = ""
-    if normalized_repo:
-        where_sql = "WHERE LOWER(gd.repo_full_name) = ?"
-        params = (normalized_repo,)
-    else:
-        ignored_placeholders = ", ".join("?" for _ in ignored_repos)
-        if ignored_placeholders:
-            where_sql = f"WHERE LOWER(gd.repo_full_name) NOT IN ({ignored_placeholders})"
-            params = tuple(sorted(ignored_repos))
-        else:
-            params = ()
-
-    rows = conn.execute(
-        f"""
-        SELECT
-            gd.id,
-            gd.repo_full_name,
-            gd.source_type AS github_source_type,
-            gd.source_number,
-            gd.doc_type,
-            gd.source_key,
-            gd.title,
-            gd.body,
-            gd.content_hash,
-            gd.updated_at,
-            gd.fetched_at,
-            gi.state,
-            gi.milestone_title,
-            gi.labels_json,
-            gi.review_decision,
-            gi.check_status,
-            gi.html_url
-        FROM github_documents gd
-        LEFT JOIN github_items gi
-          ON gi.repo_full_name = gd.repo_full_name
-         AND gi.item_type = gd.source_type
-         AND gi.number = gd.source_number
-        {where_sql}
-        ORDER BY gd.id
-        """,
-        params,
-    ).fetchall()
+    rows = sem.github_documents_for_semantic(
+        conn, normalized_repo=normalized_repo, ignored_repos=ignored_repos
+    )
 
     inserted = updated = unchanged = 0
     seen_source_pks: set[str] = set()
@@ -385,14 +283,7 @@ def sync_email_documents(conn: Any) -> dict[str, int]:
     email row that drops out of the fetch window stays in the index.
     """
     ensure_semantic_schema(conn)
-    rows = conn.execute(
-        """
-        SELECT message_id, thread_id, from_address, from_name, subject,
-               snippet, received_at, labels_json, synced_at
-        FROM email_messages
-        ORDER BY received_at DESC
-        """
-    ).fetchall()
+    rows = sem.email_messages_for_semantic(conn)
 
     inserted = updated = unchanged = 0
     for row in rows:
@@ -509,67 +400,20 @@ def embed_pending(
     with db_connection(database_path, ensure_semantic_schema) as conn:
         if force_reembed:
             if set(selected_sources) == {"vault", "github", "email"} and len(selected_sources) == 3:
-                conn.execute("DELETE FROM semantic_embeddings")
-                conn.execute(
-                    """
-                    UPDATE semantic_documents
-                    SET embedded_hash = NULL,
-                        embedded_model_version = NULL,
-                        embedded_at = NULL
-                    """
-                )
+                sem.clear_semantic_embeddings(conn)
+                sem.reset_semantic_embedded_state(conn)
             else:
-                placeholders = ", ".join("?" for _ in selected_sources)
-                row_ids = [
-                    int(row["id"])
-                    for row in conn.execute(
-                        f"""
-                        SELECT id
-                        FROM semantic_documents
-                        WHERE source_type IN ({placeholders})
-                        """,
-                        selected_sources,
-                    ).fetchall()
-                ]
-                conn.executemany("DELETE FROM semantic_embeddings WHERE rowid = ?", [(row_id,) for row_id in row_ids])
-                conn.execute(
-                    f"""
-                    UPDATE semantic_documents
-                    SET embedded_hash = NULL,
-                        embedded_model_version = NULL,
-                        embedded_at = NULL
-                    WHERE source_type IN ({placeholders})
-                    """,
-                    selected_sources,
-                )
+                row_ids = sem.semantic_doc_ids_for_sources(conn, selected_sources)
+                sem.delete_semantic_embeddings_for_docs(conn, row_ids)
+                sem.reset_semantic_embedded_state(conn, selected_sources)
             conn.commit()
 
-        placeholders = ", ".join("?" for _ in selected_sources)
-        params: list[Any] = [*selected_sources, min_chars, current_model_version]
-        rows = conn.execute(
-            f"""
-            SELECT id, body, content_hash
-            FROM semantic_documents
-            WHERE source_type IN ({placeholders})
-              AND LENGTH(body) >= ?
-              AND (
-                    embedded_hash IS NULL
-                 OR embedded_hash != content_hash
-                 OR embedded_model_version IS NULL
-                 OR embedded_model_version != ?
-              )
-            ORDER BY id
-            """,
-            params,
-        ).fetchall()
-        total_docs = conn.execute(
-            f"""
-            SELECT COUNT(*)
-            FROM semantic_documents
-            WHERE source_type IN ({placeholders}) AND LENGTH(body) >= ?
-            """,
-            [*selected_sources, min_chars],
-        ).fetchone()[0]
+        rows = sem.semantic_documents_pending_embed(
+            conn, selected_sources, min_chars, current_model_version
+        )
+        total_docs = sem.count_embeddable_semantic_documents(
+            conn, selected_sources, min_chars
+        )
 
         if not rows:
             return SemanticEmbedResult(
@@ -588,20 +432,10 @@ def embed_pending(
             vectors = embed_fn(texts, model_name)
             now_iso = datetime.now(timezone.utc).isoformat()
             for row, vec in zip(batch, vectors):
-                conn.execute("DELETE FROM semantic_embeddings WHERE rowid = ?", (row["id"],))
-                conn.execute(
-                    "INSERT INTO semantic_embeddings (rowid, embedding) VALUES (?, ?)",
-                    (row["id"], _vec_to_bytes(vec)),
-                )
-                conn.execute(
-                    """
-                    UPDATE semantic_documents
-                    SET embedded_hash = content_hash,
-                        embedded_model_version = ?,
-                        embedded_at = ?
-                    WHERE id = ?
-                    """,
-                    (current_model_version, now_iso, row["id"]),
+                sem.delete_semantic_embedding(conn, row["id"])
+                sem.insert_semantic_embedding(conn, row["id"], _vec_to_bytes(vec))
+                sem.mark_semantic_document_embedded(
+                    conn, row["id"], current_model_version, now_iso
                 )
                 embedded += 1
             conn.commit()
@@ -613,10 +447,7 @@ def embed_pending(
             ("embedder_version", current_model_version),
             ("last_embed_at", now_iso),
         ]:
-            conn.execute(
-                "INSERT OR REPLACE INTO semantic_embedding_meta (key, value) VALUES (?, ?)",
-                (key, value),
-            )
+            sem.set_semantic_embedding_meta(conn, key, value)
         conn.commit()
 
     return SemanticEmbedResult(
@@ -644,28 +475,7 @@ def query(
     query_vec = _vec_to_bytes(embed_fn([query_text], model_name)[0])
 
     with db_connection(database_path, ensure_semantic_schema) as conn:
-        placeholders = ", ".join("?" for _ in selected_sources)
-        rows = conn.execute(
-            f"""
-            SELECT
-                se.rowid AS doc_id,
-                se.distance,
-                sd.source_type,
-                sd.source_table,
-                sd.source_pk,
-                sd.doc_kind,
-                sd.title,
-                SUBSTR(sd.body, 1, 400) AS body_preview,
-                sd.metadata_json,
-                sd.updated_at
-            FROM semantic_embeddings se
-            JOIN semantic_documents sd ON sd.id = se.rowid
-            WHERE se.embedding MATCH ? AND se.k = ?
-              AND sd.source_type IN ({placeholders})
-            ORDER BY se.distance
-            """,
-            [query_vec, top_k, *selected_sources],
-        ).fetchall()
+        rows = sem.search_semantic_documents(conn, query_vec, top_k, selected_sources)
 
     results: list[dict[str, Any]] = []
     for row in rows:

--- a/src/rebalance/paths.py
+++ b/src/rebalance/paths.py
@@ -342,6 +342,52 @@ def set_user_config_value(key: str, value: str) -> Path:
     return USER_CONFIG_FILE
 
 
+# ---------------------------------------------------------------------------
+# CLI convenience: shared Typer option for the --database flag
+# ---------------------------------------------------------------------------
+
+_DB_OPTION_HELP = (
+    "SQLite database path (resolves via layered chain — see "
+    "`rebalance config show-defaults`)"
+)
+
+
+def DBOption(*flag_names: str, help: str = _DB_OPTION_HELP):  # noqa: N802 — Typer-style factory
+    """Return the shared ``typer.Option`` for the --database CLI flag.
+
+    Collapses the 23-site duplication of::
+
+        database: Path | None = typer.Option(None, envvar="REBALANCE_DB",
+            help="SQLite database path (resolves via layered chain — see ...)")
+
+    Used like::
+
+        from rebalance.paths import DBOption
+        @app.command()
+        def foo(database: Path | None = DBOption()): ...
+
+    Pass extra positional flag names to override the default flag::
+
+        database: Path | None = DBOption("--database-path")
+
+    Imported lazily so importing ``rebalance.paths`` works in contexts where
+    Typer isn't installed.
+    """
+    import typer  # local import: keeps paths.py importable without typer
+
+    return typer.Option(None, *flag_names, envvar="REBALANCE_DB", help=help)
+
+
+def resolve_db(explicit: Path | None = None) -> Path:
+    """Thin alias for :func:`resolve_database_path` with a shorter name.
+
+    The full function name remains the canonical API; ``resolve_db`` is the
+    one-liner CLI handlers and MCP tools reach for. Both raise
+    :class:`DatabaseNotFoundError` on failure.
+    """
+    return resolve_database_path(explicit)
+
+
 def get_user_config_summary() -> dict:
     """Return a dict suitable for ``rebalance config show-defaults`` output."""
     cfg = _load_user_config()

--- a/tests/test_collector_registry.py
+++ b/tests/test_collector_registry.py
@@ -1,0 +1,72 @@
+"""Tests for the Collector registry in index_ops."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from typing import Any
+
+from rebalance.ingest.index_ops import (
+    COLLECTORS,
+    Collector,
+    _all_scope_names,
+    _scope_values,
+    register_collector,
+)
+
+
+class CollectorRegistryTests(unittest.TestCase):
+    def test_builtin_collectors_registered(self) -> None:
+        for name in ("vault", "github", "calendar", "sleuth", "email", "semantic"):
+            self.assertIn(name, COLLECTORS, f"missing built-in collector {name}")
+
+    def test_scope_values_includes_all(self) -> None:
+        values = _scope_values()
+        self.assertIn("all", values)
+        for name in ("vault", "github", "calendar"):
+            self.assertIn(name, values)
+
+    def test_all_scope_includes_default_built_ins(self) -> None:
+        names = _all_scope_names()
+        self.assertEqual(
+            sorted(names),
+            sorted(["vault", "github", "calendar", "sleuth", "email", "semantic"]),
+        )
+
+    def test_register_new_collector_then_unregister(self) -> None:
+        calls: list[dict[str, Any]] = []
+
+        def _refresh(db: Path, **opts: Any) -> dict[str, Any]:
+            calls.append(opts)
+            return {"scope": "linear_test", "dry_run": opts.get("dry_run", False)}
+
+        try:
+            register_collector(Collector("linear_test", _refresh, included_in_all=False))
+            self.assertIn("linear_test", COLLECTORS)
+            # included_in_all=False keeps it OUT of the "all" expansion
+            self.assertNotIn("linear_test", _all_scope_names())
+            # But it shows up in the full scope-values list
+            self.assertIn("linear_test", _scope_values())
+            # And calling its refresh works
+            result = COLLECTORS["linear_test"].refresh(Path("/tmp/x"), dry_run=True)
+            self.assertEqual(result, {"scope": "linear_test", "dry_run": True})
+        finally:
+            COLLECTORS.pop("linear_test", None)
+
+    def test_duplicate_registration_raises(self) -> None:
+        def _refresh(db: Path, **opts: Any) -> dict[str, Any]:
+            return {"scope": "vault"}
+
+        with self.assertRaises(ValueError):
+            register_collector(Collector("vault", _refresh))
+
+    def test_reserved_name_rejected(self) -> None:
+        def _refresh(db: Path, **opts: Any) -> dict[str, Any]:
+            return {"scope": "all"}
+
+        with self.assertRaises(ValueError):
+            register_collector(Collector("all", _refresh))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_collector_registry.py
+++ b/tests/test_collector_registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import tempfile
 import unittest
 from pathlib import Path
 from typing import Any
@@ -11,6 +12,7 @@ from rebalance.ingest.index_ops import (
     Collector,
     _all_scope_names,
     _scope_values,
+    refresh_index,
     register_collector,
 )
 
@@ -66,6 +68,36 @@ class CollectorRegistryTests(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             register_collector(Collector("all", _refresh))
+
+    def test_refresh_index_dispatches_through_registry(self) -> None:
+        """refresh_index must route scope keys through COLLECTORS, not legacy code."""
+        calls: list[tuple[Path, dict[str, Any]]] = []
+
+        def _mock_refresh(db: Path, **opts: Any) -> dict[str, Any]:
+            calls.append((db, opts))
+            return {"scope": "smoke_test", "synced": 1}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "test.db"
+            try:
+                register_collector(
+                    Collector("smoke_test", _mock_refresh, included_in_all=False)
+                )
+                result = refresh_index(
+                    db_path,
+                    scope=["smoke_test"],
+                    dry_run=False,
+                    update_dashboard_note=False,
+                )
+                # The dispatcher must have called our collector exactly once.
+                self.assertEqual(len(calls), 1, "collector was not called by refresh_index")
+                called_db, called_opts = calls[0]
+                self.assertEqual(called_db, db_path.resolve())
+                # Result envelope must include our collector's return value.
+                scopes_in_result = [r.get("scope") for r in result.get("results", [])]
+                self.assertIn("smoke_test", scopes_in_result)
+            finally:
+                COLLECTORS.pop("smoke_test", None)
 
 
 if __name__ == "__main__":

--- a/tests/test_db_github.py
+++ b/tests/test_db_github.py
@@ -1,0 +1,378 @@
+"""Direct unit tests for the db/github.py typed query helpers.
+
+These pin the column layouts the helpers own — a drift in any upsert helper's
+column list is caught here rather than only through the broader ingest suite.
+"""
+
+import struct
+import tempfile
+import unittest
+from pathlib import Path
+
+from rebalance.ingest.db import (
+    db_connection,
+    ensure_github_schema,
+    ensure_semantic_schema,
+)
+from rebalance.ingest.db import github as gh
+
+# 35-column github_items record, in schema order. Tests override what they need.
+_ITEM_COLUMNS = [
+    "repo_full_name", "item_type", "number", "node_id", "github_id", "title",
+    "body", "state", "state_reason", "author_login", "assignees_json",
+    "labels_json", "milestone_number", "milestone_title", "is_draft",
+    "is_merged", "base_ref", "head_ref", "head_sha", "mergeable_state",
+    "review_decision", "check_status", "requested_reviewers_json",
+    "comments_count", "review_comments_count", "commits_count", "additions",
+    "deletions", "changed_files", "html_url", "created_at", "updated_at",
+    "closed_at", "merged_at", "fetched_at",
+]
+
+
+def _item_record(**overrides: object) -> dict[str, object]:
+    record: dict[str, object] = {col: 0 for col in _ITEM_COLUMNS}
+    record.update(
+        repo_full_name="Org/repo",
+        item_type="issue",
+        number=1,
+        node_id="",
+        title="",
+        body="",
+        state="open",
+        state_reason="",
+        author_login="",
+        assignees_json="[]",
+        labels_json="[]",
+        milestone_title="",
+        base_ref="",
+        head_ref="",
+        head_sha="",
+        mergeable_state="",
+        review_decision="",
+        check_status="",
+        requested_reviewers_json="[]",
+        html_url="",
+        created_at="2026-05-20",
+        updated_at="2026-05-20",
+        closed_at=None,
+        merged_at=None,
+        fetched_at="2026-05-20",
+    )
+    record.update(overrides)
+    return record
+
+
+class GitHubHelperTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.db_path = Path(self._tmp.name) / "rebalance.db"
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    # -- activity queries ---------------------------------------------------
+
+    def test_activity_query_helpers(self) -> None:
+        with db_connection(self.db_path, ensure_github_schema) as conn:
+            conn.executemany(
+                "INSERT INTO github_activity "
+                "(login, repo_full_name, scan_date, commits, prs_opened, prs_merged, "
+                "issues_opened, issue_comments, reviews, last_active_at, scanned_at) "
+                "VALUES (?, ?, date('now'), ?, 0, 0, 0, 0, 0, ?, date('now'))",
+                [
+                    ("me", "org/hot", 10, "2026-05-20T10:00:00Z"),
+                    ("me", "org/warm", 3, "2026-05-19T10:00:00Z"),
+                    ("me", "org/cold", 0, None),
+                ],
+            )
+            conn.execute(
+                "INSERT INTO github_repo_meta (repo_full_name, fetched_at) "
+                "VALUES (?, date('now'))",
+                ("org/hot",),
+            )
+            conn.commit()
+
+            # Zero-score repo excluded; ranked by score desc.
+            self.assertEqual(gh.top_active_repos(conn, 5), ["org/hot", "org/warm"])
+            self.assertEqual(gh.top_active_repos(conn, 1), ["org/hot"])
+
+            # last_active: all, subset, empty subset; null last_active omitted.
+            self.assertEqual(
+                gh.repo_last_active(conn),
+                {"org/hot": "2026-05-20T10:00:00Z", "org/warm": "2026-05-19T10:00:00Z"},
+            )
+            self.assertEqual(
+                gh.repo_last_active(conn, ["org/hot"]),
+                {"org/hot": "2026-05-20T10:00:00Z"},
+            )
+            self.assertEqual(gh.repo_last_active(conn, []), {})
+
+            self.assertEqual(gh.repo_meta_names(conn), {"org/hot"})
+
+    def test_top_active_repos_honours_since_days_window(self) -> None:
+        with db_connection(self.db_path, ensure_github_schema) as conn:
+            conn.execute(
+                "INSERT INTO github_activity "
+                "(login, repo_full_name, scan_date, commits, prs_opened, prs_merged, "
+                "issues_opened, issue_comments, reviews, last_active_at, scanned_at) "
+                "VALUES ('me', 'org/old', date('now','-40 days'), 9, 0, 0, 0, 0, 0, "
+                "NULL, date('now'))"
+            )
+            conn.commit()
+            # Inside a 90-day window, outside the default 7-day window.
+            self.assertEqual(gh.top_active_repos(conn, 5, since_days=90), ["org/old"])
+            self.assertEqual(gh.top_active_repos(conn, 5), [])
+
+    # -- artifact upserts ---------------------------------------------------
+
+    def test_artifact_upserts_round_trip(self) -> None:
+        with db_connection(self.db_path, ensure_github_schema) as conn:
+            R = "Org/repo"
+            gh.upsert_repo_meta(conn, (R, "main", "p", "u", 4, 1, 0, "f"))
+            gh.upsert_branch(conn, (R, "main", "sha", 1, 1, "f"))
+            gh.upsert_label(conn, (R, "bug", "f00", "desc", 1))
+            gh.upsert_milestone(
+                conn, (R, 2, "M2", "d", "open", 3, 1, None, None, None, None, "url")
+            )
+            gh.upsert_release(
+                conn, (R, 7, "v2", "v2", "main", 0, 1, "notes", None, None, "url")
+            )
+            gh.upsert_comment(
+                conn,
+                (R, "issue", 1, "issue_comment", 50, "me", "OWNER", "hi", "", None,
+                 "url", None, None, "f"),
+            )
+            gh.upsert_link(conn, (R, "pull_request", 9, "issue", 8, "closes"))
+            gh.upsert_commit(
+                conn, (R, "pull_request", 9, "sha9", "me", "msg", "c", "url", "f")
+            )
+            gh.upsert_check_run(
+                conn,
+                (R, "pull_request", 9, "sha9", "ci", "completed", "success", "url",
+                 None, None, "f"),
+            )
+            conn.commit()
+
+            self.assertEqual(
+                conn.execute(
+                    "SELECT default_branch, open_issues_count FROM github_repo_meta"
+                ).fetchone()["default_branch"],
+                "main",
+            )
+            self.assertEqual(
+                conn.execute("SELECT name FROM github_branches").fetchone()["name"],
+                "main",
+            )
+            self.assertEqual(
+                conn.execute("SELECT color FROM github_labels").fetchone()["color"],
+                "f00",
+            )
+            self.assertEqual(
+                conn.execute("SELECT title FROM github_milestones").fetchone()["title"],
+                "M2",
+            )
+            self.assertEqual(
+                conn.execute("SELECT tag_name FROM github_releases").fetchone()["tag_name"],
+                "v2",
+            )
+            self.assertEqual(
+                conn.execute("SELECT body FROM github_comments").fetchone()["body"],
+                "hi",
+            )
+            self.assertEqual(
+                conn.execute("SELECT link_kind FROM github_links").fetchone()["link_kind"],
+                "closes",
+            )
+            self.assertEqual(
+                conn.execute("SELECT sha FROM github_commits").fetchone()["sha"],
+                "sha9",
+            )
+            self.assertEqual(
+                conn.execute(
+                    "SELECT conclusion FROM github_check_runs"
+                ).fetchone()["conclusion"],
+                "success",
+            )
+
+    def test_upsert_item_binds_by_name(self) -> None:
+        with db_connection(self.db_path, ensure_github_schema) as conn:
+            record = _item_record(
+                item_type="pull_request",
+                number=42,
+                title="A PR",
+                state="open",
+                review_decision="APPROVED",
+                check_status="success",
+                is_merged=1,
+            )
+            gh.upsert_item(conn, record)
+            conn.commit()
+            row = conn.execute(
+                "SELECT item_type, number, title, review_decision, check_status, "
+                "is_merged FROM github_items"
+            ).fetchone()
+            self.assertEqual(row["item_type"], "pull_request")
+            self.assertEqual(row["number"], 42)
+            self.assertEqual(row["title"], "A PR")
+            self.assertEqual(row["review_decision"], "APPROVED")
+            self.assertEqual(row["check_status"], "success")
+            self.assertEqual(row["is_merged"], 1)
+
+    def test_upsert_item_replaces_on_conflict(self) -> None:
+        with db_connection(self.db_path, ensure_github_schema) as conn:
+            gh.upsert_item(conn, _item_record(number=5, title="first"))
+            gh.upsert_item(conn, _item_record(number=5, title="second"))
+            conn.commit()
+            rows = conn.execute(
+                "SELECT title FROM github_items WHERE number = 5"
+            ).fetchall()
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0]["title"], "second")
+
+    # -- documents ----------------------------------------------------------
+
+    def test_insert_document_and_delete_item_children(self) -> None:
+        with db_connection(self.db_path, ensure_github_schema) as conn:
+            R = "Org/repo"
+            gh.upsert_item(conn, _item_record(item_type="pull_request", number=3))
+            doc_id = gh.insert_github_document(
+                conn,
+                repo_full_name=R,
+                source_type="pull_request",
+                source_number=3,
+                doc_type="item_body",
+                source_key=f"{R}:pr:3:item",
+                title="t",
+                body="b" * 60,
+                content_hash="h",
+                updated_at="2026-05-20",
+                fetched_at="2026-05-20",
+            )
+            self.assertIsInstance(doc_id, int)
+            gh.upsert_commit(
+                conn,
+                (R, "pull_request", 3, "sha", "me", "m", "c", "url", "f"),
+            )
+            conn.commit()
+
+            gh.delete_item_children(conn, R, "pull_request", 3)
+            conn.commit()
+            # Children gone; the item row itself is left intact.
+            self.assertEqual(
+                conn.execute("SELECT COUNT(*) FROM github_documents").fetchone()[0], 0
+            )
+            self.assertEqual(
+                conn.execute("SELECT COUNT(*) FROM github_commits").fetchone()[0], 0
+            )
+            self.assertEqual(
+                conn.execute("SELECT COUNT(*) FROM github_items").fetchone()[0], 1
+            )
+
+    # -- embeddings ---------------------------------------------------------
+
+    def test_embedding_helpers(self) -> None:
+        with db_connection(self.db_path, ensure_github_schema) as conn:
+            R = "Org/repo"
+            doc_id = gh.insert_github_document(
+                conn, repo_full_name=R, source_type="issue", source_number=1,
+                doc_type="item_body", source_key=f"{R}:i:1", title="t",
+                body="x" * 60, content_hash="hash-1", updated_at="2026-05-20",
+                fetched_at="2026-05-20",
+            )
+            short_id = gh.insert_github_document(
+                conn, repo_full_name=R, source_type="issue", source_number=2,
+                doc_type="item_body", source_key=f"{R}:i:2", title="t",
+                body="tiny", content_hash="hash-2", updated_at="2026-05-20",
+                fetched_at="2026-05-20",
+            )
+            conn.commit()
+
+            # Both docs exist; only one clears the 40-char embed threshold.
+            self.assertEqual(gh.count_embeddable_github_documents(conn, 40), 1)
+            pending = gh.github_documents_pending_embed(conn, 40)
+            self.assertEqual([r["id"] for r in pending], [doc_id])
+
+            gh.upsert_github_embedding(conn, doc_id, struct.pack("1024f", *([0.0] * 1024)))
+            gh.mark_github_document_embedded(conn, doc_id)
+            gh.set_github_embedding_meta(conn, "model_name", "test-model")
+            conn.commit()
+
+            # Marked fresh -> no longer pending.
+            self.assertEqual(gh.github_documents_pending_embed(conn, 40), [])
+            self.assertEqual(
+                conn.execute(
+                    "SELECT value FROM github_embedding_meta WHERE key='model_name'"
+                ).fetchone()["value"],
+                "test-model",
+            )
+
+            # force-reembed primitives.
+            gh.clear_github_embeddings(conn)
+            gh.reset_github_embedded_hashes(conn)
+            conn.commit()
+            self.assertEqual(
+                conn.execute("SELECT COUNT(*) FROM github_embeddings").fetchone()[0], 0
+            )
+            self.assertEqual(len(gh.github_documents_pending_embed(conn, 40)), 1)
+
+    def test_search_github_documents(self) -> None:
+        vec = struct.pack("1024f", *([0.1] * 1024))
+        with db_connection(self.db_path, ensure_github_schema) as conn:
+            R = "Org/repo"
+            doc_id = gh.insert_github_document(
+                conn, repo_full_name=R, source_type="issue", source_number=1,
+                doc_type="item_body", source_key=f"{R}:i:1", title="T",
+                body="b" * 60, content_hash="h", updated_at="2026-05-20",
+                fetched_at="2026-05-20",
+            )
+            gh.upsert_github_embedding(conn, doc_id, vec)
+            conn.commit()
+            self.assertEqual(len(gh.search_github_documents(conn, vec, 8)), 1)
+            self.assertEqual(
+                len(gh.search_github_documents(conn, vec, 8, repo_full_name=R)), 1
+            )
+            self.assertEqual(
+                gh.search_github_documents(conn, vec, 8, repo_full_name="Org/other"),
+                [],
+            )
+
+    # -- per-repo purge -----------------------------------------------------
+
+    def test_purge_helpers(self) -> None:
+        with db_connection(self.db_path, ensure_github_schema) as conn:
+            ensure_semantic_schema(conn)
+            R = "Org/Repo"
+            gh.upsert_item(conn, _item_record(repo_full_name=R, number=1))
+            doc_id = gh.insert_github_document(
+                conn, repo_full_name=R, source_type="issue", source_number=1,
+                doc_type="item_body", source_key=f"{R}:i:1", title="t",
+                body="x" * 60, content_hash="h", updated_at="2026-05-20",
+                fetched_at="2026-05-20",
+            )
+            gh.upsert_github_embedding(conn, doc_id, struct.pack("1024f", *([0.0] * 1024)))
+            conn.commit()
+
+            # Case-insensitive repo match.
+            self.assertEqual(gh.count_repo_rows(conn, "github_items", "org/repo"), 1)
+            ids = gh.github_document_ids(conn, "org/repo")
+            self.assertEqual(ids, [doc_id])
+            self.assertEqual(
+                gh.count_ids_in(conn, "github_embeddings", "doc_id", ids), 1
+            )
+            self.assertEqual(
+                gh.count_ids_in(conn, "github_embeddings", "doc_id", []), 0
+            )
+
+            gh.delete_github_embeddings_for_docs(conn, ids)
+            gh.delete_repo_rows(conn, "github_items", "org/repo")
+            gh.delete_repo_table(conn, "github_documents", R)
+            conn.commit()
+            self.assertEqual(gh.count_repo_rows(conn, "github_items", "org/repo"), 0)
+            self.assertEqual(gh.github_document_ids(conn, "org/repo"), [])
+            self.assertEqual(
+                conn.execute("SELECT COUNT(*) FROM github_embeddings").fetchone()[0], 0
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_db_migrations.py
+++ b/tests/test_db_migrations.py
@@ -1,0 +1,80 @@
+"""Tests for the forward-only schema migration runner (db/migrate.py)."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from rebalance.ingest.db import (
+    BASELINE_SCHEMA_VERSION,
+    current_schema_version,
+    db_connection,
+    ensure_schema,
+    run_migrations,
+)
+from rebalance.ingest.db import migrate
+
+
+class MigrationRunnerTests(unittest.TestCase):
+    def test_fresh_database_is_stamped_at_baseline(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "rebalance.db"
+            with db_connection(db_path, ensure_schema) as conn:
+                version = run_migrations(conn)
+                self.assertEqual(version, BASELINE_SCHEMA_VERSION)
+                self.assertEqual(current_schema_version(conn), BASELINE_SCHEMA_VERSION)
+
+    def test_run_migrations_is_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "rebalance.db"
+            with db_connection(db_path, ensure_schema) as conn:
+                run_migrations(conn)
+                second = run_migrations(conn)
+                self.assertEqual(second, BASELINE_SCHEMA_VERSION)
+                rows = conn.execute("SELECT COUNT(*) FROM schema_version").fetchone()[0]
+                self.assertEqual(rows, 1)
+
+    def test_pending_migration_is_applied_once(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            mig_dir = Path(tmp) / "migrations"
+            mig_dir.mkdir()
+            (mig_dir / "0002_add_probe.sql").write_text(
+                "CREATE TABLE migration_probe (id INTEGER PRIMARY KEY);",
+                encoding="utf-8",
+            )
+            db_path = Path(tmp) / "rebalance.db"
+            original_dir = migrate.MIGRATIONS_DIR
+            migrate.MIGRATIONS_DIR = mig_dir
+            try:
+                with db_connection(db_path, ensure_schema) as conn:
+                    version = run_migrations(conn)
+                    self.assertEqual(version, 2)
+                    # The migration's table exists.
+                    conn.execute("SELECT COUNT(*) FROM migration_probe")
+                    # Re-running applies nothing further.
+                    self.assertEqual(run_migrations(conn), 2)
+                    recorded = {
+                        int(r[0])
+                        for r in conn.execute("SELECT version FROM schema_version")
+                    }
+                    self.assertEqual(recorded, {BASELINE_SCHEMA_VERSION, 2})
+            finally:
+                migrate.MIGRATIONS_DIR = original_dir
+
+    def test_discover_migrations_ignores_non_numeric_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            mig_dir = Path(tmp) / "migrations"
+            mig_dir.mkdir()
+            (mig_dir / "0002_real.sql").write_text("SELECT 1;", encoding="utf-8")
+            (mig_dir / "notes.sql").write_text("SELECT 1;", encoding="utf-8")
+            (mig_dir / "README.md").write_text("ignored", encoding="utf-8")
+            original_dir = migrate.MIGRATIONS_DIR
+            migrate.MIGRATIONS_DIR = mig_dir
+            try:
+                discovered = migrate.discover_migrations()
+                self.assertEqual([v for v, _ in discovered], [2])
+            finally:
+                migrate.MIGRATIONS_DIR = original_dir
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_github_knowledge.py
+++ b/tests/test_github_knowledge.py
@@ -2,6 +2,7 @@
 
 import tempfile
 import unittest
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from rebalance.ingest import config as config_module
@@ -14,6 +15,15 @@ from rebalance.ingest.github_knowledge import (
 )
 from rebalance.ingest.config import add_github_ignored_repo
 from rebalance.ingest.embedder import _vec_to_bytes
+
+
+# sync_github_repo filters the /pulls list client-side via stop_updated_before,
+# so the PR-summary updated_at must stay inside the since_days window. Computed
+# relative to now so the fixture never ages out — a hardcoded April-2026 date
+# previously drifted past a 30-day cutoff and silently zeroed prs_synced.
+_RECENT_ISO = (datetime.now(timezone.utc) - timedelta(days=1)).strftime(
+    "%Y-%m-%dT%H:%M:%SZ"
+)
 
 
 def _fake_github_api(url: str) -> object:
@@ -113,7 +123,7 @@ def _fake_github_api(url: str) -> object:
         return [
             {
                 "number": 202,
-                "updated_at": "2026-04-17T13:00:00Z",
+                "updated_at": _RECENT_ISO,
             }
         ]
 

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1,0 +1,163 @@
+"""Tests for the shared GitHub HTTP client (src/rebalance/ingest/_http.py)."""
+
+from __future__ import annotations
+
+import io
+import json
+import unittest
+import urllib.error
+from typing import Any
+from unittest.mock import patch
+
+from rebalance.ingest._http import GitHubClient, GitHubHTTPError
+
+
+def _ok_response(payload: Any, response_headers: dict[str, str] | None = None):
+    """Return a fake context manager mimicking urlopen's response."""
+    body = json.dumps(payload).encode()
+    hdrs = response_headers or {}
+
+    class _Resp:
+        status = 200
+        headers = hdrs
+
+        def __enter__(self_inner):
+            return self_inner
+
+        def __exit__(self_inner, *_exc):
+            return False
+
+        def read(self_inner):
+            return body
+
+    return _Resp()
+
+
+def _http_error(code: int, body: str = "", headers: dict[str, str] | None = None) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(
+        url="https://api.github.com/",
+        code=code,
+        msg="err",
+        hdrs=headers or {},
+        fp=io.BytesIO(body.encode()),
+    )
+
+
+class GitHubClientHeadersTests(unittest.TestCase):
+    def test_uses_bearer_auth_and_api_version(self) -> None:
+        client = GitHubClient("ghp_test")
+        h = client.headers()
+        self.assertEqual(h["Authorization"], "Bearer ghp_test")
+        self.assertEqual(h["X-GitHub-Api-Version"], "2022-11-28")
+        self.assertIn("rebalance-os", h["User-Agent"])
+
+
+class GitHubClientGetTests(unittest.TestCase):
+    def test_get_returns_status_and_data(self) -> None:
+        client = GitHubClient("ghp", retries=1)
+        with patch("urllib.request.urlopen", return_value=_ok_response({"login": "alice"})):
+            status, data = client.get("/user")
+        self.assertEqual(status, 200)
+        self.assertEqual(data, {"login": "alice"})
+
+    def test_get_returns_status_none_on_http_error_with_no_retry(self) -> None:
+        client = GitHubClient("ghp", retries=1)
+        with patch("urllib.request.urlopen", side_effect=_http_error(404)):
+            status, data = client.get("/user")
+        self.assertEqual(status, 404)
+        self.assertIsNone(data)
+
+
+class GitHubClientGetJsonTests(unittest.TestCase):
+    def test_get_json_returns_data_on_2xx(self) -> None:
+        client = GitHubClient("ghp", retries=1)
+        with patch("urllib.request.urlopen", return_value=_ok_response([1, 2, 3])):
+            data = client.get_json("/list")
+        self.assertEqual(data, [1, 2, 3])
+
+    def test_get_json_raises_on_4xx(self) -> None:
+        client = GitHubClient("ghp", retries=1)
+        with patch("urllib.request.urlopen", side_effect=_http_error(404)):
+            with self.assertRaises(GitHubHTTPError) as ctx:
+                client.get_json("/missing")
+        self.assertEqual(ctx.exception.status, 404)
+        self.assertFalse(ctx.exception.is_rate_limit)
+
+    def test_get_json_flags_rate_limit_on_429(self) -> None:
+        client = GitHubClient("ghp", retries=1)
+        with patch("urllib.request.urlopen", side_effect=_http_error(429)):
+            with self.assertRaises(GitHubHTTPError) as ctx:
+                client.get_json("/x")
+        self.assertTrue(ctx.exception.is_rate_limit)
+
+    def test_get_json_flags_rate_limit_on_403_with_zero_remaining(self) -> None:
+        client = GitHubClient("ghp", retries=1)
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=_http_error(403, headers={"x-ratelimit-remaining": "0"}),
+        ):
+            with self.assertRaises(GitHubHTTPError) as ctx:
+                client.get_json("/x")
+        self.assertTrue(ctx.exception.is_rate_limit)
+
+
+class GitHubClientRetryTests(unittest.TestCase):
+    def test_retries_on_5xx_then_succeeds(self) -> None:
+        sleeps: list[float] = []
+        client = GitHubClient("ghp", retries=3, sleep=lambda s: sleeps.append(s))
+        responses = [_http_error(503), _http_error(503), _ok_response({"ok": True})]
+
+        def _side(*_a, **_k):
+            r = responses.pop(0)
+            if isinstance(r, urllib.error.HTTPError):
+                raise r
+            return r
+
+        with patch("urllib.request.urlopen", side_effect=_side):
+            data = client.get_json("/flaky")
+        self.assertEqual(data, {"ok": True})
+        self.assertEqual(len(sleeps), 2)
+
+    def test_does_not_retry_on_4xx(self) -> None:
+        sleeps: list[float] = []
+        client = GitHubClient("ghp", retries=3, sleep=lambda s: sleeps.append(s))
+        with patch("urllib.request.urlopen", side_effect=_http_error(404)):
+            with self.assertRaises(GitHubHTTPError):
+                client.get_json("/missing")
+        self.assertEqual(sleeps, [])
+
+    def test_honors_retry_after_header(self) -> None:
+        sleeps: list[float] = []
+        client = GitHubClient("ghp", retries=2, sleep=lambda s: sleeps.append(s))
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=_http_error(429, headers={"retry-after": "7"}),
+        ):
+            with self.assertRaises(GitHubHTTPError):
+                client.get_json("/x")
+        self.assertEqual(sleeps, [7.0])
+
+
+class GitHubClientPaginateTests(unittest.TestCase):
+    def test_paginate_accumulates_until_short_page(self) -> None:
+        client = GitHubClient("ghp", retries=1)
+        page1 = [{"id": i, "updated_at": "2024-01-01"} for i in range(100)]
+        page2 = [{"id": 100, "updated_at": "2024-01-01"}]  # short page → stop
+        responses = [_ok_response(page1), _ok_response(page2)]
+        with patch("urllib.request.urlopen", side_effect=lambda *a, **k: responses.pop(0)):
+            data = client.paginate("/repos/x/y/issues")
+        self.assertEqual(len(data), 101)
+
+    def test_paginate_stops_on_updated_before(self) -> None:
+        client = GitHubClient("ghp", retries=1)
+        page = [
+            {"id": 1, "updated_at": "2024-06-01"},
+            {"id": 2, "updated_at": "2023-01-01"},  # below cutoff
+        ]
+        with patch("urllib.request.urlopen", return_value=_ok_response(page)):
+            data = client.paginate("/repos/x/y/issues", stop_updated_before="2024-01-01")
+        self.assertEqual([row["id"] for row in data], [1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Multi-phase, behavior-preserving refactor of the rebalance-OS codebase. Each
phase is an independent step verified against the full test suite.

### Phase 1 — logging + DRY foundations
Logging bootstrap; shared `DBOption` helper.

### Phase 2 — shared GitHub HTTP client
One HTTP client with retries + pagination (`ingest/_http.py`), replacing
per-module request code.

### Phase 4 — collector registry
`Collector` protocol + source registry; `refresh_index` dispatches through it
instead of a hand-maintained branch ladder.

### Phase 3 — DB access layer + migrations (the bulk of this PR)
- **3a:** the 312-line `ensure_github_schema` decomposed into per-table-group
  helpers. `db.py` became a `db/` package (`connection` / `schema` / `github` /
  `semantic`), re-exporting the full public API so all 40+ importers are
  untouched. All raw SQL evicted from `cli.py`, `github_knowledge.py`, and
  `semantic_index.py` (74 statements) into typed helpers — those three modules
  now contain **zero raw SQL**.
- **3b:** a `schema_version` table + forward-only migration runner
  (`db/migrate.py`, `db/migrations/`), wired into `refresh_index`. External
  tools reading `rebalance.db` no longer break silently on column changes.

### Also in this PR
- Fixed a time-fragile `prs_synced` test fixture (a hardcoded date had drifted
  past a 30-day cutoff — pre-existing failure on `main`, not a product bug).
- Added direct unit tests for `db/github.py` (9) and the migration runner (4).

## Testing

**299 passed** — full suite (`pytest -q --continue-on-collection-errors`).
One pre-existing collection error remains: `test_pulse_sleuth_scope.py` —
`pulse.py` imports `requests`, an undeclared dependency. Pre-existing on `main`;
tracked for a follow-up docs/manifest phase.

## Notes

Behavior-preserving throughout — every phase held the suite at its baseline.
Remaining planned phases (MCP server registry, CLI decomposition, config
consolidation, docs/manifest reconcile) are deliberately deferred to later PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)