### PR TITLE
Chat with your data — Phase 0 (ask_self federation) + status docs

### DIFF
--- a/PROJECT/2-WORKING/CHAT-WITH-DATA.md
+++ b/PROJECT/2-WORKING/CHAT-WITH-DATA.md
@@ -2,7 +2,7 @@
 title: Chat with Your Rebalance Data
 status: proposed
 created: 2026-06-04
-updated: 2026-06-04
+updated: 2026-06-05
 owner: noel
 tool_surface: chat_with_data(query, scope, top_k, skip_synthesis) — new MCP tool, NOT an extension of ask()
 depends_on: semantic_index (vec0 ANN), index_ops incremental refresh, semantic_query MCP tool, ask_self code/doc RAG

--- a/PROJECT/2-WORKING/CHAT-WITH-DATA.md
+++ b/PROJECT/2-WORKING/CHAT-WITH-DATA.md
@@ -7,8 +7,8 @@ owner: noel
 tool_surface: chat_with_data(query, scope, top_k, skip_synthesis) — new MCP tool, NOT an extension of ask()
 depends_on: semantic_index (vec0 ANN), index_ops incremental refresh, semantic_query MCP tool, ask_self code/doc RAG
 phases: 0 spike · 1 hybrid retrieval · 2 native code corpus · 3 synthesis · 4 surface/UX
-phases_done: none
-phases_next: Phase 0 — Federation spike
+phases_done: 0 (federation spike — 7/10 federated vs 4/10 work-only)
+phases_next: Phase 1 — Hybrid retrieval (FTS5 + vec, RRF) to close exact-match misses
 decision_gates:
   - Phase 0 recall@k + latency → decide federate-vs-build-native
   - Phase 2 runs only if federation is insufficient or ask_self proves too fragile
@@ -19,7 +19,7 @@ non_goals: replacing ask(); a general chatbot; cloud inference; multi-user
 
 | ✅ Most recently completed | ▶️ What's next |
 |---|---|
-| **Plan drafted** *(2026-06-04)*. Grounded against the code: confirmed there is **no `code` source_type** (corpus is `vault/github/calendar/sleuth/email`) and that `semantic_index.query()` is **ANN-only** (vector distance, no lexical path). No phases implemented yet. | **Phase 0 — Federation spike**: prototype `chat_with_data` that merges `semantic_query` (work artifacts) + `ask_self` (code/docs), **citations-only**, run a 10-question eval, measure recall@k and latency. Gate the federate-vs-build decision on the numbers. |
+| **Phase 0 — Federation spike, complete** *(2026-06-05)*: `chat_with_data` ships (citations-first, RRF merge), wired to a dashboard **Filter\|Ask** search-bar switch via `POST /api/chat`. ask_self federation gated on availability (the mlx-embeddings gotcha → uses the rebalance venv). Eval (`scripts/chat_eval.py`, 10 questions): **federated 7/10 vs work-only 4/10**, ~2.1 s median, and federation surfaces *real code* (`index_ops.py`, `sleuth_reminders.py`) the work corpus never did. **Decision: federation is worth it.** | **Phase 1 — Hybrid retrieval**: add an FTS5 lexical index beside vec0 and fuse (RRF), to close the 3 exact-match misses (`auth_log`, `web.py`/`pulse_server`, `config`/keyring) that semantic-only ranking lost. |
 
 ## Table of Contents
 
@@ -76,13 +76,32 @@ Adjusted from the source analysis:
 Goal: a throwaway-quality prototype that proves merged retrieval answers real
 questions, with numbers — before building anything durable.
 
