### PR TITLE
docs: read/display layer simplification audit with phased plan

### DIFF
--- a/PROJECT/2-WORKING/SIMPLIFICATION-AUDIT.md
+++ b/PROJECT/2-WORKING/SIMPLIFICATION-AUDIT.md
@@ -1,0 +1,188 @@
+# Simplification Audit — rebalance-OS Read/Display Layer
+
+**Scope:** `scripts/dashboard.py`, `scripts/pulse_web.py`, `src/rebalance/ingest/dashboard.py`,
+`src/rebalance/ingest/github_scan.py` (get_github_balance only), `src/rebalance/ingest/project_inference.py`,
+`src/rebalance/ingest/registry.py`, `src/rebalance/ingest/project_classifier.py`
+
+**Constraint:** Do not touch ingest scripts (DB writers). Do not break MCP server tools.
+
+---
+
+## Maintainer instructions
+
+This document is the living record of the simplification effort. Update it every time you complete a task:
+
+1. **Tick the checkbox** next to the completed item.
+2. **Update the Current Status table** — set "Last completed phase" and "Next action."
+3. If you discover a new finding mid-phase, add it to the Findings Table and reference it in the appropriate phase checklist.
+4. When an entire phase is done, move the phase header to read `### Phase N — [name] ✅` and update the status table.
+5. When all phases are done, move this file to `PROJECT/3-DONE/`.
+
+The rule: if you can tick a box and forget it, you're doing it right. If you need to think about whether something is done, write a note under the item.
+
+---
+
+## Current Status
+
+| Column | Value |
+|---|---|
+| **Last completed phase** | Phase 1 partial — display gate removed from `build_dashboard_payload()` output (stale `# PHASE 1` comments remain) |
+| **What's next** | Phase 1 — zero-risk deletions listed below |
+
+---
+
+## Findings Table
+
+Each row covers one unnecessary layer or duplicate. Risk is relative to the single-user read-only context.
+
+| # | File : Line(s) | Name | What this layer does | Replace with | Risk | Phase |
+|---|---|---|---|---|---|---|
+| F1 | `src/rebalance/ingest/dashboard.py:326,381` | Stale commented-out code | Two comment lines (`# PHASE 1: removed Obsidian gate`) left over from a previous pass | Delete the comment lines | **Zero** | 1 |
+| F2 | `scripts/dashboard.py:896-898` | `_interleave()` no-op | Returns its input unchanged; named like a utility but does nothing | Delete function + its single call site on line 885 | **Zero** | 1 |
+| F3 | `scripts/pulse_web.py:378-381` | `_repo_label()` identity function | Returns `full` unchanged after a falsy check; every call site could inline `r.get("repo_full_name") or ""` | Delete + inline at 3 call sites | **Zero** | 1 |
+| F4 | `scripts/pulse_web.py:384-386` + `scripts/dashboard.py:684-688` | Duplicate `_truncate()` | Identical 3-line helper defined independently in both files | `pulse_web.py` already imports from `dashboard.py` on line 53; import `_truncate` from there and remove the local copy | **Zero** | 1 |
+| F5 | `scripts/dashboard.py:439-490` + `src/rebalance/ingest/dashboard.py:29-78` | `fetch_org_activity()` / `get_all_repo_activity_by_org()` near-duplicate | Same query (`github_activity GROUP BY repo_full_name`), same return shape, same org-split logic. Only difference: `fetch_org_activity` applies the ignored-repos filter; `get_all_repo_activity_by_org` uses `ensure_github_schema` and no filter | One function in `scripts/dashboard.py` with optional `ignored` param; remove from `src/rebalance/ingest/dashboard.py` and update its one import site in `build_dashboard_payload()` | **Low** — one consumer; unit tests don't cover it by name | 2 |
+| F6 | `src/rebalance/ingest/dashboard.py:299-304` | Parallel `repo_map` + `get_github_balance()` path | Builds `{project_name: [repos]}` from project_registry, then calls `get_github_balance()` — the old registry-gated path — on every Obsidian note build, in parallel with the already-working direct `get_all_repo_activity_by_org()` call on line 305 | Remove the `repo_map` build and `get_github_balance()` call from this function. Adapt `_determine_verdict()` to use per-repo data from `get_all_repo_activity_by_org()` instead, OR drop the per-project verdict section from the Obsidian note (it's stale anyway) | **Medium** — verdict labels (Active / Heavy focus / Quiet) would lose project granularity; calendar attribution still needs registry | 3 |
+| F7 | `src/rebalance/ingest/github_scan.py:557-641` | `get_github_balance()` in Obsidian note build | Requires a manually-curated `{project: [repos]}` map to aggregate activity; returns zero for any repo not registered in Obsidian | Already bypassed for display; preserved in MCP server (`mcp_server.py:40`) where per-project aggregation is genuinely useful for agents | **Medium** — MCP tool `github_balance` depends on it; changing semantics affects agent consumers | 3 |
+| F8 | `scripts/dashboard.py:400-436` | `fetch_repo_activity_counts()` union query | Counts events by unioning `github_items + github_commits + github_comments` to drive the repo pie chart. Same totals could come from `github_activity` aggregate columns | Replace with: `SELECT repo_full_name, SUM(commits+prs_opened+prs_merged+issues_opened) FROM github_activity WHERE scan_date >= ? GROUP BY repo_full_name ORDER BY total DESC LIMIT ?` | **Low** — semantics shift slightly (no comment counts) but pie chart purpose unchanged | 3 |
+| F9 | `src/rebalance/ingest/registry.py:27-36` | 6-list `Registry` model | `Registry` has `active_projects`, `most_likely_active_projects`, `semi_active_projects`, `dormant_projects`, `potential_projects`, `archived_projects`. The display layer only ever calls `get_projects(db, status="active")` — a flat SQLite query that ignores this model entirely | The model is only needed for the Obsidian markdown ↔ YAML sync path. If that path is removed in Phase 4, the entire `Registry`/`load_registry`/`save_registry`/`sync_registry` stack collapses to a no-op | **Medium** — MCP `confirm_projects` writes via `save_registry`; until Phase 4 is decided, leave the model alone | 4 |
+| F10 | `src/rebalance/ingest/registry.py:195-223` | `sync_registry()` 3-way pull/push/check | Provides a pull/push/check sync between Obsidian markdown and SQLite. In the decoupled architecture, the Obsidian note is the *output*, not the source of truth | After Phase 3 confirms nothing breaks, the `pull` mode (Obsidian → SQLite) can be removed; `push` mode (SQLite → Obsidian) is the future direction | **Medium** — CLI and MCP use it today | 4 |
+| F11 | `src/rebalance/ingest/project_classifier.py:183-195` | `repos_json` alias-building for calendar matching | Loads `repos_json` from `project_registry` and converts repo names into text aliases (e.g. `acmecorp/shopify-theme` → `shopify theme` → alias for "AcmeCorp") used to tag calendar events. **This is the only remaining functional load-bearing use of `repos_json` once the display gate is removed.** | If `project_inference.py` is running and auto-populating `repos_json` from activity, this works correctly already. If repos are all empty, calendar events still match by project name — graceful degradation, not a hard failure. Lowest-risk path: leave it alone; it costs nothing | **Low** — graceful degradation; does not gate display | flag only |
+| F12 | `src/rebalance/ingest/dashboard.py` (entire file name) | Name collision between two `dashboard.py` files | `scripts/dashboard.py` is the TUI renderer + shared data fetchers (imported by `pulse_web.py`). `src/rebalance/ingest/dashboard.py` is the Obsidian note generator. Same name, different stacks — any new contributor will be confused | Rename `src/rebalance/ingest/dashboard.py` → `src/rebalance/ingest/note_builder.py`; update all import sites | **Low** — pure rename; no logic change | 2 |
+| F13 | `tests/test_project_priority.py:122-145` + `tests/test_dashboard_cli.py` | Tests covering registry-gated path | Both test files exercise `build_dashboard_payload()` with `repos_json` populated (repos registered to projects) and verify per-project verdict generation via `get_github_balance()`. If Phase 3 removes that path, these tests cover machinery being deleted | After Phase 3: update `test_project_priority.py` to verify org-based activity instead; `test_dashboard_cli.py` can remain as an integration smoke test | **n/a** — test impact only | 3 |
+
+---
+
+## Phased Plan
+
+### Phase 1 — Zero-risk deletions (dead code, duplicate helpers)
+
+No logic changes. No tests need updating. Safe to do in one commit.
+
+- [ ] **F1** — `src/rebalance/ingest/dashboard.py:326,381`: delete the two comment lines tagged `# PHASE 1: removed Obsidian gate` (lines 326-327 and 381-382 as of last read). The surrounding live code stays.
+- [ ] **F2** — `scripts/dashboard.py:884-898`: delete `_interleave()` (lines 896-898) and replace the call on line 885 with just `sections` directly.
+  ```python
+  # Before:
+  body = Group(*[Group(s, Text("")) for s in _interleave(sections)])
+  # After:
+  body = Group(*[Group(s, Text("")) for s in sections])
+  ```
+- [ ] **F3** — `scripts/pulse_web.py:378-381`: delete `_repo_label()`. Inline the null check at its 3 call sites:
+  - `pulse_web.py:785` `repo = _repo_label(r.get("repo_full_name"))` → `repo = r.get("repo_full_name") or ""`
+  - `pulse_web.py:853` `repo_label = _repo_label(repo["repo_full_name"])` → `repo_label = repo["repo_full_name"] or ""`
+  - `pulse_web.py:894` `repo_label = _repo_label(repo["repo_full_name"])` → same
+- [ ] **F4** — `scripts/pulse_web.py:384-386`: delete local `_truncate()` definition. Add `_truncate` to the import from `dashboard` on line 41-55 (already in that import block). Verify no other local shadow.
+- [ ] Run tests to confirm green: `uv run pytest tests/test_dashboard_terminal_theme.py tests/test_pulse_web_goals.py -x -q`
+
+---
+
+### Phase 2 — Consolidate the two dashboard.py files
+
+One data layer per output format. Rename the collision.
+
+- [ ] **F12** — Rename `src/rebalance/ingest/dashboard.py` → `src/rebalance/ingest/note_builder.py`. Update all import sites:
+  - `src/rebalance/cli.py` (search: `from rebalance.ingest.dashboard import`)
+  - `tests/test_dashboard_cli.py:14` (`from rebalance.ingest.dashboard import build_dashboard_payload`)
+  - `tests/test_project_priority.py:14` (same)
+  - Any other grep hit: `grep -r "from rebalance.ingest.dashboard" src/ tests/`
+- [ ] **F5** — Remove `get_all_repo_activity_by_org()` from `src/rebalance/ingest/note_builder.py` (lines 29-78 in current file). Update `build_dashboard_payload()` to import `fetch_org_activity` from `scripts/dashboard.py` instead — or better, extract it to a shared location both can import. Suggested location: `src/rebalance/ingest/github_queries.py` (new file) with the ignored-repos filter included. Then both `scripts/dashboard.py:fetch_org_activity` and `note_builder.py:build_dashboard_payload` import from there.
+  - Alternative (simpler): since `note_builder.py` is only ever called from the CLI (not from the web or TUI), it can import `fetch_org_activity` from `scripts.dashboard` directly. But cross-package imports are fragile. The `github_queries.py` shared module is cleaner.
+- [ ] Run tests: `uv run pytest tests/test_dashboard_cli.py tests/test_project_priority.py -x -q`
+
+---
+
+### Phase 3 — Eliminate get_github_balance() from the Obsidian note build; reassess github_items/github_commits tables
+
+This is the highest-value phase but has the most moving parts.
+
+**3A — Remove the parallel registry-gated path from `build_dashboard_payload()`**
+
+- [ ] In `src/rebalance/ingest/note_builder.py:build_dashboard_payload()` (currently lines 299-304):
+  Delete the `repo_map` construction and the `github_rows` dict built from `get_github_balance()`.
+  The `org_activity` dict (from `get_all_repo_activity_by_org` / unified function) already covers all repos.
+- [ ] Update `_determine_verdict()` (currently `note_builder.py:238-285`) to accept the org-based per-repo data instead of the per-project aggregated stats. Simplest path: sum all repos under the matching org. This will slightly change the verdict semantics for multi-repo projects but will not silently hide any activity.
+- [ ] Update `build_dashboard_payload()` to pass org-derived stats into `_determine_verdict()`.
+- [ ] Update evidence strings (currently lines 338-346) to reflect org-based data, not `github_rows`.
+- [ ] Update `tests/test_project_priority.py` — the test verifies per-project commit counts attributed via `repos_json`; rewrite to verify activity is attributed via org membership.
+- [ ] Update `tests/test_dashboard_cli.py` — verify the note still renders correctly; the key assertions (project names, verdict labels) should still pass.
+
+**3B — Assess `fetch_repo_activity_counts()` (F8)**
+
+- [ ] Replace the union query in `scripts/dashboard.py:400-436` with a direct `github_activity` query:
+  ```sql
+  SELECT repo_full_name,
+         SUM(commits + prs_opened + prs_merged + issues_opened) AS events
+  FROM github_activity
+  WHERE scan_date >= date('now', ?)
+  GROUP BY repo_full_name
+  ORDER BY events DESC
+  LIMIT ?
+  ```
+  Apply the ignored-repos filter the same way as the rest of the function.
+- [ ] Confirm the pie chart in `pulse_web.py` renders correctly with the new data shape (same dict keys, different counts — visual comparison only).
+
+**3C — Assess `github_commits` / `github_items` table necessity (context, not action)**
+
+These tables are NOT redundant with `github_activity`. Keep them. The reasons:
+
+| Consumer | Table | Purpose | Replaceable by `github_activity`? |
+|---|---|---|---|
+| `fetch_recent_github()` (TUI + web activity feed) | `github_items` + `github_commits` + `github_comments` | Detailed per-item view: PR titles, commit messages, issue titles | No — `github_activity` has counts only |
+| `fetch_open_prs()` (web PR panel) | `github_items WHERE item_type='pull_request'` | PR state, title, review decision, draft flag | No — `github_activity` has no per-PR detail |
+| `fetch_watched_summary()` (TUI watched panel) | `github_items` + `github_commits` + `github_repo_meta` | Last-sync timestamp per repo | Partially — `github_activity.last_active_at` is close but not identical to `fetched_at` |
+| `fetch_repo_activity_counts()` (pie chart) | union of all three | Event count per repo | **Yes** — replace with `github_activity` in 3B above |
+
+Verdict: `github_items` and `github_commits` earn their keep. The only query that should migrate to `github_activity` is the pie chart counter.
+
+---
+
+### Phase 4 — Evaluate project_registry, priority tiers, and onboarding flow
+
+This phase is an architectural decision, not a refactor. It should be treated as an owner decision, not a code cleanup.
+
+- [ ] **Inventory load-bearing uses of `project_registry`** after Phase 3 completes:
+  - MCP `list_projects` — returns project names, summaries, priorities. Still useful for agents.
+  - MCP `github_balance` — uses `{project: [repos]}` map from registry. After Phase 3, the Obsidian note no longer needs this, but the MCP tool still calls it. Decision: keep for agents, or replace with org-grouped view?
+  - MCP `confirm_projects` / `onboarding_status` — write to registry via `save_registry()`. Load-bearing for onboarding flow.
+  - Calendar classifier (`project_classifier.py`) — uses `repos_json` for alias building (F11). Low-risk if empty.
+  - `apply_project_priorities()` — reads priority tiers from registry rows to sort projects in the Obsidian note. If the Obsidian note is removed in a future phase, this becomes dead code.
+
+- [ ] **Decision point: does the Obsidian note (`rebalanceOS Dashboard.md`) still serve a purpose?**
+  - As of the last known state (May 12), it was stale.
+  - The web dashboard (`pulse_web.py`) and TUI (`scripts/dashboard.py`) are the live views.
+  - If the Obsidian note is retired: `src/rebalance/ingest/note_builder.py` (Phase 2 renamed) and all its supporting machinery (`read_current_goals`, `read_recent_changelog_highlights`, `build_dashboard_note_content`, `synthesize_dashboard_narrative`, `DashboardProjectRow`, `DashboardPayload`) can be archived.
+  - If it stays: keep everything, but eliminate the `get_github_balance()` call from it (Phase 3A).
+
+- [ ] **Decision point: replace `get_github_balance()` MCP semantics with org-grouped view?**
+  - Current: returns `[{project_name, total_commits, repos_linked, repos_touched, is_idle}]` — per manually-registered project.
+  - Alternative: `[{org, repo, commits, prs_opened, prs_merged, last_active_at}]` — per discovered repo, no registration required.
+  - The agent-facing use case may genuinely prefer per-project names ("how is the LTVera project doing?") over per-org grouping. If project names matter to agents, keep `get_github_balance()` as-is.
+
+- [ ] **`Registry` model and `sync_registry()` audit (F9, F10)**
+  - After Phase 3, determine whether `sync_registry(mode='pull')` (Obsidian → SQLite) is still called.
+  - If not: remove `pull` mode from `sync_registry()`; keep `push` mode (or replace with a simpler writer).
+  - `_default_registry_markdown()`, `_extract_yaml_block()`, `YAML_BLOCK_PATTERN` are only needed by `load_registry()` / `save_registry()`. If those are removed, these helpers go too.
+
+---
+
+## Test coverage map — machinery under review
+
+| Test file | What it covers | Survives Phase 3? |
+|---|---|---|
+| `tests/test_project_priority.py` | `build_dashboard_payload()` + `get_github_balance()` via `repos_json` | Needs rewrite in Phase 3A |
+| `tests/test_dashboard_cli.py` | CLI `dashboard-render` command end-to-end | Update assertions; structure stays |
+| `tests/test_github_scan.py` | `scan_github()`, `upsert_github_activity()`, `discover_repos_from_activity()` | Unchanged — ingest only |
+| `tests/test_project_inference.py` | `infer_project_registry()` auto-inference | Unchanged — ingest only |
+| `tests/test_watched_repos.py` | `fetch_watched_summary()` + repo registry fixture | Unchanged — display only, uses `github_items` not `get_github_balance` |
+| `tests/test_pulse_web_goals.py` | Goal parse + completion flow in `pulse_web.py` | Unchanged — not related to GitHub data path |
+
+---
+
+## How the symptom map connects to findings
+
+| Original symptom | Root cause finding(s) | Phase that fixes it |
+|---|---|---|
+| SYMPTOM 1 — `repos_json` gate silently hides repos from dashboards | F6 (parallel paths), F7 (get_github_balance still called), F5 (duplicate org-activity functions) | Phase 3A removes the call; Phase 1+2 reduce noise |
+| SYMPTOM 2 — Two `dashboard.py` files with overlapping concerns | F5 (duplicate query function), F12 (name collision) | Phase 2 |
+| Downstream: `fetch_repo_activity_counts()` hitting wrong tables | F8 | Phase 3B |
+| calendar classifier's last dependency on `repos_json` | F11 | flag only — graceful degradation, no action needed |


### PR DESCRIPTION
## Summary

- Adds `PROJECT/2-WORKING/SIMPLIFICATION-AUDIT.md` — a complete audit of over-engineering in the read/display layer, prompted by two diagnosed symptoms (the `repos_json` gate and the dual `dashboard.py` naming collision)
- 13 findings with file:line callouts, risk levels, and concrete replacement paths
- Four-phase plan with living-document maintainer instructions and MD checklists

## What's in scope

Audits these files only (no code changed):
- `scripts/dashboard.py`
- `scripts/pulse_web.py`
- `src/rebalance/ingest/dashboard.py`
- `src/rebalance/ingest/github_scan.py` (get_github_balance only)
- `src/rebalance/ingest/project_inference.py`
- `src/rebalance/ingest/registry.py`
- `src/rebalance/ingest/project_classifier.py`

## Key findings

| Risk | Finding |
|---|---|
| Zero | Two stale `# PHASE 1` comment lines left in `note_builder` after a previous pass |
| Zero | `_interleave()` in `scripts/dashboard.py` returns its input unchanged — dead helper |
| Zero | `_repo_label()` in `pulse_web.py` is a no-op identity function |
| Zero | `_truncate()` defined independently in both files; `pulse_web.py` already imports from `dashboard.py` |
| Low | `fetch_org_activity()` and `get_all_repo_activity_by_org()` are near-identical queries in two separate files |
| Low | `scripts/dashboard.py` and `src/rebalance/ingest/dashboard.py` share a name but serve entirely different purposes |
| Medium | Both `get_github_balance()` (registry-gated) AND `get_all_repo_activity_by_org()` (direct) run on every Obsidian note build — the old path is still live after the gate was removed from output |
| Medium | `fetch_repo_activity_counts()` (pie chart) hits a union of `github_items + github_commits + github_comments` when `github_activity` aggregates already hold the same counts |

## Phase plan

- **Phase 1** — Zero-risk deletions (dead code, duplicate helpers). Safe in one commit.
- **Phase 2** — Rename `ingest/dashboard.py` → `note_builder.py`; merge the duplicate org-activity query into one shared function.
- **Phase 3** — Remove `get_github_balance()` from the Obsidian note build; migrate pie chart to `github_activity`; includes table keep-worth analysis (result: `github_items`/`github_commits` stay).
- **Phase 4** — Owner decision: is the Obsidian note (`rebalanceOS Dashboard.md`) still serving a purpose? Can `project_registry` + priority tiers be simplified further?

## Test plan

- [ ] No code changes in this PR — pure documentation
- [ ] Verify doc renders correctly in GitHub markdown
- [ ] Phase 1 implementation (follow-on PR): `uv run pytest tests/test_dashboard_terminal_theme.py tests/test_pulse_web_goals.py -x -q` must stay green after deletions

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8eNSiaTPXKByV35NBsgWu)_