-- [ ] Add prototype `chat_with_data(query, scope, top_k, skip_synthesis=True)` returning citations only.
-- [ ] Retrieve from `semantic_query` (work corpus) and `ask_self` (code/docs); merge + dedupe by `(source, path)`.
-- [ ] **ask_self availability gate**: probe ask_self at call time; if unreachable, degrade to rebalance-only and log it (no hard failure).
-- [ ] Build a fixed eval set of 10 real questions (mix code + data): e.g. "where is X orchestrated?", "what writes table Y?", "how does refresh flow into the semantic index?", "what code owns MCP tool Z?", "which collector logs auth failures?".
-- [ ] Record per-question: did a correct source appear in top-k? (recall@k) and end-to-end latency.
-- [ ] Write results to a short scorecard in this doc (recall@k, p50/p95 latency).
-- [ ] **Decision gate**: if recall@k ≥ 7/10 and p95 < target → continue federation; if code recall is the weak spot → prioritize Phase 2; if exact-match misses dominate → Phase 1 first.
+- [x] Add prototype `chat_with_data(query, scope, top_k, skip_synthesis=True)` returning citations only. → `src/rebalance/chat.py`
+- [x] Retrieve from `semantic_query` (work corpus) and `ask_self` (code/docs); merge via RRF, dedupe by `(source, path)`.
+- [x] **ask_self availability gate**: `ask_self_available()` probes config/env + the wrapper; unreachable → work-only, no hard failure. (Found the mlx-embeddings gotcha — federation runs `ask-self-query.sh` with the **rebalance venv** as `ASK_SELF_PYTHON`.)
+- [x] Build a fixed eval set of 10 real questions. → `scripts/chat_eval.py`
+- [x] Record per-question recall@k + latency. → scorecard below
+- [x] Write results to a short scorecard in this doc.
+- [x] **Decision gate** → exact-match misses dominate the gap → **do Phase 1 (hybrid) next**, keep federation.
+
+### Phase 0 scorecard (2026-06-05, top_k=8)
+
+| run | recall@8 | latency median / p95 | sources |
+|---|---|---|---|
+| work-only (`--scope work`) | **4/10** | 32 ms / 2.3 s* | semantic_index |
+| federated (`--scope all`, ask_self) | **7/10** | 2.1 s / 4.2 s | semantic_index + ask_self |
+
+\* work-only first query pays the embed-model load (~2.3 s), then ~30 ms.
+
+Findings: (1) federation ~doubles code recall and surfaces *actual code files*
+(`index_ops.py`, `sleuth_reminders.py`, `health_issue_reporter.py`) the
+work-only run never returned — its 4 "hits" were coincidental keyword matches in
+GitHub PR/issue titles. (2) The 3 federated misses — `auth_log`, `web.py`/
+`pulse_server`, `config`/keyring — are exact-identifier/ranking failures, the
+canonical semantic-only weakness → motivates Phase 1. (3) Federation latency
+(~2 s) is acceptable for an explicit "Ask"; it stays **off by default** for the
+dashboard (gated on `ask_self_path` config / `ASK_SELF_PATH` env) so Filter and
+work-only Ask stay snappy.
 
 ## Phase 1 — Hybrid retrieval (the decisive fix)
 

--- a/PROJECT/3-DONE/SLEUTH-PRODUCTION.md
+++ b/PROJECT/3-DONE/SLEUTH-PRODUCTION.md
@@ -1,5 +1,16 @@
 # Sleuth → rebalance-OS: Production Cutover Checklist
 
+> **Status: COMPLETED 2026-06-05.** rebalance now pulls **production** reminders
+> (workspace `neochrome`) over the SSH tunnel (`http://127.0.0.1:12020`, launchd
+> `com.rebalance-os.sleuth-tunnel`). Two issues were fixed during cutover:
+> (1) the tunnel authenticated by key but the rebuilt prod box had **no key
+> installed** → installed the Mac Studio's `~/.ssh/id_ed25519.pub` in the box's
+> `authorized_keys`; (2) the config still pointed at the **dev** box
+> (`neochrome-dev`) → repointed to the production creds from
+> `~/secrets/sleuth/sleuth-web-api-production.env` (kept in keyring). The dev
+> integration (`104.238.130.109`, `neochrome-dev`) remains available for manual
+> use. First production sync returned 24/24 reminders.
+
 **Trigger:** Sleuth has been deployed to the production host (`<prod-host>`) on
 a HEAD that includes commit `15725ec` (`Add rebalance reminders API export`) or later.
 

--- a/PROJECT/README.md
+++ b/PROJECT/README.md
@@ -25,7 +25,7 @@ the repo root (see [../README.md → Documentation](../README.md#documentation))
 | Doc | Topic |
 |-----|-------|
 | [CLAUDE-ONBOARDING.md](./2-WORKING/CLAUDE-ONBOARDING.md) | Onboarding flow (GitHub repos, registry) |
-| [CHAT-WITH-DATA.md](./2-WORKING/CHAT-WITH-DATA.md) | "Chat with your rebalance data" — scoped, hybrid, citations-first retrieval (`chat_with_data`); proposed, Phase 0 next |
+| [CHAT-WITH-DATA.md](./2-WORKING/CHAT-WITH-DATA.md) | "Chat with your rebalance data" — scoped, citations-first retrieval (`chat_with_data`) + dashboard Filter\|Ask switch. **Phase 0 done** (federated 7/10 vs 4/10 work-only); Phase 1 (hybrid FTS5+vec) next |
 | [CLAUDE-REFACTOR.md](./2-WORKING/CLAUDE-REFACTOR.md) | Codebase refactor (CLI decomposition, observability) |
 | [DECOUPLE-OBSIDIAN-AS-SOT.md](./2-WORKING/DECOUPLE-OBSIDIAN-AS-SOT.md) | Decouple Obsidian as source of truth for GitHub activity |
 | [GH-SYNC-DELTA.md](./2-WORKING/GH-SYNC-DELTA.md) | Incremental GitHub sync (delta) |

--- a/src/rebalance/chat.py
+++ b/src/rebalance/chat.py
@@ -11,13 +11,20 @@ intentionally off by default — return grounded citations, fast and debuggable.
 
 from __future__ import annotations
 
+import json
+import os
+import subprocess
+import sys
 import time
 from pathlib import Path
 from typing import Any, Callable
 
 # Reserved scope vocabulary. "work" = the ingested work artifacts; "code" =
-# source tree + GitHub artifacts (code federation lands in the spike); "all" = both.
+# source tree + docs via the federated ask_self index; "all" = both.
 SCOPES = ("all", "work", "code")
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]  # …/rebalance-OS/
+ASK_SELF_TIMEOUT_SECONDS = 60
 
 
 def _citation_from_semantic(row: dict[str, Any]) -> dict[str, Any]:
@@ -37,6 +44,79 @@ def _citation_from_semantic(row: dict[str, Any]) -> dict[str, Any]:
 def _default_work_query(database_path: Path, query: str, top_k: int) -> list[dict[str, Any]]:
     from rebalance.ingest.semantic_index import query as _q
     return _q(database_path, query, top_k=top_k)
+
+
+# ---------------------------------------------------------------------------
+# ask_self federation (code/docs corpus)
+# ---------------------------------------------------------------------------
+
+def ask_self_available() -> bool:
+    """True if ask_self federation can run: a configured install + the wrapper."""
+    from rebalance.ingest.config import get_ask_self_path
+    root = get_ask_self_path()
+    wrapper = _REPO_ROOT / "scripts" / "ask-self-query.sh"
+    return bool(root) and Path(root).is_dir() and wrapper.exists()
+
+
+def _query_ask_self(query: str, top_k: int) -> list[dict[str, Any]]:
+    """Federate the ask_self code/doc index → citation dicts. Never raises.
+
+    Runs the repo's ask-self-query.sh wrapper with the rebalance venv as the
+    interpreter (ASK_SELF_PYTHON) — ask-self's own venv lacks mlx-embeddings,
+    so the rebalance venv is required for the local Qwen-MLX provider.
+    """
+    from rebalance.ingest.config import get_ask_self_path
+    root = get_ask_self_path()
+    wrapper = _REPO_ROOT / "scripts" / "ask-self-query.sh"
+    if not root or not wrapper.exists():
+        return []
+    env = {**os.environ, "ASK_SELF_PATH": root, "ASK_SELF_PYTHON": sys.executable}
+    try:
+        proc = subprocess.run(
+            ["bash", str(wrapper), query, "--retrieval-only", "--json"],
+            capture_output=True, text=True, env=env,
+            timeout=ASK_SELF_TIMEOUT_SECONDS, cwd=str(_REPO_ROOT),
+        )
+        if proc.returncode != 0:
+            return []
+        data = json.loads(proc.stdout)
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError):
+        return []
+    if not isinstance(data, dict) or not data.get("ok"):
+        return []
+
+    cites: list[dict[str, Any]] = []
+    for hit in (data.get("retrieved_hits") or [])[:top_k]:
+        if not isinstance(hit, dict):
+            continue
+        dist = hit.get("distance")
+        score = round(1.0 - dist, 4) if isinstance(dist, (int, float)) else hit.get("score")
+        cites.append({
+            "source": "code",
+            "title": hit.get("path") or "",
+            "path": hit.get("path") or "",
+            "preview": (hit.get("content") or "")[:280],
+            "score": score,
+            "kind": hit.get("source") or "code",
+        })
+    return cites
+
+
+def _rrf_merge(lists: list[list[dict[str, Any]]], top_k: int, k: int = 60) -> list[dict[str, Any]]:
+    """Reciprocal-rank fusion — rank-based, so the two systems' score scales
+    don't have to be comparable. Dedupe by (source, path|title)."""
+    def key(c: dict[str, Any]) -> tuple[str, str]:
+        return (c.get("source") or "", (c.get("path") or c.get("title") or "").lower())
+
+    scores: dict[tuple[str, str], float] = {}
+    best: dict[tuple[str, str], dict[str, Any]] = {}
+    for lst in lists:
+        for rank, c in enumerate(lst):
+            ck = key(c)
+            scores[ck] = scores.get(ck, 0.0) + 1.0 / (k + rank + 1)
+            best.setdefault(ck, c)
+    ranked = sorted(best.values(), key=lambda c: -scores[key(c)])
+    return ranked[:top_k]
 
 
 def chat_with_data(
@@ -68,22 +148,30 @@ def chat_with_data(
             "used_sources": [], "elapsed_ms": 0, "answer": None,
         }
 
-    citations: list[dict[str, Any]] = []
     used: list[str] = []
+    result_lists: list[list[dict[str, Any]]] = []
 
-    # Native work corpus. Searched for work/all now; also the only code-adjacent
-    # source until the ask_self federation / native code corpus lands.
-    if scope in ("all", "work", "code"):
+    # Native work corpus (vault / github / email): work + all.
+    if scope in ("all", "work"):
         qfn = work_query_fn or _default_work_query
-        rows = qfn(database_path, text, top_k)
-        citations.extend(_citation_from_semantic(r) for r in rows)
-        used.append("semantic_index")
+        work = [_citation_from_semantic(r) for r in qfn(database_path, text, top_k)]
+        if work:
+            result_lists.append(work)
+            used.append("semantic_index")
 
-    # Stable, deterministic ordering: score desc, then source/title for ties.
-    citations.sort(
-        key=lambda c: (-(c.get("score") or 0.0), c.get("source") or "", c.get("title") or "")
-    )
-    citations = citations[:top_k]
+    # Federated code/docs corpus via ask_self: code + all (gated on availability).
+    if scope in ("all", "code") and ask_self_available():
+        code = _query_ask_self(text, top_k)
+        if code:
+            result_lists.append(code)
+            used.append("ask_self")
+
+    if len(result_lists) > 1:
+        citations = _rrf_merge(result_lists, top_k)  # fuse across systems
+    elif result_lists:
+        citations = result_lists[0][:top_k]
+    else:
+        citations = []
 
     return {
         "query": text,

--- a/src/rebalance/ingest/config.py
+++ b/src/rebalance/ingest/config.py
@@ -340,6 +340,31 @@ def remove_health_notice_pattern(pattern: str) -> bool:
     return True
 
 
+# ---------------------------------------------------------------------------
+# ask_self federation (chat_with_data code/doc retrieval)
+# ---------------------------------------------------------------------------
+
+def get_ask_self_path() -> str | None:
+    """Return the ask-self install path for chat federation, or None.
+
+    Resolution: ``ASK_SELF_PATH`` env first (per-shell override), then the
+    ``ask_self_path`` config key (persisted, so the dashboard server can
+    federate too). See PROJECT/2-WORKING/CHAT-WITH-DATA.md.
+    """
+    env = os.environ.get("ASK_SELF_PATH")
+    if env and env.strip():
+        return env.strip()
+    value = _read_config().get("ask_self_path")
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def set_ask_self_path(path: str) -> None:
+    """Persist the ask-self install path used for chat federation."""
+    config = _read_config()
+    config["ask_self_path"] = path.strip()
+    _write_config(config)
+
+
 GMAIL_INGEST_METHODS = ("oauth", "mcp")
 
 

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -3,7 +3,7 @@
 import unittest
 from pathlib import Path
 
-from rebalance.chat import chat_with_data
+from rebalance.chat import _rrf_merge, chat_with_data
 
 
 def _fake_rows(_db, _query, top_k):
@@ -51,6 +51,22 @@ class ChatWithDataTests(unittest.TestCase):
                      "source_pk": "p", "metadata": {}, "similarity_score": 0.5}]
         out = chat_with_data(self.DB, "q", work_query_fn=big)
         self.assertLessEqual(len(out["citations"][0]["preview"]), 280)
+
+
+class RrfMergeTests(unittest.TestCase):
+    def test_fuses_shared_result_to_top_and_dedupes(self) -> None:
+        a = [{"source": "code", "path": "x.py", "title": "x"},
+             {"source": "code", "path": "y.py", "title": "y"}]
+        b = [{"source": "code", "path": "y.py", "title": "y"},
+             {"source": "work", "path": "z", "title": "z"}]
+        out = _rrf_merge([a, b], top_k=10)
+        # y.py appears in both lists → fused to the top; deduped to one entry.
+        self.assertEqual(len(out), 3)
+        self.assertEqual(out[0]["path"], "y.py")
+
+    def test_respects_top_k(self) -> None:
+        a = [{"source": "code", "path": f"{i}.py", "title": str(i)} for i in range(20)]
+        self.assertEqual(len(_rrf_merge([a], top_k=5)), 5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Completes **Phase 0** of [CHAT-WITH-DATA.md](PROJECT/2-WORKING/CHAT-WITH-DATA.md): a scoped, citations-first retrieval tool (`chat_with_data`) federating the native semantic index with the `ask_self` code/doc index, and proves value with an eval.

(The dashboard **Filter|Ask** search-bar switch + the plan doc landed in earlier commits already on `development`; this PR adds the federation + eval + status docs.)

## What's here
- **`chat_with_data` federation** (`src/rebalance/chat.py`): `ask_self_available()` gate; `_query_ask_self()` runs `ask-self-query.sh` with the **rebalance venv** as `ASK_SELF_PYTHON` (the mlx-embeddings gotcha — ask-self's own venv lacks it); `retrieved_hits` → citations; `_rrf_merge()` fuses work + code by reciprocal rank (scale-free), dedupe by `(source, path)`.
- **Config** (`config.py`): `get/set_ask_self_path` — off by default (env `ASK_SELF_PATH` > config), so the dashboard stays work-only/snappy unless explicitly enabled.
- **Eval harness** (`scripts/chat_eval.py`): 10-question recall@k + latency.
- **Tests**: RRF fusion/dedupe + top_k (chat suite green).

## Phase 0 scorecard (top_k=8)
| run | recall@8 | latency median/p95 |
|---|---|---|
| work-only | 4/10 | 32 ms / 2.3 s |
| **federated** | **7/10** | 2.1 s / 4.2 s |

Federation ~doubles code recall and surfaces *real code* (`index_ops.py`, `sleuth_reminders.py`) the work corpus never returned. The 3 misses (`auth_log`, `web.py`, `config`/keyring) are exact-identifier/ranking failures → **decision: keep federation, do Phase 1 (hybrid FTS5+vec) next**.

## Docs
- PROJECT/README + CHAT-WITH-DATA: Phase 0 done, Phase 1 next.
- SLEUTH-PRODUCTION: marked COMPLETED 2026-06-05 with the cutover findings (SSH key install on the rebuilt prod box; dev→prod creds repoint; 24/24 first sync).

## Test plan
- `pytest tests/` → 509 passed.
- `rebalance doctor` clean.
- `scripts/chat_eval.py --scope work` and `--scope all` (with `ASK_SELF_PATH` set) reproduce the scorecard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)