### PR TITLE
Focus 5 Phase 1 + 2: device-local repo collector + /focus-5 web view

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -67,3 +67,4 @@
 - git-pulse collector scans can succeed partially: preserve successful repo rows, record `repo_scan_failures` plus `scan_failure_examples` in device metadata, classify that state as `DEGRADED` in `git-pulse-health`, and do not advance `last-run` until every watched repo scan succeeds.
 - Project plan docs should prefer frontmatter, a 2-column status table (`Most recently completed phase` and `What's next`), a Table of Contents, and phased observable checklists.
 - Focus 5 product decisions are locked for now: rank by local repo activity, require zero manual repo config, and treat repos active at session start or during the session as in scope.
+- Focus 5 architecture direction shifted from a server-side "session" concept to a persisted roster snapshot with TTL; top-5 git health is live, off-roster warning inputs should be cached/persisted, and local git data is the primary signal with GitHub as enrichment.

--- a/PROJECT/2-WORKING/ASK-SELF-INVENTORY.md
+++ b/PROJECT/2-WORKING/ASK-SELF-INVENTORY.md
@@ -1,0 +1,113 @@
+---
+title: ask_self Index Inventory (Across All Repos)
+status: in-progress
+doc_type: project-plan
+owner: Noel Saw
+last_updated: 2026-06-05
+surfaces:
+  - mcp
+  - dashboard
+---
+
+| Most recently completed phase | What's next |
+|---|---|
+| Phase 0 spike complete and validated on-device: an `ask_self` collector + `list_ask_self_repos` MCP tool discover every ask_self repo on this machine, read each index read-only, and bridge it to its GitHub `owner/repo`. Real run found 10 repos (5 built indexes, 4 matching the watched set). A real bug surfaced and was fixed: stale copied harnesses mislabeled repos, now corrected via the live git remote. | Phase 2 cross-device sync: export this inventory as a per-device snapshot into the pulse repo so any machine's dashboard can answer "which device holds a queryable brain for which project." First, Phase 1 hardening + the local-checkout-vs-repo granularity decision. |
+
+## Table of Contents
+
+1. [Phase 0 - Technical Spike](#phase-0---technical-spike)
+2. [Phase 1 - Harden the Device-Local Collector](#phase-1---harden-the-device-local-collector)
+3. [Phase 2 - Cross-Device Sync Plane](#phase-2---cross-device-sync-plane)
+4. [Phase 3 - Dashboard Surface](#phase-3---dashboard-surface)
+5. [Phase 4 - Testing and Rollout](#phase-4---testing-and-rollout)
+6. [Definition of Done](#definition-of-done)
+
+Decision lock-ins for this plan:
+- The detection signal is the filesystem marker `ask_self/ask_self_harness.json`, not a registry that may omit committed/shared indexes.
+- GitHub identity is derived most→least authoritative: built index `remote_url` → live `git remote get-url origin` → harness `github` block (last resort; frequently a stale template copy).
+- The foreign ask_self index is opened read-only (`mode=ro`); the collector never writes to or migrates it.
+- Rows are keyed by `(device_id, local_path)` so one GitHub repo with multiple local checkouts stays as distinct rows.
+- The collector is opt-in (`included_in_all=False`) until cost on large trees is characterized.
+
+## Phase 0 - Technical Spike
+
+Goal: Prove that "query all repos with ask_self on this device" is feasible and bridges cleanly to the watched-repos set.
+
+- [x] Confirm the detection signal for an ask_self repo:
+  observable result: `ask_self/ask_self_harness.json` presence is necessary and sufficient; each built index also carries a `repo_metadata` row with remote, branch, counts, embed model, and last-ingest time.
+- [x] Add a device-local collector through the existing orchestration pattern in [src/rebalance/ingest/index_ops.py](/Users/noelsaw/Documents/GitHub-Repos/rebalance-OS/src/rebalance/ingest/index_ops.py:1):
+  observable result: an `ask_self` Collector is registered and runs via `refresh_index(scope=["ask_self"])`.
+- [x] Read each index's metadata without mutating it:
+  observable result: `repo_metadata` is read over a `mode=ro` connection in [src/rebalance/ingest/ask_self_scan.py](/Users/noelsaw/Documents/GitHub-Repos/rebalance-OS/src/rebalance/ingest/ask_self_scan.py:1).
+- [x] Persist the inventory in a forward-only migration:
+  observable result: [0002_ask_self_indexes.sql](/Users/noelsaw/Documents/GitHub-Repos/rebalance-OS/src/rebalance/ingest/db/migrations/0002_ask_self_indexes.sql:1) creates `ask_self_indexes`; schema version advances to 2.
+- [x] Bridge each local repo to its GitHub identity and join to the watched set:
+  observable result: `list_ask_self_repos` returns each repo with a `watched` flag; on-device run showed 4 of 5 built indexes matching watched repos.
+- [x] Validate on the real machine without touching the production DB:
+  observable result: throwaway-DB run discovered 10 repos / 5 built indexes; read-only cross-reference against the real watched set confirmed the join.
+- [x] Capture blockers/findings before Phase 1:
+  observable result: stale-harness mislabeling found (e.g. `AI-DDTK-Fix-Iterate-Loop` claimed `WP-Code-Check`) and fixed via live-git-remote fallback.
+
+## Phase 1 - Harden the Device-Local Collector
+
+Goal: Make discovery dependable and cheap enough to consider running in the daily sweep.
+
+- [ ] Characterize walk cost on large trees:
+  observable result: documented timing for the default scan roots and a worst-case `$HOME` walk, with a decision on whether to flip `included_in_all` to True.
+- [ ] Make zero-config discovery robust without whole-disk drag:
+  observable result: depth bound and prune list are tuned so active repos are still found while heavy dirs (node_modules, .venv, build, vendor) are skipped.
+- [ ] Decide ranking/granularity: local checkout vs GitHub repo:
+  observable result: documented choice for how multiple checkouts of one repo (e.g. two `deckme` clones) are presented.
+- [ ] Surface stale-harness identity mismatches as a signal, not a silent fix:
+  observable result: rows flag when the harness `github` block disagrees with the live git remote.
+- [ ] Handle missing/abnormal indexes honestly:
+  observable result: harness-without-index repos are recorded `index_built=0` (not skipped), and unreadable indexes are reported rather than dropped.
+
+## Phase 2 - Cross-Device Sync Plane
+
+Goal: Let any machine see the ask_self inventory of every device.
+
+- [ ] Export a per-device inventory snapshot into the pulse repo:
+  observable result: `<sync_subdir>/ask_self/<device_id>.json` is written using the same snapshot/`latest.json` pattern as calendar/email.
+- [ ] Consume snapshots back into the local DB:
+  observable result: the collector reads other devices' snapshots so one machine's view spans all devices.
+- [ ] Preserve device attribution in the joined view:
+  observable result: `list_ask_self_repos` reports, per repo, which device(s) hold a built index.
+- [ ] Keep the snapshot non-destructive and conflict-safe:
+  observable result: commit/push reuses the existing RepairFSM path; concurrent device writes do not clobber each other.
+
+## Phase 3 - Dashboard Surface
+
+Goal: Make the inventory visible where the operator already looks.
+
+- [ ] Add an `ask_self` summary block to the index-status surface:
+  observable result: repo count, built-index count, and last-scanned time appear in `index_status` (already wired) and render in the dashboard.
+- [ ] Show "indexed but not watched" and "watched but not indexed" gaps:
+  observable result: the view highlights coverage gaps in both directions.
+- [ ] Provide a per-repo drill-in:
+  observable result: each repo shows local path, device, branch, head SHA, chunk/file counts, and embed model.
+
+## Phase 4 - Testing and Rollout
+
+Goal: Ship with confidence and operational visibility.
+
+- [x] Unit-test the collector's pure and persistence paths:
+  observable result: [tests/test_ask_self_scan.py](/Users/noelsaw/Documents/GitHub-Repos/rebalance-OS/tests/test_ask_self_scan.py:1) covers identity parsing, scanning/dedupe, upsert/unchanged/updated, unbuilt-index handling, and the watched join (10 tests passing).
+- [ ] Add sync-plane tests for Phase 2:
+  observable result: mocks cover snapshot export, multi-device merge, and conflict handling.
+- [ ] Add timing and structured logs around the scan path:
+  observable result: slow walks and unreadable indexes are diagnosable from logs.
+- [ ] Decide and document the run cadence:
+  observable result: opt-in vs all-scope decision recorded; if scheduled, the launchd/daily-sync wiring is noted here.
+- [ ] Update this plan with rollout notes:
+  observable result: completed phases and follow-ups are recorded here instead of drifting into chat.
+
+## Definition of Done
+
+- [ ] `list_ask_self_repos` returns every ask_self repo on the operator's devices, each bridged to `owner/repo` and flagged `watched`.
+- [ ] Identity is derived from the live git remote, not the (possibly stale) harness.
+- [ ] One GitHub repo with multiple local checkouts is represented without collapsing distinct work surfaces.
+- [ ] The foreign ask_self index is never mutated by discovery.
+- [ ] Cross-device snapshots let any machine see the full inventory with device attribution.
+- [ ] Coverage gaps (indexed-not-watched, watched-not-indexed) are visible on the dashboard.
+- [ ] Tests and logs are in place for the collector and the sync plane.

--- a/PROJECT/2-WORKING/FOCUS-5.md
+++ b/PROJECT/2-WORKING/FOCUS-5.md
@@ -11,7 +11,7 @@ surfaces:
 
 | Most recently completed phase | What's next |
 |---|---|
-| Intake and concept capture completed; additive `Focus 5` view defined and anchored to the existing web dashboard. Product decisions now fixed: use local repo activity and require zero manual repo config. | Phase 0 technical spike: validate automatic local repo discovery, local git health reads, and top-5 ranking before UI implementation. |
+| Phase 0 technical spike executed against the real device (2026-06-05). Discovery, live git-health reads, and the live-vs-cached split all validated. One contradiction found and escalated: the naive "most recently active" ranking by `.git/index` mtime is invalid — it surfaces dormant third-party clones over the operator's own dirty work-in-progress. | Resolve the ranking-signal policy (escalated below), then proceed to Phase 1 collector with the corrected signal. |
 
 ## Table of Contents
 
@@ -20,26 +20,90 @@ surfaces:
 3. [Phase 2 - Web View and Interaction Model](#phase-2---web-view-and-interaction-model)
 4. [Phase 3 - Refresh Behavior and Safety Signals](#phase-3---refresh-behavior-and-safety-signals)
 5. [Phase 4 - Testing, Observability, and Rollout](#phase-4---testing-observability-and-rollout)
-6. [Definition of Done](#definition-of-done)
+6. [Working Model](#working-model)
+7. [Risks and Open Decisions](#risks-and-open-decisions)
+8. [Definition of Done](#definition-of-done)
 
 Decision lock-ins for this plan:
 - Local repo activity is the ranking signal, not remote GitHub activity.
+- Local git state and local git history are the primary activity sources; GitHub corpus data is enrichment only.
 - Repo scope must be zero-config for the operator.
-- The roster should reflect repos actively being worked on at the moment the session starts, plus repos that become active during the session.
+- There is no server-side session model in the first implementation; the view should use a persisted roster snapshot with timestamps and refresh rules.
+
+## Working Model
+
+- Roster model:
+  the page reads from a persisted `Focus 5` roster snapshot with `computed_at` metadata and a 24-hour freshness window.
+- Refresh trigger model:
+  "automatic 24-hour refresh" means lazy recompute on page load when the persisted roster is stale, unless a background scheduler is later added explicitly.
+- Manual refresh model:
+  the refresh button forces roster recompute immediately and can admit newly active repos at that moment.
+- Persistence split:
+  roster membership, ranking inputs, off-roster warning inputs, and recent activity summaries may be persisted; top-5 working tree health should be treated as a live probe with visible freshness markers.
+- Off-roster warning model:
+  the hidden-attention strip should read cached or persisted health summaries for non-visible repos rather than probing the entire discovered set live on every request.
+- GitHub enrichment fallback:
+  a locally active repo remains eligible even when no GitHub mapping exists; in that case the PR section should render an explicit empty or unavailable state rather than dropping the repo.
+- Discovery model:
+  zero-config discovery should reuse the repo's existing bounded local-scan pattern rather than introducing whole-disk search or brittle editor-state scraping.
+- Activity signal model:
+  the first pass should use local git signals, such as local commit history, working tree state, and repository timestamps, rather than undocumented VS Code workspace internals.
+- UI implementation scope:
+  the first pass may stay inside the existing single-file FastAPI surface, but the plan should allow a small rendering split if the page becomes unwieldy in one file.
+
+## Risks and Open Decisions
+
+- Stateless server constraint:
+  the current FastAPI surface is stateless, so the plan must not imply cookies, per-browser session memory, or page-load identity without explicitly adding storage.
+- Live-probe budget:
+  top-5 live probes are acceptable; full-set live probes for off-roster warnings are not. Non-visible repos need cached summaries, caps, or time budgets.
+- Automatic refresh semantics:
+  if no scheduler is added, "automatic" means "recompute on next visit after TTL expiry," not "refresh in the background while nobody is looking."
+- Discovery reuse:
+  the repo already has a bounded local-discovery pattern; Phase 0 should bias toward adapting that pattern instead of inventing a second unrelated discovery mechanism.
+- Local-first rendering:
+  cards must still feel populated for active repos that have no GitHub corpus coverage yet, especially personal or side-project repos.
+- Ranking signal (OPEN — blocks Phase 1, raised by the Phase 0 spike):
+  `.git/index` mtime is polluted by clone/fetch/checkout and surfaces dormant third-party clones over the operator's own dirty WIP. The activity signal must be operator-authored (commits by the operator's git email) and/or dirty-tree based, not raw index mtime. The exact eligibility/ranking policy is pending an explicit decision before the collector is written.
 
 ## Phase 0 - Technical Spike
 
 Goal: Prove the critical assumptions in 1-2 hours before committing to the full build.
 
+### Phase 0 spike results (executed 2026-06-05, read-only, real device)
+
+Validated empirically with a throwaway script reusing the ask_self scan-root + pruned-walk pattern (`.git` marker instead of the ask_self harness):
+
+- **Discovery — PASS.** 21 git repos found under the existing zero-config scan roots in **95 ms**, bounded by the existing prune list + max-depth and stopping at each repo boundary (no submodule fan-out). No operator config needed.
+- **Live git-health reads — PASS.** A single `git status --porcelain=v2 --branch` per repo yields branch, upstream, ahead/behind, modified count, untracked count, and clean/dirty verdict in **~51 ms/repo**. Big drift reads correctly (e.g. one clone at `+0/-1484`).
+- **Live-vs-cached split — PASS / confirms the plan.** Full 21-repo health sweep = **~1.2 s**; top-5-only probe ≈ **256 ms**. Confirms off-roster warnings must read **cached** summaries (a full live sweep per request is too slow), while top-5 live probing per request is fine.
+- **Activity ranking — FAIL / CONTRADICTION (escalated).** Ranking by "most recent local activity" using `.git/index` mtime is **invalid**: index mtime is bumped by `git clone`/`fetch`/`checkout`, not just by the operator's edits. The spike's top 5 were dormant third-party clones the operator has **never committed to** (e.g. `shopify_python_api` — index touched 0h ago but last commit 39d ago, zero operator commits; `hermes-agent` — `+0/-1484` behind, never touched), while the operator's actual dirty WIP (`rebalance-OS`: 5 modified / 4 untracked) was pushed to rank #7, *out* of the top 5. The signal must be **operator-authored activity** (commits by the operator's email) and/or **dirty working tree**, explicitly excluding raw index/fetch mtime. Final ranking policy is the open decision blocking Phase 1 — see [Risks and Open Decisions](#risks-and-open-decisions).
+
+Secondary observation: repo display names can collide across scan roots (two `sleuth-app` paths seen). Phase 1 must key the roster by resolved path / repo identity, not bare name.
+
 - [ ] Confirm the additive surface will live as a new route in [src/rebalance/web.py](/Users/noelsaw/Documents/GitHub-Repos/rebalance-OS/src/rebalance/web.py:1) without replacing any existing page.
-- [ ] Validate the best source of local repo discovery:
-  observable result: documented zero-config discovery path for active local repos, without requiring operator-maintained repo lists or scan-root setup.
+- [ ] Validate reuse of the existing bounded local-scan pattern for repo discovery:
+  observable result: documented zero-config discovery path for active local repos that adapts the current bounded filesystem-walk approach instead of requiring operator-maintained repo lists or whole-disk search.
+- [ ] Define the authoritative local activity signals:
+  observable result: documented source-of-truth for "active on this device" using local git signals and related local repo metadata, without depending on undocumented editor-state internals.
+- [ ] Replace the loose session idea with a persisted roster contract:
+  observable result: documented roster row shape, `computed_at` semantics, TTL behavior, and recompute rules for page load and manual refresh.
 - [ ] Validate local git health reads for candidate repos:
   observable result: per-repo sample output for branch, ahead/behind, modified count, untracked count, and clean/dirty verdict.
 - [ ] Validate ranking logic for "most recently active on this device":
-  observable result: documented ranking by local repo activity at session start and during the active session.
+  observable result: documented ranking by local repo activity using local git-first signals, with GitHub data excluded from primary rank decisions.
+- [ ] Define the live-versus-persisted split:
+  observable result: documented separation between persisted roster data and live working-tree probes so freshness and storage behavior are explicit.
+- [ ] Define the off-roster warning strategy:
+  observable result: documented decision that hidden-attention warnings for non-visible repos use cached or persisted health summaries, caps, or a time budget rather than full-set live probes on every request.
+- [ ] Define fallback behavior for repos without a clean GitHub identity:
+  observable result: documented card behavior for local-only repos, non-GitHub remotes, or repos not yet present in the GitHub corpus.
+- [ ] Define the 24-hour refresh trigger precisely:
+  observable result: documented choice between lazy-on-visit refresh and an explicit scheduler-backed refresh path, with the first implementation selected intentionally.
 - [ ] Validate performance for the top-5 read path:
-  observable result: one-page load can discover active repos and gather their data without operator setup or unacceptable UI delay.
+  observable result: one-page load can discover active repos, probe top-5 live health, and render the page without operator setup or unacceptable UI delay.
+- [ ] Validate performance for off-roster warning generation:
+  observable result: warning-strip computation stays bounded and does not require a synchronous live health sweep across the full discovered repo set.
 - [ ] Pause and escalate if any spike result contradicts the current plan:
   observable result: blockers captured in this doc before Phase 1 starts.
 
@@ -55,10 +119,16 @@ Goal: Create a reliable device-local data source for the `Focus 5` view.
   observable result: collector finds repos being actively worked on without any manual repo registration step.
 - [ ] Bound discovery so zero-config does not become full-machine drag:
   observable result: collector avoids expensive or noisy whole-disk scans while still finding active repos automatically.
-- [ ] Persist enough local repo health data to power the view:
-  observable result: the app can answer "did I forget to commit or push?" without recomputing everything on every render.
+- [ ] Persist the roster snapshot and related stable summary fields:
+  observable result: the app can explain why a repo is in the top 5 without recomputing the full ranking history on every render.
+- [ ] Persist off-roster health summaries for warning-strip use:
+  observable result: the app can surface hidden-attention warnings without live-probing every discovered repo on each request.
+- [ ] Keep working tree health as a live read with freshness metadata:
+  observable result: the app can answer "did I forget to commit or push?" using visibly fresh repo-health probes rather than stale stored status.
 - [ ] Join local repo records to existing GitHub corpus data:
   observable result: each visible repo can show the newest remote PR title and number when available.
+- [ ] Define enrichment fallback states in the repo card contract:
+  observable result: the contract explicitly supports "no remote configured", "non-GitHub remote", and "GitHub repo not yet synced" without breaking the page.
 - [ ] Capture last-activity signals for each repo:
   observable result: each repo can render 3 recent activity items in a stable, documented order based on local work first and remote context second.
 
@@ -68,6 +138,8 @@ Goal: Add the new additive dashboard page and make the 5-column layout useful fo
 
 - [ ] Add a new `Focus 5` page to the local web server in [src/rebalance/web.py](/Users/noelsaw/Documents/GitHub-Repos/rebalance-OS/src/rebalance/web.py:1):
   observable result: the existing home page links to the new view and current screens remain unchanged.
+- [ ] Decide whether the first implementation stays in single-file HTML rendering or extracts a small helper layer:
+  observable result: the plan records an intentional rendering approach instead of drifting into ad hoc complexity.
 - [ ] Build a responsive 5-column layout for desktop:
   observable result: five repo columns render left-to-right with readable labels and no ambiguity about what each section means.
 - [ ] Add `Open in VS Code` affordance per repo:
@@ -84,15 +156,17 @@ Goal: Add the new additive dashboard page and make the 5-column layout useful fo
 Goal: Keep the focused view fresh without hiding risky repos.
 
 - [ ] Implement 24-hour automatic roster refresh:
-  observable result: the selected top 5 repos can roll forward based on device-local activity without manual intervention.
+  observable result: the selected top 5 repos can roll forward based on device-local activity when the persisted roster TTL expires and the page is next visited, unless a scheduler-backed refresh is added explicitly.
 - [ ] Add manual refresh control:
   observable result: user can force re-ranking and push inactive repos out of the grid immediately.
-- [ ] Capture session-start roster state:
-  observable result: the page can explain which repos were considered active when the session began.
-- [ ] Allow the roster to admit newly active repos during the session:
-  observable result: repos that become active after page load can enter the top 5 on refresh instead of waiting for the next day.
+- [ ] Surface roster snapshot metadata:
+  observable result: the page can explain when the current top-5 roster was computed and whether it came from lazy TTL refresh or manual refresh.
+- [ ] Allow the roster to admit newly active repos on refresh:
+  observable result: repos that become active after the current roster snapshot can enter the top 5 on manual refresh or TTL-based recompute.
 - [ ] Refresh local tree health on page load:
   observable result: commit/push reminders are not stale for a full day.
+- [ ] Keep roster freshness and repo-health freshness separate in the UI:
+  observable result: user can tell whether the roster snapshot is older than the live git-health probe for a given repo.
 - [ ] Add hidden-attention warning strip above the grid:
   observable result: repos outside the top 5 with dirty trees or unhealthy branch state still surface as summary warnings.
 - [ ] Define stale-data behavior:
@@ -122,6 +196,7 @@ Goal: Ship the new view with confidence and operational visibility.
 - [ ] Repo discovery requires zero manual config from the operator.
 - [ ] Each repo column includes repo open action, newest remote PR, current tree health, and last 3 activity items.
 - [ ] Manual refresh works and 24-hour automatic roster refresh is defined.
-- [ ] Session-start activity and in-session activity both influence which repos appear.
+- [ ] Roster recompute semantics are explicit and based on persisted snapshot timestamps rather than an implicit server-side session.
+- [ ] Local git data is sufficient to keep cards useful even when GitHub enrichment is unavailable.
 - [ ] Hidden attention warnings reduce the risk of losing sight of unhealthy repos outside the top 5.
 - [ ] Tests and logs are in place for the collector and the new page.

--- a/PROJECT/2-WORKING/FOCUS-5.md
+++ b/PROJECT/2-WORKING/FOCUS-5.md
@@ -11,7 +11,7 @@ surfaces:
 
 | Most recently completed phase | What's next |
 |---|---|
-| Phase 0 technical spike executed against the real device (2026-06-05). Discovery, live git-health reads, and the live-vs-cached split all validated. One contradiction found and escalated: the naive "most recently active" ranking by `.git/index` mtime is invalid — it surfaces dormant third-party clones over the operator's own dirty work-in-progress. | Resolve the ranking-signal policy (escalated below), then proceed to Phase 1 collector with the corrected signal. |
+| Phase 1 (collector + swappable ranking) and Phase 2 (additive `/focus-5` web view) shipped and tested (PR #54). Ranking corrected to operator-authored + dirty/unpushed signals; default mode `dirty_first`. The page renders the 5-column grid with per-repo VS Code link, tree health, newest PR, and last 3 local commits; first load lazily bootstraps the roster. | Phase 3: 24h roster TTL + manual refresh control, live top-5 health re-probe on load with freshness markers, and the off-roster hidden-attention warning strip (data already cached in `focus5_repo_signals`). |
 
 ## Table of Contents
 
@@ -111,45 +111,64 @@ Secondary observation: repo display names can collide across scan roots (two `sl
 
 Goal: Create a reliable device-local data source for the `Focus 5` view.
 
-- [ ] Define the `Focus 5` repo card contract in one place:
-  observable result: a single writer owns fields for repo name, local path, VS Code link, newest PR, tree health, and last 3 activity items.
-- [ ] Add a small device-local collector to [src/rebalance/ingest/index_ops.py](/Users/noelsaw/Documents/GitHub-Repos/rebalance-OS/src/rebalance/ingest/index_ops.py:1):
-  observable result: collector is registered and callable through the existing orchestration pattern.
-- [ ] Implement zero-config repo discovery for active local work:
-  observable result: collector finds repos being actively worked on without any manual repo registration step.
-- [ ] Bound discovery so zero-config does not become full-machine drag:
-  observable result: collector avoids expensive or noisy whole-disk scans while still finding active repos automatically.
-- [ ] Persist the roster snapshot and related stable summary fields:
-  observable result: the app can explain why a repo is in the top 5 without recomputing the full ranking history on every render.
-- [ ] Persist off-roster health summaries for warning-strip use:
-  observable result: the app can surface hidden-attention warnings without live-probing every discovered repo on each request.
-- [ ] Keep working tree health as a live read with freshness metadata:
-  observable result: the app can answer "did I forget to commit or push?" using visibly fresh repo-health probes rather than stale stored status.
-- [ ] Join local repo records to existing GitHub corpus data:
-  observable result: each visible repo can show the newest remote PR title and number when available.
-- [ ] Define enrichment fallback states in the repo card contract:
-  observable result: the contract explicitly supports "no remote configured", "non-GitHub remote", and "GitHub repo not yet synced" without breaking the page.
-- [ ] Capture last-activity signals for each repo:
-  observable result: each repo can render 3 recent activity items in a stable, documented order based on local work first and remote context second.
+Status: shipped in PR #54 (2026-06-05). Implemented in
+[src/rebalance/ingest/focus5_scan.py](/Users/noelsaw/Documents/GitHub-Repos/rebalance-OS/src/rebalance/ingest/focus5_scan.py:1)
+with migration `0003_focus5_roster.sql`.
+
+- [x] Define the `Focus 5` repo card contract in one place:
+  observable result: `summarize_focus5()` is the single owner of the card shape (name, local path, `vscode_url`, `newest_pr`, tree health, `recent_activity`).
+- [x] Add a small device-local collector to [src/rebalance/ingest/index_ops.py](/Users/noelsaw/Documents/GitHub-Repos/rebalance-OS/src/rebalance/ingest/index_ops.py:1):
+  observable result: `focus5` collector registered opt-in (`included_in_all=False`); runs via `refresh_index(scope=["focus5"])`.
+- [x] Implement zero-config repo discovery for active local work:
+  observable result: `iter_git_repos` finds repos with no manual registration, reusing the ask_self scan-root defaults.
+- [x] Bound discovery so zero-config does not become full-machine drag:
+  observable result: bounded by the shared prune list + max-depth, stopping at each repo boundary (95 ms / 21 repos measured).
+- [x] Persist the roster snapshot and related stable summary fields:
+  observable result: `focus5_roster` stores position + rank_reason + ranking_mode + computed_at; raw signals persisted separately so re-rank needs no re-scan.
+- [x] Persist off-roster health summaries for warning-strip use:
+  observable result: `focus5_repo_signals` caches every discovered repo's health; `summarize_focus5()` derives off-roster warnings from it.
+- [x] Keep working tree health as a live read with freshness metadata:
+  observable result: each signal row carries `probed_at`; the live top-5 re-probe on page load is wired in Phase 3.
+- [x] Join local repo records to existing GitHub corpus data:
+  observable result: `newest_pr` joins `github_items` on `repo_full_name` (newest PR by number).
+- [x] Define enrichment fallback states in the repo card contract:
+  observable result: explicit "no open PR synced yet", "non-GitHub remote", and "no remote configured" states; never drops the repo.
+- [x] Capture last-activity signals for each repo:
+  observable result: `recent_activity` returns the last 3 local commits, local-git-first, via read-only `git log`.
 
 ## Phase 2 - Web View and Interaction Model
 
 Goal: Add the new additive dashboard page and make the 5-column layout useful for fast context switching.
 
-- [ ] Add a new `Focus 5` page to the local web server in [src/rebalance/web.py](/Users/noelsaw/Documents/GitHub-Repos/rebalance-OS/src/rebalance/web.py:1):
-  observable result: the existing home page links to the new view and current screens remain unchanged.
-- [ ] Decide whether the first implementation stays in single-file HTML rendering or extracts a small helper layer:
-  observable result: the plan records an intentional rendering approach instead of drifting into ad hoc complexity.
-- [ ] Build a responsive 5-column layout for desktop:
-  observable result: five repo columns render left-to-right with readable labels and no ambiguity about what each section means.
-- [ ] Add `Open in VS Code` affordance per repo:
-  observable result: clicking the repo name or action opens the local repo root in VS Code.
-- [ ] Render the newest remote PR per repo:
-  observable result: title and PR number are visible and link to the remote artifact when present.
-- [ ] Render current tree health per repo:
-  observable result: user can immediately see dirty working tree, untracked files, and branch drift reminders.
-- [ ] Render the last 3 activity items per repo:
-  observable result: each column helps the user resume context without opening GitHub first.
+Status: shipped in PR #54 (2026-06-05).
+
+Rendering-approach decision (recorded): stay in the existing single-file
+FastAPI surface (`web.py`), but extract a **pure** `_focus5_body(data)` renderer
+plus small `_f5_*` section helpers that take a `summarize_focus5()` dict and
+return HTML. This keeps the route thin (resolve DB → summarize → render) and
+makes the view unit-testable without a DB, git, or an HTTP client. The
+`summarize_focus5()` read contract is the single owner of the card shape
+(`vscode_url`, `newest_pr`, `recent_activity`, tree-health fields).
+
+- [x] Add a new `Focus 5` page to the local web server in [src/rebalance/web.py](/Users/noelsaw/Documents/GitHub-Repos/rebalance-OS/src/rebalance/web.py:1):
+  observable result: home page and shared nav link to `/focus-5`; existing pages unchanged.
+- [x] Decide whether the first implementation stays in single-file HTML rendering or extracts a small helper layer:
+  observable result: decision recorded above — single file + pure renderer seam.
+- [x] Build a responsive 5-column layout for desktop:
+  observable result: CSS-grid `repeat(5, 1fr)` collapsing to 2 then 1 column at 1100px / 620px; wide main for the focus view.
+- [x] Add `Open in VS Code` affordance per repo:
+  observable result: repo name links to `vscode://file/<path>` (URL-encoded), opening the repo root.
+- [x] Render the newest remote PR per repo:
+  observable result: number + title link to the PR; explicit "no open PR synced yet / non-GitHub remote / no remote configured" fallbacks otherwise.
+- [x] Render current tree health per repo:
+  observable result: dirty/clean dot, modified/untracked counts, branch, and ahead/behind (or "no upstream") drift.
+- [x] Render the last 3 activity items per repo:
+  observable result: last 3 local commits (subject + short SHA + relative age) via a live `git log` read on the top-5 only.
+
+Deferred to Phase 3 (intentionally): the off-roster hidden-attention strip, the
+24h TTL recompute, the manual refresh control, and live top-5 health re-probe on
+load. Phase 2 lazily bootstraps the roster once when it is empty so the page is
+useful on first visit; full refresh semantics are Phase 3.
 
 ## Phase 3 - Refresh Behavior and Safety Signals
 

--- a/PROJECT/2-WORKING/FOCUS-5.md
+++ b/PROJECT/2-WORKING/FOCUS-5.md
@@ -11,7 +11,7 @@ surfaces:
 
 | Most recently completed phase | What's next |
 |---|---|
-| Phases 1–3 shipped and tested (PR #54). Phase 3 adds: 24h roster TTL with lazy recompute on visit, a manual refresh control (post/redirect/get), live top-5 tree-health re-probe on every load (separate from the snapshot, with `health_probed_at`), explicit freshness/stale markers, and the off-roster hidden-attention warning strip from the cached signals. The view is wired into the always-on pulse server (`:8767`) with a sidebar link. | Phase 4: collector/route test hardening (largely done — 52 tests), structured timing logs around the collector path, and final rollout notes. |
+| All four phases shipped and tested (PR #54, 69 tests). Phase 4 adds structured per-phase timing logs + slow/failed-probe warnings to `sync_focus5` (surfacing `elapsed_seconds`/`slow_repos`/`failed_repos`), rounding out collector/route coverage. The view is live on the pulse server (`:8767`) with a sidebar link. | Done bar one optional follow-up: an in-browser visual check at narrow/mobile widths (responsive CSS breakpoints are already in place). |
 
 ## Table of Contents
 
@@ -197,18 +197,20 @@ Status: shipped in PR #54 (2026-06-05). Roster TTL = 24h (`FOCUS5_ROSTER_TTL_SEC
 
 Goal: Ship the new view with confidence and operational visibility.
 
-- [ ] Add collector tests before full integration:
-  observable result: mocks cover happy path, missing repo, auth gap, git failure, and empty activity cases.
-- [ ] Add web-route coverage for the new page:
-  observable result: automated test proves the route renders and includes the expected repo-card sections.
-- [ ] Add timing and structured logs around the collector path:
-  observable result: slow repo scans and repeated failures are diagnosable from logs.
-- [ ] Add at least one integration-style happy-path test:
-  observable result: seeded local repo data produces a populated 5-column page.
-- [ ] Run manual smoke test on desktop and narrow/mobile widths:
-  observable result: layout remains usable and the page still supports quick context switching.
-- [ ] Update this plan with final rollout notes:
-  observable result: completed phases and any follow-up items are recorded here instead of drifting into chat.
+Status: shipped in PR #54 (2026-06-06). 69 tests across the collector + web view.
+
+- [x] Add collector tests before full integration:
+  observable result: tests cover happy path, missing/unreadable repo, git failure (counted + logged), empty activity, and re-sync replace.
+- [x] Add web-route coverage for the new page:
+  observable result: pure `_focus5_body` suite + TestClient route test assert the grid, VS Code links, PR/health/activity sections, refresh redirect, and warning strip.
+- [x] Add timing and structured logs around the collector path:
+  observable result: `sync_focus5` logs a per-phase summary (scan/rank/persist + total), warns on slow probes (> `SLOW_REPO_SECONDS`) and per-repo git failures, and surfaces `elapsed_seconds`/`slow_repos`/`failed_repos` in its result (and thus `refresh_index`).
+- [x] Add at least one integration-style happy-path test:
+  observable result: `WebRouteTests` seeds a repo, syncs, and asserts the route renders a populated grid.
+- [~] Run manual smoke test on desktop and narrow/mobile widths:
+  observable result: desktop verified live on :8767 (200 + markers). Responsive CSS breakpoints are in place (5-col → 2-col at 1100px → 1-col at 620px); a visual check at narrow widths in a browser is still recommended.
+- [x] Update this plan with final rollout notes:
+  observable result: phases 1–4 statuses recorded here; the only open follow-up is the in-browser narrow-width visual check.
 
 ## Definition of Done
 
@@ -220,4 +222,4 @@ Goal: Ship the new view with confidence and operational visibility.
 - [x] Roster recompute semantics are explicit and based on persisted snapshot timestamps rather than an implicit server-side session.
 - [x] Local git data is sufficient to keep cards useful even when GitHub enrichment is unavailable.
 - [x] Hidden attention warnings reduce the risk of losing sight of unhealthy repos outside the top 5.
-- [ ] Tests and logs are in place for the collector and the new page. _(52 tests in place; structured timing logs around the collector path are the remaining Phase 4 item.)_
+- [x] Tests and logs are in place for the collector and the new page. _(69 tests; `sync_focus5` emits a structured per-phase timing summary + slow/failed-probe warnings.)_

--- a/PROJECT/2-WORKING/FOCUS-5.md
+++ b/PROJECT/2-WORKING/FOCUS-5.md
@@ -11,7 +11,7 @@ surfaces:
 
 | Most recently completed phase | What's next |
 |---|---|
-| Phase 1 (collector + swappable ranking) and Phase 2 (additive `/focus-5` web view) shipped and tested (PR #54). Ranking corrected to operator-authored + dirty/unpushed signals; default mode `dirty_first`. The page renders the 5-column grid with per-repo VS Code link, tree health, newest PR, and last 3 local commits; first load lazily bootstraps the roster. | Phase 3: 24h roster TTL + manual refresh control, live top-5 health re-probe on load with freshness markers, and the off-roster hidden-attention warning strip (data already cached in `focus5_repo_signals`). |
+| Phases 1–3 shipped and tested (PR #54). Phase 3 adds: 24h roster TTL with lazy recompute on visit, a manual refresh control (post/redirect/get), live top-5 tree-health re-probe on every load (separate from the snapshot, with `health_probed_at`), explicit freshness/stale markers, and the off-roster hidden-attention warning strip from the cached signals. The view is wired into the always-on pulse server (`:8767`) with a sidebar link. | Phase 4: collector/route test hardening (largely done — 52 tests), structured timing logs around the collector path, and final rollout notes. |
 
 ## Table of Contents
 
@@ -174,22 +174,24 @@ useful on first visit; full refresh semantics are Phase 3.
 
 Goal: Keep the focused view fresh without hiding risky repos.
 
-- [ ] Implement 24-hour automatic roster refresh:
-  observable result: the selected top 5 repos can roll forward based on device-local activity when the persisted roster TTL expires and the page is next visited, unless a scheduler-backed refresh is added explicitly.
-- [ ] Add manual refresh control:
-  observable result: user can force re-ranking and push inactive repos out of the grid immediately.
-- [ ] Surface roster snapshot metadata:
-  observable result: the page can explain when the current top-5 roster was computed and whether it came from lazy TTL refresh or manual refresh.
-- [ ] Allow the roster to admit newly active repos on refresh:
-  observable result: repos that become active after the current roster snapshot can enter the top 5 on manual refresh or TTL-based recompute.
-- [ ] Refresh local tree health on page load:
-  observable result: commit/push reminders are not stale for a full day.
-- [ ] Keep roster freshness and repo-health freshness separate in the UI:
-  observable result: user can tell whether the roster snapshot is older than the live git-health probe for a given repo.
-- [ ] Add hidden-attention warning strip above the grid:
-  observable result: repos outside the top 5 with dirty trees or unhealthy branch state still surface as summary warnings.
-- [ ] Define stale-data behavior:
-  observable result: the page clearly shows when local or remote repo data is old instead of silently presenting stale status.
+Status: shipped in PR #54 (2026-06-05). Roster TTL = 24h (`FOCUS5_ROSTER_TTL_SECONDS`); the route uses a cheap `get_roster_meta()` check before any live-probe render.
+
+- [x] Implement 24-hour automatic roster refresh:
+  observable result: `get_roster_meta()` + `_roster_stale()` lazily recompute on visit when the snapshot is past 24h (no scheduler needed).
+- [x] Add manual refresh control:
+  observable result: `↻ Refresh` button hits `/focus-5?refresh=1` → forces `sync_focus5` → 303 redirect (post/redirect/get) so a reload doesn't re-scan.
+- [x] Surface roster snapshot metadata:
+  observable result: meta line shows "Roster computed {age} · ranked by {mode} · {n} discovered"; a manual refresh resets it to "just now".
+- [x] Allow the roster to admit newly active repos on refresh:
+  observable result: every recompute re-discovers and re-ranks all repos, so a newly active repo can enter the top 5 on manual or TTL refresh.
+- [x] Refresh local tree health on page load:
+  observable result: `summarize_focus5(with_live_health=True)` re-probes each top-5 repo's `git status` per load, overlaying the snapshot with a fresh `health_probed_at`.
+- [x] Keep roster freshness and repo-health freshness separate in the UI:
+  observable result: roster age ("computed {age}") and live health ("● tree health checked live" + per-card "Tree health · live") are shown distinctly.
+- [x] Add hidden-attention warning strip above the grid:
+  observable result: amber strip lists off-roster repos that are dirty or unpushed, sourced from the cached `focus5_repo_signals` (no full live sweep), labeled with the roster's age.
+- [x] Define stale-data behavior:
+  observable result: off-roster strip is labeled "as of roster computed {age}"; a roster past TTL that failed to refresh renders a "⚠ stale" marker rather than silently showing old data.
 
 ## Phase 4 - Testing, Observability, and Rollout
 
@@ -210,12 +212,12 @@ Goal: Ship the new view with confidence and operational visibility.
 
 ## Definition of Done
 
-- [ ] A new additive `Focus 5` route exists in the local web dashboard.
-- [ ] The page shows exactly 5 recent repos in a left-to-right layout.
-- [ ] Repo discovery requires zero manual config from the operator.
-- [ ] Each repo column includes repo open action, newest remote PR, current tree health, and last 3 activity items.
-- [ ] Manual refresh works and 24-hour automatic roster refresh is defined.
-- [ ] Roster recompute semantics are explicit and based on persisted snapshot timestamps rather than an implicit server-side session.
-- [ ] Local git data is sufficient to keep cards useful even when GitHub enrichment is unavailable.
-- [ ] Hidden attention warnings reduce the risk of losing sight of unhealthy repos outside the top 5.
-- [ ] Tests and logs are in place for the collector and the new page.
+- [x] A new additive `Focus 5` route exists in the local web dashboard (`/focus-5`, served by both `rebalance serve` :8787 and the always-on pulse server :8767, with a sidebar link).
+- [x] The page shows exactly 5 recent repos in a left-to-right layout (responsive 5-col grid).
+- [x] Repo discovery requires zero manual config from the operator.
+- [x] Each repo column includes repo open action, newest remote PR, current tree health, and last 3 activity items.
+- [x] Manual refresh works and 24-hour automatic roster refresh is defined.
+- [x] Roster recompute semantics are explicit and based on persisted snapshot timestamps rather than an implicit server-side session.
+- [x] Local git data is sufficient to keep cards useful even when GitHub enrichment is unavailable.
+- [x] Hidden attention warnings reduce the risk of losing sight of unhealthy repos outside the top 5.
+- [ ] Tests and logs are in place for the collector and the new page. _(52 tests in place; structured timing logs around the collector path are the remaining Phase 4 item.)_

--- a/scripts/pulse_server.py
+++ b/scripts/pulse_server.py
@@ -68,8 +68,8 @@ def auth_log_raw():
 
 
 @app.get("/focus-5")
-def focus5():
-    return _focus5_page()
+def focus5(refresh: bool = False):
+    return _focus5_page(refresh=refresh)
 
 
 class ChatRequest(BaseModel):

--- a/scripts/pulse_server.py
+++ b/scripts/pulse_server.py
@@ -47,10 +47,14 @@ from pulse_web import (  # noqa: E402
 
 app = FastAPI(title="rebalance pulse (local)", docs_url=None, redoc_url=None)
 
-# Serve the auth-activity log from this always-running server too, so the
-# sidebar "Authorization Log" link works without a separate `rebalance serve`
-# process on :8787. Reuses the renderers in rebalance.web (no duplication).
-from rebalance.web import auth_log_page as _auth_log_page, auth_log_raw as _auth_log_raw  # noqa: E402
+# Serve the auth-activity log and Focus 5 view from this always-running server
+# too, so their links work without a separate `rebalance serve` process on
+# :8787. Reuses the renderers in rebalance.web (no duplication).
+from rebalance.web import (  # noqa: E402
+    auth_log_page as _auth_log_page,
+    auth_log_raw as _auth_log_raw,
+    focus5_page as _focus5_page,
+)
 
 
 @app.get("/auth-log")
@@ -61,6 +65,11 @@ def auth_log():
 @app.get("/auth-log/raw")
 def auth_log_raw():
     return _auth_log_raw()
+
+
+@app.get("/focus-5")
+def focus5():
+    return _focus5_page()
 
 
 class ChatRequest(BaseModel):

--- a/scripts/pulse_web.py
+++ b/scripts/pulse_web.py
@@ -1176,6 +1176,12 @@ def render_sidebar(
         <div class="nav-section-label">System</div>
         <ul class="nav-list">
           <li class="auth-log-link">
+            <a href="/focus-5" target="_blank" rel="noopener noreferrer"
+               title="Open Focus 5 — the 5 repos you're actively working on (tree health, newest PR, recent commits)">
+              <span class="auth-log-icon">🎯</span><span>Focus 5</span>
+            </a>
+          </li>
+          <li class="auth-log-link">
             <a href="/auth-log" target="_blank" rel="noopener noreferrer"
                title="Open the Authorization Log (auth events across all collectors)">
               <span class="auth-log-icon">🔐</span><span>Authorization Log</span>

--- a/src/rebalance/ingest/ask_self_scan.py
+++ b/src/rebalance/ingest/ask_self_scan.py
@@ -1,0 +1,410 @@
+"""Device-local discovery of ask_self RAG indexes (spike).
+
+Rebalance knows repos by their GitHub identity (``owner/repo``, derived from
+activity / pushes / the project registry). ask_self, by contrast, leaves a
+*filesystem* footprint: every repo wired for ask_self has an
+``ask_self/ask_self_harness.json`` at its root, and (once built) a SQLite index
+whose ``repo_metadata`` row already records the git remote, branch, head SHA,
+file/chunk counts, embedding model, and last ingest time.
+
+This collector walks the configured scan roots, detects that footprint, reads
+the index's own metadata read-only (never mutating the foreign DB), and records
+one row per (device, repo) in ``ask_self_indexes``. The git remote URL is the
+bridge: parsing it to ``owner/repo`` lets the dashboard answer "which of my
+watched repos have a queryable local brain, and on which machine?".
+
+Design notes
+------------
+- **Non-destructive.** The ask_self index is opened ``mode=ro`` via a URI
+  connection. We only read ``repo_metadata``; we never migrate or write it.
+- **Device-aware.** Every row is stamped with :func:`get_device_id` (reused
+  from the sync plane) so a future sync step can fan these snapshots across
+  machines exactly like calendar/email snapshots do.
+- **Honest about "configured but not built".** A repo with a harness but no
+  index file is recorded with ``index_built=0`` rather than skipped — that
+  distinction is the whole point of an inventory.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sqlite3
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator
+
+from rebalance.ingest.db import db_connection, run_migrations
+from rebalance.ingest.sync_snapshot import get_device_id
+
+HARNESS_RELPATH = ("ask_self", "ask_self_harness.json")
+DEFAULT_MAX_DEPTH = 6
+
+# Directories never worth descending into when hunting for harness files.
+# Keeps a full-tree walk cheap; ask_self/ itself is never hidden so pruning
+# hidden dirs is safe for discovery.
+_PRUNE_DIRS = frozenset({
+    "node_modules", ".venv", "venv", "__pycache__", ".pytest_cache",
+    ".mypy_cache", ".ruff_cache", "build", "dist", ".next", ".cache",
+    "Library", ".Trash", ".npm", ".cargo", "site-packages", ".tox",
+    ".gradle", "target", "vendor", ".terraform", "DerivedData", ".git",
+})
+
+# remote_url forms we map to owner/repo:
+#   https://github.com/Owner/Repo.git
+#   git@github.com:Owner/Repo.git
+#   ssh://git@github.com/Owner/Repo
+_REMOTE_RE = re.compile(
+    r"""(?:github\.com[:/])(?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?/?$""",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class AskSelfIndex:
+    """One ask_self-enabled repo discovered on this device."""
+
+    device_id: str
+    local_path: str
+    repo_full_name: str | None  # owner/repo — the bridge to watched repos
+    repo_label: str | None
+    repo_kind: str | None
+    harness_path: str
+    index_db_path: str | None
+    index_built: bool
+    branch: str | None
+    head_sha: str | None
+    last_commit_at: str | None
+    file_count: int | None
+    total_chunks: int | None
+    embed_model: str | None
+    embed_dim: int | None
+    index_size_bytes: int | None
+    ingested_at: str | None
+    remote_url: str | None
+
+
+@dataclass(frozen=True)
+class AskSelfSyncResult:
+    device_id: str
+    found: int
+    inserted: int
+    updated: int
+    unchanged: int
+    scan_roots: list[str]
+    scanned_at: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+def derive_repo_full_name(remote_url: str | None) -> str | None:
+    """Parse a git remote URL into ``owner/repo`` (original casing), or None."""
+    if not remote_url:
+        return None
+    m = _REMOTE_RE.search(remote_url.strip())
+    if not m:
+        return None
+    return f"{m.group('owner')}/{m.group('repo')}"
+
+
+def _git_remote_full_name(repo_root: Path) -> str | None:
+    """Return ``owner/repo`` from the checkout's ``origin`` remote, or None.
+
+    Authoritative for the current checkout — unlike the harness ``github``
+    block, which is frequently copied from a template repo and left stale.
+    Best-effort: any git failure (no remote, not a repo) yields None.
+    """
+    import subprocess
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(repo_root), "remote", "get-url", "origin"],
+            capture_output=True, text=True, check=False, timeout=5,
+        )
+    except Exception:  # noqa: BLE001 — git missing / hung / unreadable repo
+        return None
+    if proc.returncode != 0:
+        return None
+    return derive_repo_full_name(proc.stdout.strip())
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    import json
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:  # noqa: BLE001 — a malformed harness shouldn't abort the sweep
+        return {}
+
+
+def _resolve_index_db_path(repo_root: Path, harness: dict[str, Any]) -> Path | None:
+    """Resolve the index SQLite path declared by the harness.
+
+    Honors ``db_path`` (relative to repo root, or absolute) first, then the
+    local-only ``db_filename`` convention (``temp/rag/<filename>``).
+    """
+    db_path = (harness.get("db_path") or "").strip()
+    if db_path:
+        p = Path(db_path)
+        return p if p.is_absolute() else (repo_root / p)
+    db_filename = (harness.get("db_filename") or "").strip()
+    if db_filename:
+        return repo_root / "temp" / "rag" / db_filename
+    return None
+
+
+def read_index_metadata(index_db_path: Path) -> dict[str, Any] | None:
+    """Read the single ``repo_metadata`` row from an ask_self index, read-only.
+
+    Returns a column->value dict, or None if the file/table/row is absent.
+    Uses a ``mode=ro`` URI connection so we never create, lock-for-write, or
+    migrate the foreign database.
+    """
+    if not index_db_path.is_file():
+        return None
+    try:
+        conn = sqlite3.connect(f"file:{index_db_path}?mode=ro", uri=True)
+    except Exception:  # noqa: BLE001
+        return None
+    try:
+        conn.row_factory = sqlite3.Row
+        row = conn.execute("SELECT * FROM repo_metadata LIMIT 1").fetchone()
+        if row is None:
+            return None
+        return {k: row[k] for k in row.keys()}
+    except Exception:  # noqa: BLE001 — older/newer ask_self schema without the table
+        return None
+    finally:
+        conn.close()
+
+
+def _should_descend(name: str) -> bool:
+    if name in _PRUNE_DIRS:
+        return False
+    # Prune hidden dirs (".git", ".cache", …); ask_self/ is not hidden.
+    return not name.startswith(".")
+
+
+def iter_repo_harnesses(
+    roots: list[str] | list[Path],
+    *,
+    max_depth: int = DEFAULT_MAX_DEPTH,
+) -> Iterator[tuple[Path, Path]]:
+    """Yield ``(repo_root, harness_path)`` for every ask_self repo under *roots*.
+
+    De-duplicates by resolved repo root so overlapping scan roots don't
+    double-count.
+    """
+    seen: set[Path] = set()
+    for raw_root in roots:
+        root = Path(raw_root).expanduser()
+        if not root.is_dir():
+            continue
+        base_depth = len(root.resolve().parts)
+        for dirpath, dirnames, _filenames in os.walk(root, followlinks=False):
+            cur = Path(dirpath)
+            if len(cur.resolve().parts) - base_depth >= max_depth:
+                dirnames[:] = []
+            else:
+                dirnames[:] = [d for d in dirnames if _should_descend(d)]
+
+            harness = cur / HARNESS_RELPATH[0] / HARNESS_RELPATH[1]
+            if harness.is_file():
+                rp = cur.resolve()
+                if rp not in seen:
+                    seen.add(rp)
+                    yield rp, harness
+
+
+def scan_ask_self_repos(
+    roots: list[str] | list[Path],
+    *,
+    max_depth: int = DEFAULT_MAX_DEPTH,
+    device_id: str | None = None,
+) -> list[AskSelfIndex]:
+    """Walk *roots* and return one :class:`AskSelfIndex` per ask_self repo."""
+    dev = device_id or get_device_id()
+    out: list[AskSelfIndex] = []
+    for repo_root, harness_path in iter_repo_harnesses(roots, max_depth=max_depth):
+        harness = _read_json(harness_path)
+        index_db = _resolve_index_db_path(repo_root, harness)
+        meta = read_index_metadata(index_db) if index_db else None
+        built = meta is not None
+
+        # GitHub identity, most→least authoritative:
+        #   1. remote_url recorded in the built index (the remote at ingest time)
+        #   2. the checkout's live `git remote get-url origin`
+        #   3. the harness github.owner/repo — last resort: often a stale copy
+        #      from a template repo (observed in the wild during the spike).
+        gh = harness.get("github") or {}
+        harness_full = None
+        if gh.get("owner") and gh.get("repo"):
+            harness_full = f"{gh['owner']}/{gh['repo']}"
+        remote_url = (meta or {}).get("remote_url")
+        repo_full_name = (
+            derive_repo_full_name(remote_url)
+            or _git_remote_full_name(repo_root)
+            or harness_full
+        )
+
+        index_size = None
+        if index_db and index_db.is_file():
+            try:
+                index_size = index_db.stat().st_size
+            except OSError:
+                index_size = None
+
+        out.append(AskSelfIndex(
+            device_id=dev,
+            local_path=str(repo_root),
+            repo_full_name=repo_full_name,
+            repo_label=(meta or {}).get("repo_label") or harness.get("repo_label"),
+            repo_kind=(meta or {}).get("repo_kind") or harness.get("repo_kind"),
+            harness_path=str(harness_path),
+            index_db_path=str(index_db) if index_db else None,
+            index_built=built,
+            branch=(meta or {}).get("branch"),
+            head_sha=(meta or {}).get("head_sha"),
+            last_commit_at=(meta or {}).get("last_commit_at"),
+            file_count=(meta or {}).get("file_count"),
+            total_chunks=(meta or {}).get("total_chunks"),
+            embed_model=(meta or {}).get("embed_model"),
+            embed_dim=(meta or {}).get("embed_dim"),
+            index_size_bytes=index_size,
+            ingested_at=(meta or {}).get("ingested_at"),
+            remote_url=remote_url,
+        ))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+_COLUMNS = (
+    "device_id", "local_path", "repo_full_name", "repo_label", "repo_kind",
+    "harness_path", "index_db_path", "index_built", "branch", "head_sha",
+    "last_commit_at", "file_count", "total_chunks", "embed_model", "embed_dim",
+    "index_size_bytes", "ingested_at", "remote_url", "scanned_at",
+)
+
+# Fields whose change makes a row "updated" rather than "unchanged".
+_SIGNATURE = ("repo_full_name", "head_sha", "ingested_at", "total_chunks", "index_built")
+
+
+def sync_ask_self_indexes(
+    database_path: Path,
+    *,
+    roots: list[str] | list[Path] | None = None,
+    device_id: str | None = None,
+    max_depth: int = DEFAULT_MAX_DEPTH,
+) -> AskSelfSyncResult:
+    """Scan the device for ask_self repos and upsert them into ``ask_self_indexes``."""
+    dev = device_id or get_device_id()
+    if roots is None:
+        from rebalance.ingest.config import get_ask_self_scan_roots
+        roots = get_ask_self_scan_roots()
+    scanned_at = datetime.now(timezone.utc).isoformat()
+    found = scan_ask_self_repos(roots, max_depth=max_depth, device_id=dev)
+
+    inserted = updated = unchanged = 0
+    placeholders = ", ".join("?" for _ in _COLUMNS)
+    updates = ", ".join(f"{c}=excluded.{c}" for c in _COLUMNS if c not in ("device_id", "local_path"))
+
+    with db_connection(database_path) as conn:
+        run_migrations(conn)  # ensure ask_self_indexes exists even on a direct call
+        for item in found:
+            existing = conn.execute(
+                "SELECT repo_full_name, head_sha, ingested_at, total_chunks, index_built "
+                "FROM ask_self_indexes WHERE device_id=? AND local_path=?",
+                (dev, item.local_path),
+            ).fetchone()
+
+            row = {
+                **asdict(item),
+                "index_built": 1 if item.index_built else 0,
+                "scanned_at": scanned_at,
+            }
+            conn.execute(
+                f"INSERT INTO ask_self_indexes ({', '.join(_COLUMNS)}) "
+                f"VALUES ({placeholders}) "
+                f"ON CONFLICT(device_id, local_path) DO UPDATE SET {updates}",
+                tuple(row[c] for c in _COLUMNS),
+            )
+
+            if existing is None:
+                inserted += 1
+            else:
+                before = (
+                    existing["repo_full_name"], existing["head_sha"],
+                    existing["ingested_at"], existing["total_chunks"],
+                    bool(existing["index_built"]),
+                )
+                after = tuple(getattr(item, f) for f in _SIGNATURE)
+                updated += 1 if before != after else 0
+                unchanged += 1 if before == after else 0
+        conn.commit()
+
+    return AskSelfSyncResult(
+        device_id=dev,
+        found=len(found),
+        inserted=inserted,
+        updated=updated,
+        unchanged=unchanged,
+        scan_roots=[str(r) for r in roots],
+        scanned_at=scanned_at,
+    )
+
+
+def get_ask_self_indexes(database_path: Path) -> list[dict[str, Any]]:
+    """Return all recorded ask_self indexes (defensive against a missing table)."""
+    try:
+        with db_connection(database_path) as conn:
+            rows = conn.execute(
+                "SELECT * FROM ask_self_indexes ORDER BY device_id, repo_full_name, local_path"
+            ).fetchall()
+            return [dict(r) for r in rows]
+    except Exception:  # noqa: BLE001 — table absent on a pre-migration DB
+        return []
+
+
+def summarize_ask_self_indexes(database_path: Path) -> dict[str, Any]:
+    """Inventory of ask_self repos, each flagged with whether Rebalance watches it.
+
+    This is the join your idea hinges on: ask_self's filesystem inventory
+    cross-referenced against the GitHub-identity watched set.
+    """
+    from rebalance.ingest.index_ops import get_watched_repos
+
+    indexes = get_ask_self_indexes(database_path)
+    watched = {r.lower() for r in get_watched_repos(database_path).get("watched", [])}
+
+    enriched: list[dict[str, Any]] = []
+    for row in indexes:
+        full = (row.get("repo_full_name") or "")
+        enriched.append({
+            **row,
+            "index_built": bool(row.get("index_built")),
+            "watched": full.lower() in watched if full else False,
+        })
+
+    devices = sorted({r["device_id"] for r in enriched})
+    summary: dict[str, Any] = {
+        "indexes": enriched,
+        "summary": {
+            "total": len(enriched),
+            "built": sum(1 for r in enriched if r["index_built"]),
+            "watched": sum(1 for r in enriched if r["watched"]),
+            "devices": devices,
+        },
+    }
+    if not enriched:
+        summary["note"] = (
+            "No ask_self indexes recorded yet. Run "
+            "refresh_index(scope=['ask_self']) to scan this device."
+        )
+    return summary

--- a/src/rebalance/ingest/config.py
+++ b/src/rebalance/ingest/config.py
@@ -340,6 +340,81 @@ def remove_health_notice_pattern(pattern: str) -> bool:
     return True
 
 
+def get_ask_self_scan_roots() -> list[str]:
+    """Return the directories the ask_self collector walks for harness files.
+
+    Config key: ``ask_self_scan_roots`` (list of absolute dirs). When unset,
+    defaults to the common dev-checkout parents that actually exist on this
+    machine, falling back to the home directory. Keeping this configurable
+    means a full-tree walk of ``$HOME`` is opt-in rather than the default.
+    """
+    config = _read_config()
+    raw = config.get("ask_self_scan_roots")
+    if isinstance(raw, list):
+        roots = [str(p).strip() for p in raw if str(p).strip()]
+        if roots:
+            return roots
+    home = Path.home()
+    candidates = [
+        home / "Documents" / "GitHub-Repos",
+        home / "Documents" / "GitHub",
+        home / "GitHub",
+        home / "code",
+        home / "src",
+        home / "dev",
+        home / "repos",
+        home / "Projects",
+    ]
+    existing = [str(c) for c in candidates if c.is_dir()]
+    return existing or [str(home)]
+
+
+def set_ask_self_scan_roots(roots: list[str]) -> None:
+    """Store the directories the ask_self collector walks. Config key: ``ask_self_scan_roots``."""
+    cleaned = [str(Path(p).expanduser()) for p in roots if str(p).strip()]
+    config = _read_config()
+    config["ask_self_scan_roots"] = cleaned
+    _write_config(config)
+
+
+def get_focus5_scan_roots() -> list[str]:
+    """Return the directories the Focus 5 collector walks for git repos.
+
+    Config key: ``focus5_scan_roots``. When unset, reuses the shared
+    zero-config discovery defaults (:func:`get_ask_self_scan_roots`) so the
+    operator never has to configure repo locations — Focus 5 just keeps its own
+    overridable key for the day the two surfaces want different scopes.
+    """
+    config = _read_config()
+    raw = config.get("focus5_scan_roots")
+    if isinstance(raw, list):
+        roots = [str(p).strip() for p in raw if str(p).strip()]
+        if roots:
+            return roots
+    return get_ask_self_scan_roots()
+
+
+def get_focus5_ranking_mode() -> str:
+    """Return the active Focus 5 ranking mode. Config key: ``focus5_ranking_mode``.
+
+    Defaults to ``dirty_first`` (surface uncommitted/unpushed work first). The
+    value is validated by the collector against the registered strategies; an
+    unknown mode is surfaced as a collector error rather than silently ignored.
+    """
+    config = _read_config()
+    mode = config.get("focus5_ranking_mode")
+    if isinstance(mode, str) and mode.strip():
+        return mode.strip()
+    return "dirty_first"
+
+
+def set_focus5_ranking_mode(mode: str) -> None:
+    """Store the Focus 5 ranking mode. Config key: ``focus5_ranking_mode``."""
+    config = _read_config()
+    config["focus5_ranking_mode"] = mode.strip()
+    _write_config(config)
+
+
 GMAIL_INGEST_METHODS = ("oauth", "mcp")
 
 

--- a/src/rebalance/ingest/db/migrations/0002_ask_self_indexes.sql
+++ b/src/rebalance/ingest/db/migrations/0002_ask_self_indexes.sql
@@ -1,0 +1,29 @@
+-- Device-local inventory of ask_self RAG indexes.
+-- Populated by the "ask_self" collector (rebalance.ingest.ask_self_scan).
+-- One row per (device, repo): the bridge from ask_self's filesystem footprint
+-- to Rebalance's GitHub-identity watched set is repo_full_name (owner/repo).
+CREATE TABLE IF NOT EXISTS ask_self_indexes (
+    device_id        TEXT    NOT NULL,
+    local_path       TEXT    NOT NULL,
+    repo_full_name   TEXT,
+    repo_label       TEXT,
+    repo_kind        TEXT,
+    harness_path     TEXT    NOT NULL,
+    index_db_path    TEXT,
+    index_built      INTEGER NOT NULL DEFAULT 0,
+    branch           TEXT,
+    head_sha         TEXT,
+    last_commit_at   TEXT,
+    file_count       INTEGER,
+    total_chunks     INTEGER,
+    embed_model      TEXT,
+    embed_dim        INTEGER,
+    index_size_bytes INTEGER,
+    ingested_at      TEXT,
+    remote_url       TEXT,
+    scanned_at       TEXT    NOT NULL,
+    PRIMARY KEY (device_id, local_path)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ask_self_repo ON ask_self_indexes(repo_full_name);
+CREATE INDEX IF NOT EXISTS idx_ask_self_device ON ask_self_indexes(device_id);

--- a/src/rebalance/ingest/db/migrations/0003_focus5_roster.sql
+++ b/src/rebalance/ingest/db/migrations/0003_focus5_roster.sql
@@ -1,0 +1,56 @@
+-- Focus 5 dashboard: device-local repo activity + the persisted top-5 roster.
+-- Populated by the "focus5" collector (rebalance.ingest.focus5_scan).
+--
+-- Two tables, deliberately split (see PROJECT/2-WORKING/FOCUS-5.md):
+--
+--   focus5_repo_signals — RAW, mode-agnostic signals for EVERY discovered repo.
+--     This is the load-bearing decision from the Phase 0 spike: we persist the
+--     raw signals a repo exposes, NOT a pre-computed rank/score. That lets the
+--     roster be re-ranked under a different ranking mode WITHOUT re-probing git,
+--     and it doubles as the cache that feeds off-roster "hidden attention"
+--     warnings (so the page never live-sweeps every repo on each request).
+--     NOTE: index_mtime_ts is captured for diagnostics ONLY. The spike proved
+--     `.git/index` mtime is polluted by clone/fetch/checkout and must never be a
+--     ranking input on its own.
+--
+--   focus5_roster — the stable top-5 snapshot: which repos, in what order, why,
+--     under which ranking mode, computed when. `computed_at` drives the 24h TTL.
+--     Re-ranking rewrites this table only; the signals cache is untouched.
+
+CREATE TABLE IF NOT EXISTS focus5_repo_signals (
+    device_id         TEXT    NOT NULL,
+    local_path        TEXT    NOT NULL,
+    repo_name         TEXT    NOT NULL,   -- basename; may collide across roots
+    repo_full_name    TEXT,               -- owner/repo bridge to the GitHub corpus
+    branch            TEXT,
+    upstream          TEXT,
+    has_upstream      INTEGER NOT NULL DEFAULT 0,
+    ahead             INTEGER NOT NULL DEFAULT 0,
+    behind            INTEGER NOT NULL DEFAULT 0,
+    modified_count    INTEGER NOT NULL DEFAULT 0,
+    untracked_count   INTEGER NOT NULL DEFAULT 0,
+    is_dirty          INTEGER NOT NULL DEFAULT 0,
+    last_commit_at    TEXT,               -- ISO-8601 of the newest commit (any author)
+    last_commit_ts    INTEGER,            -- epoch of the newest commit (any author)
+    my_last_commit_ts INTEGER,            -- epoch of newest commit by THIS repo's user.email
+    head_reflog_ts    INTEGER,            -- mtime of .git/logs/HEAD (local HEAD moves)
+    index_mtime_ts    INTEGER,            -- diagnostics ONLY — never a ranking input
+    remote_url        TEXT,
+    probed_at         TEXT    NOT NULL,   -- when these signals were captured (freshness)
+    PRIMARY KEY (device_id, local_path)
+);
+
+CREATE INDEX IF NOT EXISTS idx_focus5_signals_repo  ON focus5_repo_signals(repo_full_name);
+CREATE INDEX IF NOT EXISTS idx_focus5_signals_dirty ON focus5_repo_signals(device_id, is_dirty);
+
+CREATE TABLE IF NOT EXISTS focus5_roster (
+    device_id     TEXT    NOT NULL,
+    local_path    TEXT    NOT NULL,       -- joins to focus5_repo_signals
+    position      INTEGER NOT NULL,       -- 1-based rank within the snapshot
+    rank_reason   TEXT,                   -- human "why it's here" (dirty / unpushed / commit age)
+    ranking_mode  TEXT    NOT NULL,       -- which strategy produced this snapshot
+    computed_at   TEXT    NOT NULL,       -- snapshot time; drives the 24h TTL
+    PRIMARY KEY (device_id, local_path)
+);
+
+CREATE INDEX IF NOT EXISTS idx_focus5_roster_pos ON focus5_roster(device_id, position);

--- a/src/rebalance/ingest/focus5_scan.py
+++ b/src/rebalance/ingest/focus5_scan.py
@@ -1,0 +1,557 @@
+"""Device-local activity scan + ranking for the Focus 5 dashboard.
+
+Focus 5 answers "which 5 repos am I actually working on right now, and did I
+forget to commit or push?". It is device-local: discovery and ranking lean on
+local git, and the GitHub corpus is enrichment only (newest PR), never a
+ranking input.
+
+Pipeline (mirrors the established collect → store pattern):
+
+    discover .git repos under the bounded scan roots
+        → probe per-repo SIGNALS (branch, ahead/behind, dirty, commit times)
+        → persist ALL signals (focus5_repo_signals — also the off-roster cache)
+        → rank via the selected strategy → persist top-N (focus5_roster)
+
+Why the spike forced this shape (see PROJECT/2-WORKING/FOCUS-5.md):
+
+- **Raw signals are persisted, never a baked score.** The ranking "mode" is a
+  pure function ``RepoSignals -> RankVerdict``. Switching modes is a config
+  flip, and because the raw signals are stored, an existing roster can be
+  re-ranked under a different mode *without re-probing git*. This is the seam
+  that keeps mode changes from becoming a refactor.
+- **`.git/index` mtime is NOT a ranking input.** The spike proved it is bumped
+  by clone/fetch/checkout and surfaced dormant third-party clones over the
+  operator's own dirty WIP. The honest signals are operator-authored commits
+  (matched against each repo's own ``user.email`` — the operator commits under a
+  GitHub noreply address, so a hardcoded email would silently miss them) and a
+  dirty/unpushed working tree.
+
+Everything here is read-only with respect to the scanned repos: we only run
+read-only git plumbing and ``stat`` files; we never write to a foreign repo.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Iterator
+
+from rebalance.ingest.db import db_connection, run_migrations
+from rebalance.ingest.sync_snapshot import get_device_id
+# Reuse the prune discipline and the (already tested) remote-URL → owner/repo
+# parser rather than duplicating them; both are low-churn and shared by intent.
+from rebalance.ingest.ask_self_scan import _PRUNE_DIRS, derive_repo_full_name
+
+DEFAULT_MAX_DEPTH = 6
+DEFAULT_ROSTER_SIZE = 5
+GIT_TIMEOUT = 5
+
+
+# ---------------------------------------------------------------------------
+# Signal model — the mode-agnostic facts a repo exposes
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class RepoSignals:
+    """Raw, ranking-mode-agnostic signals for one discovered repo.
+
+    Persisted verbatim so the roster can be re-ranked under any mode without
+    re-probing git. No field here is a score or a rank.
+    """
+
+    device_id: str
+    local_path: str
+    repo_name: str
+    repo_full_name: str | None
+    branch: str | None
+    upstream: str | None
+    has_upstream: bool
+    ahead: int
+    behind: int
+    modified_count: int
+    untracked_count: int
+    is_dirty: bool
+    last_commit_at: str | None
+    last_commit_ts: int | None
+    my_last_commit_ts: int | None
+    head_reflog_ts: int | None
+    index_mtime_ts: int | None  # diagnostics only — never ranked on
+    remote_url: str | None
+    probed_at: str
+
+    @property
+    def is_unpushed(self) -> bool:
+        """Local commits not on the upstream (a 'did I forget to push?' signal)."""
+        return self.ahead > 0
+
+
+# ---------------------------------------------------------------------------
+# Ranking strategies — a pure function per mode, selected by config
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class RankVerdict:
+    """A strategy's verdict for one repo.
+
+    ``sort_key`` is compared descending (bigger = higher in the roster). Within
+    a single ranking run every repo is scored by the same strategy, so all
+    ``sort_key`` tuples share a shape and sort cleanly.
+    """
+
+    eligible: bool
+    sort_key: tuple
+    reason: str
+
+
+# A ranking strategy maps (signals, now_epoch) -> verdict. Pure: no I/O, no clock.
+RankingStrategy = Callable[[RepoSignals, int], RankVerdict]
+
+DEFAULT_RANKING_MODE = "dirty_first"
+
+
+def _humanize_ago(ts: int | None, now_ts: int) -> str:
+    if not ts:
+        return "no local commits"
+    secs = max(0, now_ts - ts)
+    for label, unit in (("d", 86400), ("h", 3600), ("m", 60)):
+        if secs >= unit:
+            return f"{secs // unit}{label} ago"
+    return "just now"
+
+
+def _recency(s: RepoSignals) -> int:
+    """Best 'when did I last touch this' estimate from operator-authored signals.
+
+    Deliberately excludes index_mtime_ts (clone/fetch pollution); falls back to
+    head-reflog (local HEAD moves) and finally any-author commit time so a repo
+    is never ranked purely on a foreign push.
+    """
+    return s.my_last_commit_ts or s.head_reflog_ts or s.last_commit_ts or 0
+
+
+def _eligible_as_my_work(s: RepoSignals) -> bool:
+    """Operator has work here: authored a commit, or the tree is dirty."""
+    return s.is_dirty or s.my_last_commit_ts is not None
+
+
+def rank_my_work(s: RepoSignals, now_ts: int) -> RankVerdict:
+    """My work only — exclude repos I've never committed to unless dirty now."""
+    eligible = _eligible_as_my_work(s)
+    recency = max(s.my_last_commit_ts or 0, now_ts if s.is_dirty else 0)
+    reason = "uncommitted changes" if s.is_dirty else f"your commit {_humanize_ago(s.my_last_commit_ts, now_ts)}"
+    return RankVerdict(eligible, (recency,), reason)
+
+
+def rank_dirty_first(s: RepoSignals, now_ts: int) -> RankVerdict:
+    """Dirty-first safety view (DEFAULT).
+
+    Same eligibility as my_work, but anything with uncommitted or unpushed work
+    is forced above clean repos, then ordered by operator-authored recency. This
+    optimizes for "don't lose track of WIP".
+    """
+    eligible = _eligible_as_my_work(s)
+    at_risk = s.is_dirty or s.is_unpushed
+    if s.is_dirty and s.is_unpushed:
+        reason = f"{s.modified_count + s.untracked_count} uncommitted, {s.ahead} unpushed"
+    elif s.is_dirty:
+        reason = f"{s.modified_count} modified, {s.untracked_count} untracked"
+    elif s.is_unpushed:
+        reason = f"{s.ahead} unpushed commit(s)"
+    else:
+        reason = f"your commit {_humanize_ago(s.my_last_commit_ts, now_ts)}"
+    return RankVerdict(eligible, (1 if at_risk else 0, _recency(s)), reason)
+
+
+def rank_any_touch(s: RepoSignals, now_ts: int) -> RankVerdict:
+    """Anything I've touched — broadest, includes clone/fetch/checkout activity.
+
+    Provided for completeness/comparison; noisier (the Phase 0 default that
+    surfaced dormant clones). Eligible for every discovered repo.
+    """
+    recency = max(
+        s.index_mtime_ts or 0, s.head_reflog_ts or 0,
+        s.last_commit_ts or 0, s.my_last_commit_ts or 0,
+    )
+    return RankVerdict(True, (recency,), f"local activity {_humanize_ago(recency, now_ts)}")
+
+
+RANKING_STRATEGIES: dict[str, RankingStrategy] = {
+    "my_work": rank_my_work,
+    "dirty_first": rank_dirty_first,
+    "any_touch": rank_any_touch,
+}
+
+
+def resolve_ranking_strategy(mode: str) -> RankingStrategy:
+    """Return the strategy for *mode*, or raise with the valid set listed.
+
+    Raising (rather than silently defaulting) keeps a misconfigured mode honest
+    — the collector surfaces it in its error envelope instead of quietly serving
+    a different ranking than configured.
+    """
+    try:
+        return RANKING_STRATEGIES[mode]
+    except KeyError:
+        valid = ", ".join(sorted(RANKING_STRATEGIES))
+        raise ValueError(f"unknown focus5 ranking mode {mode!r}; valid modes: {valid}") from None
+
+
+@dataclass(frozen=True)
+class RankedRepo:
+    signals: RepoSignals
+    position: int
+    reason: str
+
+
+def rank_repos(
+    signals: list[RepoSignals], *, mode: str, now_ts: int, limit: int = DEFAULT_ROSTER_SIZE,
+) -> list[RankedRepo]:
+    """Apply *mode* to *signals* and return the top *limit* eligible repos."""
+    strategy = resolve_ranking_strategy(mode)
+    scored: list[tuple[tuple, RepoSignals, RankVerdict]] = []
+    for s in signals:
+        v = strategy(s, now_ts)
+        if v.eligible:
+            scored.append((v.sort_key, s, v))
+    # Sort by score desc, then local_path for a stable tiebreak across runs.
+    scored.sort(key=lambda t: (t[0], t[1].local_path), reverse=True)
+    return [RankedRepo(s, i, v.reason) for i, (_k, s, v) in enumerate(scored[:limit], 1)]
+
+
+# ---------------------------------------------------------------------------
+# Discovery — bounded, zero-config .git walk (reuses the ask_self prune list)
+# ---------------------------------------------------------------------------
+
+def _should_descend(name: str) -> bool:
+    if name in _PRUNE_DIRS:
+        return False
+    return not name.startswith(".")  # ".git" is matched by marker, never descended
+
+
+def iter_git_repos(
+    roots: list[str] | list[Path], *, max_depth: int = DEFAULT_MAX_DEPTH,
+) -> Iterator[Path]:
+    """Yield each git repo root under *roots*, bounded by depth + the prune list.
+
+    Stops descending at a repo boundary so nested submodules don't multiply the
+    candidate set. De-duplicates by resolved path so overlapping roots are safe.
+    """
+    seen: set[Path] = set()
+    for raw_root in roots:
+        root = Path(raw_root).expanduser()
+        if not root.is_dir():
+            continue
+        base_depth = len(root.resolve().parts)
+        for dirpath, dirnames, _files in os.walk(root, followlinks=False):
+            cur = Path(dirpath)
+            # `.git` may be a dir (normal checkout) or a file (worktree/submodule).
+            if (cur / ".git").exists():
+                rp = cur.resolve()
+                if rp not in seen:
+                    seen.add(rp)
+                    yield rp
+                dirnames[:] = []  # repo boundary — do not descend further
+                continue
+            if len(cur.resolve().parts) - base_depth >= max_depth:
+                dirnames[:] = []
+            else:
+                dirnames[:] = [d for d in dirnames if _should_descend(d)]
+
+
+# ---------------------------------------------------------------------------
+# Signal probing — read-only git plumbing per repo
+# ---------------------------------------------------------------------------
+
+def _git(repo: Path, *args: str, timeout: int = GIT_TIMEOUT) -> str | None:
+    """Run a read-only git command in *repo*; return stdout or None on any failure."""
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(repo), *args],
+            capture_output=True, text=True, check=False, timeout=timeout,
+        )
+    except Exception:  # noqa: BLE001 — git missing / hung / unreadable repo
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout
+
+
+def _parse_status(out: str) -> dict[str, Any]:
+    """Parse ``git status --porcelain=v2 --branch`` into health fields."""
+    branch = upstream = None
+    ahead = behind = modified = untracked = 0
+    has_upstream = False
+    for line in out.splitlines():
+        if line.startswith("# branch.head"):
+            branch = line.split(" ", 2)[2]
+            if branch == "(detached)":
+                branch = None
+        elif line.startswith("# branch.upstream"):
+            upstream = line.split(" ", 2)[2]
+            has_upstream = True
+        elif line.startswith("# branch.ab"):
+            parts = line.split()
+            ahead = int(parts[2].lstrip("+"))
+            behind = int(parts[3].lstrip("-"))
+        elif line[:1] in ("1", "2", "u"):  # changed/renamed/unmerged tracked entry
+            modified += 1
+        elif line.startswith("?"):
+            untracked += 1
+    return {
+        "branch": branch, "upstream": upstream, "has_upstream": has_upstream,
+        "ahead": ahead, "behind": behind,
+        "modified_count": modified, "untracked_count": untracked,
+        "is_dirty": modified > 0 or untracked > 0,
+    }
+
+
+def _mtime(path: Path) -> int | None:
+    try:
+        return int(path.stat().st_mtime)
+    except OSError:
+        return None
+
+
+def probe_repo_signals(repo: Path, *, device_id: str, probed_at: str) -> RepoSignals:
+    """Read one repo's signals with read-only git plumbing + file stats."""
+    status = _parse_status(_git(repo, "status", "--porcelain=v2", "--branch") or "")
+
+    # Newest commit (any author): epoch | ISO. Empty repos return None.
+    last_commit_ts = last_commit_at = None
+    head = _git(repo, "log", "-1", "--format=%ct|%cI")
+    if head and "|" in head:
+        epoch, iso = head.strip().split("|", 1)
+        if epoch.isdigit():
+            last_commit_ts, last_commit_at = int(epoch), iso
+
+    # Operator-authored newest commit: match THIS repo's configured identity,
+    # not a hardcoded address (the operator commits under a noreply email).
+    my_last_commit_ts = None
+    email = _git(repo, "config", "user.email")
+    if email and email.strip():
+        mine = _git(repo, "log", "-1", f"--author={email.strip()}", "--format=%ct")
+        if mine and mine.strip().isdigit():
+            my_last_commit_ts = int(mine.strip())
+
+    remote_url = (_git(repo, "remote", "get-url", "origin") or "").strip() or None
+
+    git_dir = repo / ".git"
+    head_reflog_ts = _mtime(git_dir / "logs" / "HEAD") if git_dir.is_dir() else None
+    index_mtime_ts = _mtime(git_dir / "index") if git_dir.is_dir() else None
+
+    return RepoSignals(
+        device_id=device_id,
+        local_path=str(repo),
+        repo_name=repo.name,
+        repo_full_name=derive_repo_full_name(remote_url),
+        last_commit_at=last_commit_at,
+        last_commit_ts=last_commit_ts,
+        my_last_commit_ts=my_last_commit_ts,
+        head_reflog_ts=head_reflog_ts,
+        index_mtime_ts=index_mtime_ts,
+        remote_url=remote_url,
+        probed_at=probed_at,
+        **status,
+    )
+
+
+def scan_focus5_repos(
+    roots: list[str] | list[Path], *, device_id: str, probed_at: str,
+    max_depth: int = DEFAULT_MAX_DEPTH,
+) -> list[RepoSignals]:
+    """Discover repos under *roots* and probe each one's signals."""
+    return [
+        probe_repo_signals(repo, device_id=device_id, probed_at=probed_at)
+        for repo in iter_git_repos(roots, max_depth=max_depth)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+_SIGNAL_COLUMNS = (
+    "device_id", "local_path", "repo_name", "repo_full_name", "branch",
+    "upstream", "has_upstream", "ahead", "behind", "modified_count",
+    "untracked_count", "is_dirty", "last_commit_at", "last_commit_ts",
+    "my_last_commit_ts", "head_reflog_ts", "index_mtime_ts", "remote_url",
+    "probed_at",
+)
+
+
+@dataclass(frozen=True)
+class Focus5SyncResult:
+    device_id: str
+    discovered: int
+    roster_size: int
+    ranking_mode: str
+    scan_roots: list[str]
+    computed_at: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _signal_row(s: RepoSignals) -> tuple:
+    d = asdict(s)
+    d["has_upstream"] = 1 if s.has_upstream else 0
+    d["is_dirty"] = 1 if s.is_dirty else 0
+    return tuple(d[c] for c in _SIGNAL_COLUMNS)
+
+
+def sync_focus5(
+    database_path: Path, *,
+    roots: list[str] | list[Path] | None = None,
+    device_id: str | None = None,
+    mode: str | None = None,
+    limit: int = DEFAULT_ROSTER_SIZE,
+    max_depth: int = DEFAULT_MAX_DEPTH,
+) -> Focus5SyncResult:
+    """Scan the device, persist all signals, and rewrite this device's roster.
+
+    Signals and roster are each replaced wholesale for this device inside one
+    transaction, so a removed repo never lingers in the cache and a re-rank is
+    atomic.
+    """
+    dev = device_id or get_device_id()
+    if roots is None:
+        from rebalance.ingest.config import get_focus5_scan_roots
+        roots = get_focus5_scan_roots()
+    if mode is None:
+        from rebalance.ingest.config import get_focus5_ranking_mode
+        mode = get_focus5_ranking_mode()
+
+    now = datetime.now(timezone.utc)
+    now_ts = int(now.timestamp())
+    computed_at = now.isoformat()
+
+    signals = scan_focus5_repos(roots, device_id=dev, probed_at=computed_at, max_depth=max_depth)
+    # resolve_ranking_strategy raises on a bad mode BEFORE we touch the DB.
+    ranked = rank_repos(signals, mode=mode, now_ts=now_ts, limit=limit)
+
+    placeholders = ", ".join("?" for _ in _SIGNAL_COLUMNS)
+    with db_connection(database_path) as conn:
+        run_migrations(conn)  # ensure tables exist even on a direct call
+        conn.execute("DELETE FROM focus5_repo_signals WHERE device_id=?", (dev,))
+        conn.executemany(
+            f"INSERT INTO focus5_repo_signals ({', '.join(_SIGNAL_COLUMNS)}) "
+            f"VALUES ({placeholders})",
+            [_signal_row(s) for s in signals],
+        )
+        conn.execute("DELETE FROM focus5_roster WHERE device_id=?", (dev,))
+        conn.executemany(
+            "INSERT INTO focus5_roster "
+            "(device_id, local_path, position, rank_reason, ranking_mode, computed_at) "
+            "VALUES (?,?,?,?,?,?)",
+            [
+                (dev, r.signals.local_path, r.position, r.reason, mode, computed_at)
+                for r in ranked
+            ],
+        )
+        conn.commit()
+
+    return Focus5SyncResult(
+        device_id=dev,
+        discovered=len(signals),
+        roster_size=len(ranked),
+        ranking_mode=mode,
+        scan_roots=[str(r) for r in roots],
+        computed_at=computed_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Read side — what the web view consumes
+# ---------------------------------------------------------------------------
+
+def _newest_pr(conn: Any, repo_full_name: str | None) -> dict[str, Any] | None:
+    """Newest remote PR (highest number) for *repo_full_name*, or None.
+
+    Enrichment only: a missing corpus row, an unsynced repo, or a non-GitHub
+    remote all yield None rather than breaking the card.
+    """
+    if not repo_full_name:
+        return None
+    try:
+        row = conn.execute(
+            "SELECT number, title, state, html_url, is_draft, is_merged "
+            "FROM github_items "
+            "WHERE repo_full_name=? AND item_type='pull_request' "
+            "ORDER BY number DESC LIMIT 1",
+            (repo_full_name,),
+        ).fetchone()
+    except Exception:  # noqa: BLE001 — corpus table may not exist yet
+        return None
+    if row is None:
+        return None
+    return {
+        "number": row["number"], "title": row["title"], "state": row["state"],
+        "html_url": row["html_url"],
+        "is_draft": bool(row["is_draft"]), "is_merged": bool(row["is_merged"]),
+    }
+
+
+def summarize_focus5(database_path: Path, *, device_id: str | None = None) -> dict[str, Any]:
+    """Return the roster cards, off-roster warnings, and snapshot metadata.
+
+    This is the single read contract for the web view. Each roster card carries
+    local signals (the source of truth) plus a ``newest_pr`` enrichment that is
+    None whenever the GitHub corpus can't supply it.
+    """
+    dev = device_id or get_device_id()
+    empty = {
+        "roster": [], "off_roster_warnings": [],
+        "computed_at": None, "ranking_mode": None,
+        "summary": {"discovered": 0, "roster_size": 0, "off_roster_attention": 0},
+    }
+    try:
+        with db_connection(database_path) as conn:
+            roster_rows = conn.execute(
+                "SELECT r.position, r.rank_reason, r.ranking_mode, r.computed_at, s.* "
+                "FROM focus5_roster r JOIN focus5_repo_signals s "
+                "  ON s.device_id=r.device_id AND s.local_path=r.local_path "
+                "WHERE r.device_id=? ORDER BY r.position",
+                (dev,),
+            ).fetchall()
+
+            roster = []
+            for row in roster_rows:
+                card = {k: row[k] for k in row.keys()}
+                card["is_dirty"] = bool(card["is_dirty"])
+                card["has_upstream"] = bool(card["has_upstream"])
+                card["newest_pr"] = _newest_pr(conn, card.get("repo_full_name"))
+                roster.append(card)
+
+            roster_paths = {c["local_path"] for c in roster}
+            warn_rows = conn.execute(
+                "SELECT repo_name, local_path, repo_full_name, branch, ahead, "
+                "       modified_count, untracked_count, is_dirty, probed_at "
+                "FROM focus5_repo_signals "
+                "WHERE device_id=? AND (is_dirty=1 OR ahead>0) "
+                "ORDER BY is_dirty DESC, ahead DESC, repo_name",
+                (dev,),
+            ).fetchall()
+            off_roster = [
+                {**{k: w[k] for k in w.keys()}, "is_dirty": bool(w["is_dirty"])}
+                for w in warn_rows if w["local_path"] not in roster_paths
+            ]
+
+            discovered = conn.execute(
+                "SELECT COUNT(*) FROM focus5_repo_signals WHERE device_id=?", (dev,)
+            ).fetchone()[0]
+    except Exception:  # noqa: BLE001 — tables absent on a brand-new DB
+        return empty
+
+    return {
+        "roster": roster,
+        "off_roster_warnings": off_roster,
+        "computed_at": roster[0]["computed_at"] if roster else None,
+        "ranking_mode": roster[0]["ranking_mode"] if roster else None,
+        "summary": {
+            "discovered": discovered,
+            "roster_size": len(roster),
+            "off_roster_attention": len(off_roster),
+        },
+    }

--- a/src/rebalance/ingest/focus5_scan.py
+++ b/src/rebalance/ingest/focus5_scan.py
@@ -466,6 +466,34 @@ def sync_focus5(
 # Read side — what the web view consumes
 # ---------------------------------------------------------------------------
 
+def vscode_url(local_path: str) -> str:
+    """Build a ``vscode://file/...`` URL that opens the repo root in VS Code."""
+    from urllib.parse import quote
+    return f"vscode://file{quote(local_path, safe='/')}"
+
+
+def recent_activity(local_path: str, *, limit: int = 3) -> list[dict[str, Any]]:
+    """Return the repo's last *limit* commits (local-first activity), newest first.
+
+    Live read of ``git log``; an inaccessible or empty repo yields ``[]`` rather
+    than raising. Uses the unit-separator (0x1f) so commit subjects can contain
+    any printable character without breaking the parse.
+    """
+    out = _git(
+        Path(local_path), "log", f"-{limit}",
+        "--format=%h%x1f%s%x1f%cI%x1f%ce",
+    )
+    items: list[dict[str, Any]] = []
+    for line in (out or "").splitlines():
+        parts = line.split("\x1f")
+        if len(parts) == 4:
+            items.append({
+                "sha": parts[0], "subject": parts[1],
+                "committed_at": parts[2], "author_email": parts[3],
+            })
+    return items
+
+
 def _newest_pr(conn: Any, repo_full_name: str | None) -> dict[str, Any] | None:
     """Newest remote PR (highest number) for *repo_full_name*, or None.
 
@@ -493,12 +521,19 @@ def _newest_pr(conn: Any, repo_full_name: str | None) -> dict[str, Any] | None:
     }
 
 
-def summarize_focus5(database_path: Path, *, device_id: str | None = None) -> dict[str, Any]:
+def summarize_focus5(
+    database_path: Path, *, device_id: str | None = None, with_activity: bool = True,
+) -> dict[str, Any]:
     """Return the roster cards, off-roster warnings, and snapshot metadata.
 
-    This is the single read contract for the web view. Each roster card carries
-    local signals (the source of truth) plus a ``newest_pr`` enrichment that is
-    None whenever the GitHub corpus can't supply it.
+    This is the single read contract for the web view, and the one place that
+    owns the repo-card shape. Each roster card carries local signals (the source
+    of truth), a ``vscode_url`` open action, a ``newest_pr`` enrichment that is
+    None whenever the GitHub corpus can't supply it, and the last 3 local
+    commits as ``recent_activity``.
+
+    ``recent_activity`` is a live ``git log`` read per roster repo (top-5 only,
+    so bounded). Pass ``with_activity=False`` to skip it for a pure DB read.
     """
     dev = device_id or get_device_id()
     empty = {
@@ -521,7 +556,11 @@ def summarize_focus5(database_path: Path, *, device_id: str | None = None) -> di
                 card = {k: row[k] for k in row.keys()}
                 card["is_dirty"] = bool(card["is_dirty"])
                 card["has_upstream"] = bool(card["has_upstream"])
+                card["vscode_url"] = vscode_url(card["local_path"])
                 card["newest_pr"] = _newest_pr(conn, card.get("repo_full_name"))
+                card["recent_activity"] = (
+                    recent_activity(card["local_path"]) if with_activity else []
+                )
                 roster.append(card)
 
             roster_paths = {c["local_path"] for c in roster}

--- a/src/rebalance/ingest/focus5_scan.py
+++ b/src/rebalance/ingest/focus5_scan.py
@@ -494,6 +494,56 @@ def recent_activity(local_path: str, *, limit: int = 3) -> list[dict[str, Any]]:
     return items
 
 
+_LIVE_HEALTH_FIELDS = (
+    "branch", "upstream", "has_upstream", "ahead", "behind",
+    "modified_count", "untracked_count", "is_dirty",
+)
+
+
+def live_health(local_path: str) -> dict[str, Any]:
+    """Re-probe just the working-tree health for one repo (single git call).
+
+    This is the Phase 3 freshness path: roster *membership* may be a day old,
+    but "did I forget to commit or push?" must be answered against the tree's
+    current state. Returns the health fields plus ``health_probed_at``; a repo
+    that can't be read yields ``health_available=False`` (never raises).
+    """
+    probed_at = datetime.now(timezone.utc).isoformat()
+    out = _git(Path(local_path), "status", "--porcelain=v2", "--branch")
+    if out is None:
+        return {"health_available": False, "health_probed_at": probed_at}
+    h = _parse_status(out)
+    h["health_available"] = True
+    h["health_probed_at"] = probed_at
+    return h
+
+
+def get_roster_meta(database_path: Path, *, device_id: str | None = None) -> dict[str, Any]:
+    """Cheap roster freshness check (no git, no enrichment): when + how many.
+
+    Lets the web route decide whether to lazily recompute on a stale TTL without
+    paying for the full live-probe render first.
+    """
+    dev = device_id or get_device_id()
+    try:
+        with db_connection(database_path) as conn:
+            row = conn.execute(
+                "SELECT computed_at, ranking_mode FROM focus5_roster "
+                "WHERE device_id=? ORDER BY position LIMIT 1",
+                (dev,),
+            ).fetchone()
+            n = conn.execute(
+                "SELECT COUNT(*) FROM focus5_roster WHERE device_id=?", (dev,)
+            ).fetchone()[0]
+    except Exception:  # noqa: BLE001 — table absent on a brand-new DB
+        return {"computed_at": None, "ranking_mode": None, "roster_size": 0}
+    return {
+        "computed_at": row["computed_at"] if row else None,
+        "ranking_mode": row["ranking_mode"] if row else None,
+        "roster_size": n,
+    }
+
+
 def _newest_pr(conn: Any, repo_full_name: str | None) -> dict[str, Any] | None:
     """Newest remote PR (highest number) for *repo_full_name*, or None.
 
@@ -522,18 +572,24 @@ def _newest_pr(conn: Any, repo_full_name: str | None) -> dict[str, Any] | None:
 
 
 def summarize_focus5(
-    database_path: Path, *, device_id: str | None = None, with_activity: bool = True,
+    database_path: Path, *, device_id: str | None = None,
+    with_activity: bool = True, with_live_health: bool = True,
 ) -> dict[str, Any]:
     """Return the roster cards, off-roster warnings, and snapshot metadata.
 
     This is the single read contract for the web view, and the one place that
-    owns the repo-card shape. Each roster card carries local signals (the source
-    of truth), a ``vscode_url`` open action, a ``newest_pr`` enrichment that is
-    None whenever the GitHub corpus can't supply it, and the last 3 local
-    commits as ``recent_activity``.
+    owns the repo-card shape. Each roster card carries local signals, a
+    ``vscode_url`` open action, a ``newest_pr`` enrichment (None when the GitHub
+    corpus can't supply it), and the last 3 local commits as ``recent_activity``.
 
-    ``recent_activity`` is a live ``git log`` read per roster repo (top-5 only,
-    so bounded). Pass ``with_activity=False`` to skip it for a pure DB read.
+    Freshness split (Phase 3): roster *membership* comes from the persisted
+    snapshot, but each card's working-tree **health is re-probed live** here
+    (``with_live_health``) and stamped with ``health_probed_at`` — so commit/push
+    reminders reflect the tree right now, not the last sync. Off-roster warnings
+    stay cached (we never live-sweep the whole machine per request).
+
+    Both ``with_activity`` and ``with_live_health`` are bounded to the top-5 and
+    can be disabled for a pure DB read.
     """
     dev = device_id or get_device_id()
     empty = {
@@ -561,6 +617,18 @@ def summarize_focus5(
                 card["recent_activity"] = (
                     recent_activity(card["local_path"]) if with_activity else []
                 )
+                # Overlay live working-tree health on top of the stored snapshot
+                # so "did I forget to commit/push?" is answered against now.
+                if with_live_health:
+                    lh = live_health(card["local_path"])
+                    if lh.get("health_available"):
+                        for k in _LIVE_HEALTH_FIELDS:
+                            card[k] = lh[k]
+                    card["health_available"] = lh.get("health_available", True)
+                    card["health_probed_at"] = lh["health_probed_at"]
+                else:
+                    card["health_available"] = True
+                    card["health_probed_at"] = card.get("probed_at")
                 roster.append(card)
 
             roster_paths = {c["local_path"] for c in roster}

--- a/src/rebalance/ingest/focus5_scan.py
+++ b/src/rebalance/ingest/focus5_scan.py
@@ -31,11 +31,13 @@ read-only git plumbing and ``stat`` files; we never write to a foreign repo.
 """
 from __future__ import annotations
 
+import logging
 import os
 import subprocess
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from time import perf_counter
 from typing import Any, Callable, Iterator
 
 from rebalance.ingest.db import db_connection, run_migrations
@@ -44,9 +46,14 @@ from rebalance.ingest.sync_snapshot import get_device_id
 # parser rather than duplicating them; both are low-churn and shared by intent.
 from rebalance.ingest.ask_self_scan import _PRUNE_DIRS, derive_repo_full_name
 
+logger = logging.getLogger(__name__)
+
 DEFAULT_MAX_DEPTH = 6
 DEFAULT_ROSTER_SIZE = 5
 GIT_TIMEOUT = 5
+# A single repo probe over this many seconds is worth flagging — a slow disk, a
+# huge working tree, or a hung git is the usual cause.
+SLOW_REPO_SECONDS = 1.5
 
 
 # ---------------------------------------------------------------------------
@@ -314,9 +321,23 @@ def _mtime(path: Path) -> int | None:
         return None
 
 
-def probe_repo_signals(repo: Path, *, device_id: str, probed_at: str) -> RepoSignals:
-    """Read one repo's signals with read-only git plumbing + file stats."""
-    status = _parse_status(_git(repo, "status", "--porcelain=v2", "--branch") or "")
+def probe_repo_signals(
+    repo: Path, *, device_id: str, probed_at: str, stats: dict[str, Any] | None = None,
+) -> RepoSignals:
+    """Read one repo's signals with read-only git plumbing + file stats.
+
+    Pass a ``stats`` dict to accumulate diagnostics across a scan: per-repo probe
+    duration is timed, slow probes (> ``SLOW_REPO_SECONDS``) and repos whose
+    ``git status`` fails are logged and counted so a degraded scan is diagnosable
+    from the logs rather than silently slow or partial.
+    """
+    started = perf_counter()
+    status_out = _git(repo, "status", "--porcelain=v2", "--branch")
+    if status_out is None:
+        logger.warning("focus5: git status failed for %s (skipping its health)", repo)
+        if stats is not None:
+            stats["failed"] = stats.get("failed", 0) + 1
+    status = _parse_status(status_out or "")
 
     # Newest commit (any author): epoch | ISO. Empty repos return None.
     last_commit_ts = last_commit_at = None
@@ -341,6 +362,12 @@ def probe_repo_signals(repo: Path, *, device_id: str, probed_at: str) -> RepoSig
     head_reflog_ts = _mtime(git_dir / "logs" / "HEAD") if git_dir.is_dir() else None
     index_mtime_ts = _mtime(git_dir / "index") if git_dir.is_dir() else None
 
+    elapsed = perf_counter() - started
+    if elapsed > SLOW_REPO_SECONDS:
+        logger.warning("focus5: slow repo probe %.2fs for %s", elapsed, repo)
+        if stats is not None:
+            stats.setdefault("slow", []).append((str(repo), round(elapsed, 2)))
+
     return RepoSignals(
         device_id=device_id,
         local_path=str(repo),
@@ -359,11 +386,15 @@ def probe_repo_signals(repo: Path, *, device_id: str, probed_at: str) -> RepoSig
 
 def scan_focus5_repos(
     roots: list[str] | list[Path], *, device_id: str, probed_at: str,
-    max_depth: int = DEFAULT_MAX_DEPTH,
+    max_depth: int = DEFAULT_MAX_DEPTH, stats: dict[str, Any] | None = None,
 ) -> list[RepoSignals]:
-    """Discover repos under *roots* and probe each one's signals."""
+    """Discover repos under *roots* and probe each one's signals.
+
+    ``stats`` (optional) accumulates slow-probe and git-failure diagnostics
+    across the scan; see :func:`probe_repo_signals`.
+    """
     return [
-        probe_repo_signals(repo, device_id=device_id, probed_at=probed_at)
+        probe_repo_signals(repo, device_id=device_id, probed_at=probed_at, stats=stats)
         for repo in iter_git_repos(roots, max_depth=max_depth)
     ]
 
@@ -389,6 +420,9 @@ class Focus5SyncResult:
     ranking_mode: str
     scan_roots: list[str]
     computed_at: str
+    elapsed_seconds: float = 0.0
+    slow_repos: int = 0
+    failed_repos: int = 0
 
     def as_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -427,10 +461,18 @@ def sync_focus5(
     now_ts = int(now.timestamp())
     computed_at = now.isoformat()
 
-    signals = scan_focus5_repos(roots, device_id=dev, probed_at=computed_at, max_depth=max_depth)
+    started = perf_counter()
+    stats: dict[str, Any] = {}
+    signals = scan_focus5_repos(
+        roots, device_id=dev, probed_at=computed_at, max_depth=max_depth, stats=stats
+    )
+    t_scan = perf_counter() - started
     # resolve_ranking_strategy raises on a bad mode BEFORE we touch the DB.
+    t0 = perf_counter()
     ranked = rank_repos(signals, mode=mode, now_ts=now_ts, limit=limit)
+    t_rank = perf_counter() - t0
 
+    t0 = perf_counter()
     placeholders = ", ".join("?" for _ in _SIGNAL_COLUMNS)
     with db_connection(database_path) as conn:
         run_migrations(conn)  # ensure tables exist even on a direct call
@@ -451,6 +493,21 @@ def sync_focus5(
             ],
         )
         conn.commit()
+    t_persist = perf_counter() - t0
+
+    elapsed = perf_counter() - started
+    slow_repos, failed_repos = len(stats.get("slow", [])), stats.get("failed", 0)
+    logger.info(
+        "focus5 sync: %d repos in %.2fs (scan %.2fs, rank %.3fs, persist %.3fs); "
+        "roster=%d mode=%s slow=%d failed=%d",
+        len(signals), elapsed, t_scan, t_rank, t_persist,
+        len(ranked), mode, slow_repos, failed_repos,
+    )
+    if failed_repos:
+        logger.warning(
+            "focus5 sync: %d/%d repo(s) failed their git probe — health for those is "
+            "stale/blank (see per-repo warnings above)", failed_repos, len(signals),
+        )
 
     return Focus5SyncResult(
         device_id=dev,
@@ -459,6 +516,9 @@ def sync_focus5(
         ranking_mode=mode,
         scan_roots=[str(r) for r in roots],
         computed_at=computed_at,
+        elapsed_seconds=round(elapsed, 3),
+        slow_repos=slow_repos,
+        failed_repos=failed_repos,
     )
 
 

--- a/src/rebalance/ingest/index_ops.py
+++ b/src/rebalance/ingest/index_ops.py
@@ -201,6 +201,18 @@ def get_index_status(database_path: Path) -> dict[str, Any]:
             "newest_received_at": _safe_max(conn, "email_messages", "received_at"),
         }
 
+        try:
+            built = conn.execute(
+                "SELECT COUNT(*) FROM ask_self_indexes WHERE index_built = 1"
+            ).fetchone()[0]
+        except Exception:
+            built = None
+        payload["sources"]["ask_self"] = {
+            "repos": _safe_count(conn, "ask_self_indexes"),
+            "built_indexes": built,
+            "last_scanned_at": _safe_max(conn, "ask_self_indexes", "scanned_at"),
+        }
+
         # Semantic index
         sem_total = _safe_count(conn, "semantic_documents")
         sem_meta = _safe_meta(conn, "semantic_embedding_meta")
@@ -1067,6 +1079,78 @@ def _sync_adapter(db_path: Path, **opts: Any) -> dict[str, Any]:
     return _refresh_sync(db_path, dry_run=opts["dry_run"])
 
 
+def _refresh_ask_self(database_path: Path, *, dry_run: bool) -> dict[str, Any]:
+    """Walk this device for ask_self-enabled repos and record their indexes.
+
+    Discovery-only: reads each repo's ask_self harness + index metadata
+    (read-only) and upserts one row per repo into ``ask_self_indexes``. Does not
+    build or refresh any RAG index itself. Opt-in (``included_in_all=False``)
+    because it walks the filesystem; run explicitly via
+    ``refresh_index(scope=["ask_self"])``.
+    """
+    from rebalance.ingest.config import get_ask_self_scan_roots
+
+    roots = get_ask_self_scan_roots()
+    if dry_run:
+        return {
+            "scope": "ask_self",
+            "dry_run": True,
+            "scan_roots": roots,
+            "steps": [
+                f"scan_ask_self_repos(roots={roots})",
+                "read each ask_self index repo_metadata (read-only)",
+                "upsert ask_self_indexes (keyed by device_id, local_path)",
+            ],
+        }
+
+    from rebalance.ingest.ask_self_scan import sync_ask_self_indexes
+
+    result = sync_ask_self_indexes(database_path, roots=roots)
+    return {"scope": "ask_self", "dry_run": False, **result.as_dict()}
+
+
+def _ask_self_adapter(db_path: Path, **opts: Any) -> dict[str, Any]:
+    return _refresh_ask_self(db_path, dry_run=opts["dry_run"])
+
+
+def _refresh_focus5(database_path: Path, *, dry_run: bool) -> dict[str, Any]:
+    """Scan device-local git repos and rebuild the Focus 5 roster.
+
+    Discovers active local repos (bounded zero-config walk), probes per-repo
+    git signals, and persists both the full signal cache and the ranked top-5
+    roster. Local-git-first: the GitHub corpus is enrichment only. Opt-in
+    (``included_in_all=False``) because it walks the filesystem and shells git;
+    run explicitly via ``refresh_index(scope=["focus5"])`` or lazily from the
+    web view when the roster TTL has expired.
+    """
+    from rebalance.ingest.config import get_focus5_ranking_mode, get_focus5_scan_roots
+
+    roots = get_focus5_scan_roots()
+    mode = get_focus5_ranking_mode()
+    if dry_run:
+        return {
+            "scope": "focus5",
+            "dry_run": True,
+            "scan_roots": roots,
+            "ranking_mode": mode,
+            "steps": [
+                f"iter_git_repos(roots={roots})",
+                "probe per-repo signals (read-only git status/log + .git stats)",
+                "replace focus5_repo_signals for this device (off-roster cache)",
+                f"rank via {mode!r} strategy and replace focus5_roster (top 5)",
+            ],
+        }
+
+    from rebalance.ingest.focus5_scan import sync_focus5
+
+    result = sync_focus5(database_path, roots=roots, mode=mode)
+    return {"scope": "focus5", "dry_run": False, **result.as_dict()}
+
+
+def _focus5_adapter(db_path: Path, **opts: Any) -> dict[str, Any]:
+    return _refresh_focus5(db_path, dry_run=opts["dry_run"])
+
+
 register_collector(Collector("vault", _vault_adapter, requires=("vault_path",)))
 register_collector(Collector("github", _github_adapter, requires=("github_token",)))
 register_collector(Collector("calendar", _calendar_adapter))
@@ -1074,3 +1158,5 @@ register_collector(Collector("sleuth", _sleuth_adapter))
 register_collector(Collector("email", _email_adapter))
 register_collector(Collector("semantic", _semantic_adapter))
 register_collector(Collector("sync", _sync_adapter))
+register_collector(Collector("focus5", _focus5_adapter, included_in_all=False))
+register_collector(Collector("ask_self", _ask_self_adapter, included_in_all=False))

--- a/src/rebalance/mcp/tools/index.py
+++ b/src/rebalance/mcp/tools/index.py
@@ -132,6 +132,27 @@ def register(mcp: FastMCP, database_path: Path) -> None:
         return get_watched_repos(database_path, since_days=since_days)
 
     @mcp.tool()
+    def list_ask_self_repos() -> dict[str, Any]:
+        """
+        Inventory every repo on this device that has an ask_self RAG index,
+        cross-referenced against the watched-repos set.
+
+        Each entry reports its local path, derived GitHub identity
+        (owner/repo), whether the index is actually built, chunk/file counts,
+        embedding model, last-ingest time, the device it lives on, and a
+        ``watched`` flag (True when Rebalance already monitors that repo). The
+        ``summary`` block totals built vs. watched and lists the devices seen.
+
+        Read-only over the ``ask_self_indexes`` table. Populate/refresh it with
+        refresh_index(scope=["ask_self"]) — this tool does not scan the disk.
+
+        Use this to answer "which of my projects have a queryable local brain,
+        and which machine is it on?".
+        """
+        from rebalance.ingest.ask_self_scan import summarize_ask_self_indexes
+        return summarize_ask_self_indexes(database_path)
+
+    @mcp.tool()
     def publish_pulse(
         dry_run: bool = False,
         push: bool = True,

--- a/src/rebalance/web.py
+++ b/src/rebalance/web.py
@@ -19,9 +19,14 @@ from datetime import datetime, timezone
 from typing import Any
 
 from fastapi import FastAPI
-from fastapi.responses import HTMLResponse, PlainTextResponse
+from fastapi.responses import HTMLResponse, PlainTextResponse, RedirectResponse
 
 from rebalance.ingest.auth_log import read_log, _log_path
+
+# How long a persisted Focus 5 roster stays authoritative before a visit lazily
+# recomputes it. Membership is snapshot-stable for this window; working-tree
+# health is always re-probed live on load regardless.
+FOCUS5_ROSTER_TTL_SECONDS = 24 * 3600
 
 app = FastAPI(title="rebalance-OS", docs_url=None, redoc_url=None)
 
@@ -104,6 +109,15 @@ main.wide { max-width: 1480px; }
 .f5-act li { font-size: 12px; line-height: 1.35; }
 .f5-act .when { color: #9aa0a6; font-size: 10px; }
 .f5-meta { font-size: 12px; color: #5f6368; margin-bottom: 16px; }
+.f5-live { color: #34a853; }
+.f5-stale { color: #b06000; font-weight: 700; }
+.f5-refresh { font-size: 13px; font-weight: 600; color: #1a73e8; text-decoration: none;
+              margin-left: 10px; }
+.f5-refresh:hover { text-decoration: underline; }
+.f5-warn { background: #fef7e0; border: 1px solid #f9e3a0; color: #5f4b00;
+           border-radius: 8px; padding: 10px 14px; margin-bottom: 16px; font-size: 13px;
+           line-height: 1.5; }
+.f5-warn b { color: #3c2f00; }
 """
 
 
@@ -164,7 +178,10 @@ def _rel_time(iso: str | None) -> str:
 
 
 def _f5_health(card: dict[str, Any]) -> str:
-    """Working-tree health: dirty/clean dot + counts + branch + ahead/behind drift."""
+    """Working-tree health (re-probed live): dot + counts + branch + drift."""
+    if not card.get("health_available", True):
+        return ("<div class='f5-sec'><h4>Tree health · live</h4>"
+                "<span class='f5-muted'>⚠ unavailable (repo not readable)</span></div>")
     if card["is_dirty"]:
         dot, parts = "#ea4335", []
         if card["modified_count"]:
@@ -185,6 +202,34 @@ def _f5_health(card: dict[str, Any]) -> str:
         f"<span class='f5-dot' style='background:{dot}'></span>"
         f"<span>{state}</span><br>"
         f"<span class='f5-branch'>{branch}</span>{drift}</div>"
+    )
+
+
+def _f5_warning_strip(data: dict[str, Any]) -> str:
+    """Hidden-attention strip: repos outside the top 5 that still need care.
+
+    Sourced from the cached signals (not a live sweep), so it carries the roster
+    snapshot's freshness, made explicit in the label.
+    """
+    warns = data.get("off_roster_warnings") or []
+    if not warns:
+        return ""
+    shown, items = warns[:8], []
+    for w in shown:
+        bits = []
+        if w.get("modified_count"):
+            bits.append(f"{w['modified_count']} modified")
+        if w.get("untracked_count"):
+            bits.append(f"{w['untracked_count']} untracked")
+        if w.get("ahead"):
+            bits.append(f"{w['ahead']} unpushed")
+        items.append(f"<b>{html.escape(w['repo_name'])}</b> ({', '.join(bits) or 'attention'})")
+    more = f" · +{len(warns) - len(shown)} more" if len(warns) > len(shown) else ""
+    age = _rel_time(data.get("computed_at"))
+    return (
+        f"<div class='f5-warn'>⚠ <b>{len(warns)}</b> repo(s) outside the top 5 need "
+        f"attention <span class='f5-muted'>(as of roster computed {age})</span>: "
+        f"{' · '.join(items)}{more}</div>"
     )
 
 
@@ -236,28 +281,46 @@ def _f5_card(card: dict[str, Any]) -> str:
 
 def _focus5_body(data: dict[str, Any]) -> str:
     """Render the Focus 5 page body from a summarize_focus5() dict (pure)."""
+    refresh_btn = "<a class='f5-refresh' href='/focus-5?refresh=1' title='Re-rank now'>↻ Refresh</a>"
     roster = data.get("roster") or []
     if not roster:
         return (
-            "<h2>🎯 Focus 5</h2>"
+            f"<h2>🎯 Focus 5 {refresh_btn}</h2>"
             "<div class='empty'>No active repos found yet. The roster builds from "
             "your local git activity — make a commit or leave uncommitted work in a "
-            "repo under your dev folders, then reload. "
-            "You can also run <code>rebalance refresh-index</code> after a sync.</div>"
+            "repo under your dev folders, then reload.</div>"
         )
     mode = html.escape(data.get("ranking_mode") or "")
     computed = _rel_time(data.get("computed_at"))
+    # Roster membership is a snapshot (≤24h); tree health is re-probed live. Say
+    # so, and flag the rare stale case (e.g. a refresh that failed) explicitly.
+    stale = "<span class='f5-stale'>⚠ stale</span> " if _roster_stale(data.get("computed_at")) else ""
     meta = (
-        f"<div class='f5-meta'>Roster computed {computed} · ranked by "
-        f"<b>{mode}</b> · {data['summary']['discovered']} repos discovered</div>"
+        f"<div class='f5-meta'>{stale}Roster computed <b>{computed}</b> · ranked by "
+        f"<b>{mode}</b> · {data['summary']['discovered']} repos discovered · "
+        f"<span class='f5-live'>● tree health checked live</span></div>"
     )
+    strip = _f5_warning_strip(data)
     cards = "".join(_f5_card(c) for c in roster)
-    return f"<h2>🎯 Focus 5</h2>{meta}<div class='f5-grid'>{cards}</div>"
+    return f"<h2>🎯 Focus 5 {refresh_btn}</h2>{meta}{strip}<div class='f5-grid'>{cards}</div>"
 
 
-@app.get("/focus-5", response_class=HTMLResponse)
-def focus5_page() -> HTMLResponse:
-    from rebalance.ingest.focus5_scan import summarize_focus5, sync_focus5
+def _roster_stale(computed_at: str | None) -> bool:
+    """True if the roster snapshot is missing or older than the TTL."""
+    if not computed_at:
+        return True
+    try:
+        ts = datetime.fromisoformat(computed_at.replace("Z", "+00:00"))
+    except ValueError:
+        return True
+    return (datetime.now(timezone.utc) - ts).total_seconds() > FOCUS5_ROSTER_TTL_SECONDS
+
+
+@app.get("/focus-5")
+def focus5_page(refresh: bool = False):
+    from rebalance.ingest.focus5_scan import (
+        get_roster_meta, summarize_focus5, sync_focus5,
+    )
     from rebalance.paths import DatabaseNotFoundError, resolve_database_path
 
     try:
@@ -267,16 +330,19 @@ def focus5_page() -> HTMLResponse:
                 "Run <code>rebalance refresh-index</code> first.</div>")
         return _page("Focus 5", body, wide=True)
 
-    data = summarize_focus5(db)
-    # Lazy bootstrap: first visit has an empty roster, so build it once on load.
-    # (The full 24h-TTL recompute + manual refresh button land in Phase 3.)
-    if not data["roster"]:
+    # Recompute the roster when forced, never built, or past its 24h TTL. The
+    # meta check is a cheap DB read so we don't pay the live-probe render twice.
+    meta = get_roster_meta(db)
+    if refresh or not meta["roster_size"] or _roster_stale(meta["computed_at"]):
         try:
             sync_focus5(db)
-            data = summarize_focus5(db)
         except Exception:  # noqa: BLE001 — a scan failure must not 500 the page
             pass
+        if refresh:
+            # Post/redirect/get: drop ?refresh so a browser reload doesn't re-scan.
+            return RedirectResponse("/focus-5", status_code=303)
 
+    data = summarize_focus5(db)  # roster from snapshot; health re-probed live
     return _page("Focus 5", _focus5_body(data), wide=True)
 
 

--- a/src/rebalance/web.py
+++ b/src/rebalance/web.py
@@ -7,11 +7,16 @@ Start with:
 Routes
 ------
 GET /              — index with links to all pages
+GET /focus-5       — top-5 device-local repos: tree health, newest PR, activity
 GET /auth-log      — unified auth-activity log across all collectors (HTML table)
 GET /auth-log/raw  — raw JSONL file download
 """
 
 from __future__ import annotations
+
+import html
+from datetime import datetime, timezone
+from typing import Any
 
 from fastapi import FastAPI
 from fastapi.responses import HTMLResponse, PlainTextResponse
@@ -71,11 +76,40 @@ tr:hover td { background: #fafafa; }
 .empty { text-align: center; padding: 48px; color: #5f6368; font-size: 14px; }
 .raw-link { float: right; font-size: 12px; color: #1a73e8; text-decoration: none; }
 .raw-link:hover { text-decoration: underline; }
+
+/* Focus 5 */
+main.wide { max-width: 1480px; }
+.f5-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 16px;
+           align-items: start; }
+@media (max-width: 1100px) { .f5-grid { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 620px)  { .f5-grid { grid-template-columns: 1fr; } }
+.f5-card { background: #fff; border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,.12);
+           padding: 14px; display: flex; flex-direction: column; gap: 10px; }
+.f5-pos { font-size: 11px; font-weight: 700; color: #9aa0a6; }
+.f5-name { font-size: 15px; font-weight: 600; color: #1a73e8; text-decoration: none;
+           word-break: break-word; }
+.f5-name:hover { text-decoration: underline; }
+.f5-reason { font-size: 11px; color: #5f6368; }
+.f5-sec { border-top: 1px solid #f1f3f4; padding-top: 8px; }
+.f5-sec h4 { font-size: 10px; text-transform: uppercase; letter-spacing: .04em;
+             color: #9aa0a6; font-weight: 700; margin-bottom: 5px; }
+.f5-branch { font-family: "SF Mono", monospace; font-size: 11px; color: #202124; }
+.f5-drift { font-size: 11px; color: #5f6368; margin-left: 6px; }
+.f5-dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%;
+          margin-right: 5px; vertical-align: middle; }
+.f5-pr a { color: #1a73e8; text-decoration: none; font-size: 12px; }
+.f5-pr a:hover { text-decoration: underline; }
+.f5-muted { font-size: 12px; color: #9aa0a6; }
+.f5-act { list-style: none; display: flex; flex-direction: column; gap: 5px; }
+.f5-act li { font-size: 12px; line-height: 1.35; }
+.f5-act .when { color: #9aa0a6; font-size: 10px; }
+.f5-meta { font-size: 12px; color: #5f6368; margin-bottom: 16px; }
 """
 
 
-def _page(title: str, body: str) -> HTMLResponse:
-    html = f"""<!DOCTYPE html>
+def _page(title: str, body: str, *, wide: bool = False) -> HTMLResponse:
+    main_attr = ' class="wide"' if wide else ""
+    html_doc = f"""<!DOCTYPE html>
 <html lang="en">
 <head><meta charset="utf-8"><title>{title} — rebalance-OS</title>
 <style>{_CSS}</style></head>
@@ -84,12 +118,13 @@ def _page(title: str, body: str) -> HTMLResponse:
   <h1>rebalance-OS</h1>
   <nav>
     <a href="/">Home</a>&ensp;·&ensp;
+    <a href="/focus-5">Focus 5</a>&ensp;·&ensp;
     <a href="/auth-log">Auth Log</a>
   </nav>
 </header>
-<main>{body}</main>
+<main{main_attr}>{body}</main>
 </body></html>"""
-    return HTMLResponse(html)
+    return HTMLResponse(html_doc)
 
 
 @app.get("/", response_class=HTMLResponse)
@@ -97,6 +132,12 @@ def index() -> HTMLResponse:
     body = """
 <h2>Local dashboards</h2>
 <ul style="margin-top:16px;line-height:2;list-style:none;">
+  <li><a href="/focus-5" style="color:#1a73e8;font-size:15px;">
+      🎯 Focus 5</a>
+      <span style="color:#5f6368;font-size:13px;margin-left:8px;">
+      — the 5 repos you're actively working on: working-tree health, newest PR,
+      and recent local commits, ranked by uncommitted/unpushed work first</span>
+  </li>
   <li><a href="/auth-log" style="color:#1a73e8;font-size:15px;">
       📋 Auth Activity Log</a>
       <span style="color:#5f6368;font-size:13px;margin-left:8px;">
@@ -105,6 +146,138 @@ def index() -> HTMLResponse:
   </li>
 </ul>"""
     return _page("Home", body)
+
+
+def _rel_time(iso: str | None) -> str:
+    """Render an ISO-8601 timestamp as a compact relative age (e.g. '3h ago')."""
+    if not iso:
+        return ""
+    try:
+        ts = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+    except ValueError:
+        return ""
+    secs = max(0, int((datetime.now(timezone.utc) - ts).total_seconds()))
+    for label, unit in (("d", 86400), ("h", 3600), ("m", 60)):
+        if secs >= unit:
+            return f"{secs // unit}{label} ago"
+    return "just now"
+
+
+def _f5_health(card: dict[str, Any]) -> str:
+    """Working-tree health: dirty/clean dot + counts + branch + ahead/behind drift."""
+    if card["is_dirty"]:
+        dot, parts = "#ea4335", []
+        if card["modified_count"]:
+            parts.append(f"{card['modified_count']} modified")
+        if card["untracked_count"]:
+            parts.append(f"{card['untracked_count']} untracked")
+        state = ", ".join(parts) or "dirty"
+    else:
+        dot, state = "#34a853", "clean"
+    branch = html.escape(card["branch"] or "(detached)")
+    drift = ""
+    if card["has_upstream"] and (card["ahead"] or card["behind"]):
+        drift = f"<span class='f5-drift'>↑{card['ahead']} ↓{card['behind']}</span>"
+    elif not card["has_upstream"]:
+        drift = "<span class='f5-drift'>no upstream</span>"
+    return (
+        f"<div class='f5-sec'><h4>Tree health</h4>"
+        f"<span class='f5-dot' style='background:{dot}'></span>"
+        f"<span>{state}</span><br>"
+        f"<span class='f5-branch'>{branch}</span>{drift}</div>"
+    )
+
+
+def _f5_pr(card: dict[str, Any]) -> str:
+    """Newest remote PR, or an explicit unavailable state (never drop the repo)."""
+    pr = card.get("newest_pr")
+    if pr:
+        tag = " · draft" if pr.get("is_draft") else (" · merged" if pr.get("is_merged") else "")
+        title = html.escape(pr["title"] or "")
+        inner = (
+            f"<a href='{html.escape(pr['html_url'] or '#')}' target='_blank' rel='noopener'>"
+            f"#{pr['number']} {title}</a>"
+            f"<span class='f5-muted'> ({html.escape(pr.get('state') or '')}{tag})</span>"
+        )
+    elif card.get("repo_full_name"):
+        inner = "<span class='f5-muted'>no open PR synced yet</span>"
+    elif card.get("remote_url"):
+        inner = "<span class='f5-muted'>non-GitHub remote</span>"
+    else:
+        inner = "<span class='f5-muted'>no remote configured</span>"
+    return f"<div class='f5-sec f5-pr'><h4>Newest PR</h4>{inner}</div>"
+
+
+def _f5_activity(card: dict[str, Any]) -> str:
+    items = card.get("recent_activity") or []
+    if not items:
+        return "<div class='f5-sec'><h4>Recent activity</h4><span class='f5-muted'>no local commits</span></div>"
+    lis = "".join(
+        f"<li>{html.escape(c['subject'])}<br>"
+        f"<span class='when'>{html.escape(c['sha'])} · {_rel_time(c.get('committed_at'))}</span></li>"
+        for c in items
+    )
+    return f"<div class='f5-sec'><h4>Recent activity</h4><ul class='f5-act'>{lis}</ul></div>"
+
+
+def _f5_card(card: dict[str, Any]) -> str:
+    name = html.escape(card["repo_name"])
+    vsurl = html.escape(card.get("vscode_url") or "#")
+    reason = html.escape(card.get("rank_reason") or "")
+    return (
+        f"<div class='f5-card'>"
+        f"<div><div class='f5-pos'>#{card['position']}</div>"
+        f"<a class='f5-name' href='{vsurl}' title='Open in VS Code'>{name}</a>"
+        f"<div class='f5-reason'>{reason}</div></div>"
+        f"{_f5_health(card)}{_f5_pr(card)}{_f5_activity(card)}"
+        f"</div>"
+    )
+
+
+def _focus5_body(data: dict[str, Any]) -> str:
+    """Render the Focus 5 page body from a summarize_focus5() dict (pure)."""
+    roster = data.get("roster") or []
+    if not roster:
+        return (
+            "<h2>🎯 Focus 5</h2>"
+            "<div class='empty'>No active repos found yet. The roster builds from "
+            "your local git activity — make a commit or leave uncommitted work in a "
+            "repo under your dev folders, then reload. "
+            "You can also run <code>rebalance refresh-index</code> after a sync.</div>"
+        )
+    mode = html.escape(data.get("ranking_mode") or "")
+    computed = _rel_time(data.get("computed_at"))
+    meta = (
+        f"<div class='f5-meta'>Roster computed {computed} · ranked by "
+        f"<b>{mode}</b> · {data['summary']['discovered']} repos discovered</div>"
+    )
+    cards = "".join(_f5_card(c) for c in roster)
+    return f"<h2>🎯 Focus 5</h2>{meta}<div class='f5-grid'>{cards}</div>"
+
+
+@app.get("/focus-5", response_class=HTMLResponse)
+def focus5_page() -> HTMLResponse:
+    from rebalance.ingest.focus5_scan import summarize_focus5, sync_focus5
+    from rebalance.paths import DatabaseNotFoundError, resolve_database_path
+
+    try:
+        db = resolve_database_path()
+    except DatabaseNotFoundError:
+        body = ("<h2>🎯 Focus 5</h2><div class='empty'>No rebalance database found. "
+                "Run <code>rebalance refresh-index</code> first.</div>")
+        return _page("Focus 5", body, wide=True)
+
+    data = summarize_focus5(db)
+    # Lazy bootstrap: first visit has an empty roster, so build it once on load.
+    # (The full 24h-TTL recompute + manual refresh button land in Phase 3.)
+    if not data["roster"]:
+        try:
+            sync_focus5(db)
+            data = summarize_focus5(db)
+        except Exception:  # noqa: BLE001 — a scan failure must not 500 the page
+            pass
+
+    return _page("Focus 5", _focus5_body(data), wide=True)
 
 
 @app.get("/auth-log", response_class=HTMLResponse)

--- a/tests/test_ask_self_scan.py
+++ b/tests/test_ask_self_scan.py
@@ -1,0 +1,213 @@
+"""Tests for the ask_self device-local index collector (spike)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+from rebalance.ingest.ask_self_scan import (
+    derive_repo_full_name,
+    iter_repo_harnesses,
+    sync_ask_self_indexes,
+    summarize_ask_self_indexes,
+)
+
+
+def _make_ask_self_repo(
+    root: Path,
+    name: str,
+    *,
+    remote_url: str | None = "https://github.com/Acme/widget.git",
+    head_sha: str = "abc123",
+    total_chunks: int = 42,
+    build_index: bool = True,
+    github_owner: str | None = "Acme",
+    github_repo: str | None = "widget",
+) -> Path:
+    """Create a fake ask_self repo under *root*; return its repo root."""
+    repo = root / name
+    (repo / "ask_self" / "index").mkdir(parents=True, exist_ok=True)
+
+    harness: dict = {
+        "repo_label": name,
+        "repo_kind": "python-repo",
+        "db_path": "ask_self/index/idx.sqlite",
+    }
+    if github_owner and github_repo:
+        harness["github"] = {"owner": github_owner, "repo": github_repo}
+    (repo / "ask_self" / "ask_self_harness.json").write_text(
+        json.dumps(harness), encoding="utf-8"
+    )
+
+    if build_index:
+        idx = repo / "ask_self" / "index" / "idx.sqlite"
+        conn = sqlite3.connect(str(idx))
+        conn.execute("DROP TABLE IF EXISTS repo_metadata")
+        conn.execute(
+            """
+            CREATE TABLE repo_metadata (
+                slug TEXT, repo_label TEXT, repo_kind TEXT, branch TEXT,
+                head_sha TEXT, last_commit_at TEXT, remote_url TEXT,
+                file_count INTEGER, loc_total INTEGER, repo_size_bytes INTEGER,
+                ingested_at TEXT, embed_model TEXT, embed_dim INTEGER,
+                total_chunks INTEGER, harness_config_path TEXT
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO repo_metadata VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+            (
+                name.lower(), name, "python-repo", "main", head_sha,
+                "2026-06-01T00:00:00Z", remote_url, 100, 5000, 999,
+                "2026-06-01T03:00:00Z", "Qwen/Qwen3-Embedding-0.6B", 1024,
+                total_chunks, str(repo / "ask_self" / "ask_self_harness.json"),
+            ),
+        )
+        conn.commit()
+        conn.close()
+    return repo
+
+
+class DeriveRepoFullNameTests(unittest.TestCase):
+    def test_https(self) -> None:
+        self.assertEqual(
+            derive_repo_full_name("https://github.com/Owner/Repo.git"), "Owner/Repo"
+        )
+
+    def test_https_no_suffix(self) -> None:
+        self.assertEqual(
+            derive_repo_full_name("https://github.com/Owner/Repo"), "Owner/Repo"
+        )
+
+    def test_ssh_scp_form(self) -> None:
+        self.assertEqual(
+            derive_repo_full_name("git@github.com:Owner/Repo.git"), "Owner/Repo"
+        )
+
+    def test_preserves_casing(self) -> None:
+        self.assertEqual(
+            derive_repo_full_name("https://github.com/Hypercart-Dev-Tools/rebalance-OS.git"),
+            "Hypercart-Dev-Tools/rebalance-OS",
+        )
+
+    def test_none_and_garbage(self) -> None:
+        self.assertIsNone(derive_repo_full_name(None))
+        self.assertIsNone(derive_repo_full_name(""))
+        self.assertIsNone(derive_repo_full_name("not-a-url"))
+
+
+class ScannerTests(unittest.TestCase):
+    def test_finds_harness_and_dedupes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _make_ask_self_repo(root, "alpha")
+            _make_ask_self_repo(root / "nested", "beta", build_index=False)
+            # Noise that must be pruned, not descended into.
+            (root / "node_modules" / "junk").mkdir(parents=True)
+
+            found = dict(iter_repo_harnesses([root]))
+            found_names = sorted(p.name for p in found)
+            self.assertEqual(found_names, ["alpha", "beta"])
+            # Overlapping roots should not double-yield.
+            twice = list(iter_repo_harnesses([root, root / "nested"]))
+            self.assertEqual(len({rp for rp, _ in twice}), 2)
+
+
+class SyncTests(unittest.TestCase):
+    def _db(self, tmp: Path) -> Path:
+        # A bare file is enough; sync_ask_self_indexes runs migrations itself.
+        db = tmp / "rebalance.db"
+        sqlite3.connect(str(db)).close()
+        return db
+
+    def test_sync_upserts_and_bridges_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repos"
+            root.mkdir()
+            _make_ask_self_repo(root, "widget")
+            db = self._db(Path(tmp))
+
+            result = sync_ask_self_indexes(db, roots=[root], device_id="testdev")
+            self.assertEqual(result.found, 1)
+            self.assertEqual(result.inserted, 1)
+
+            rows = summarize_ask_self_indexes(db)["indexes"]
+            self.assertEqual(len(rows), 1)
+            row = rows[0]
+            # remote_url (https://github.com/Acme/widget.git) -> owner/repo bridge
+            self.assertEqual(row["repo_full_name"], "Acme/widget")
+            self.assertTrue(row["index_built"])
+            self.assertEqual(row["total_chunks"], 42)
+            self.assertEqual(row["device_id"], "testdev")
+
+    def test_resync_is_unchanged_then_updated(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repos"
+            root.mkdir()
+            _make_ask_self_repo(root, "widget", head_sha="sha1")
+            db = self._db(Path(tmp))
+
+            sync_ask_self_indexes(db, roots=[root], device_id="testdev")
+            again = sync_ask_self_indexes(db, roots=[root], device_id="testdev")
+            self.assertEqual(again.unchanged, 1)
+            self.assertEqual(again.updated, 0)
+
+            # Re-ingest moved the head SHA -> the row is "updated", not duplicated.
+            _make_ask_self_repo(root, "widget", head_sha="sha2", total_chunks=99)
+            third = sync_ask_self_indexes(db, roots=[root], device_id="testdev")
+            self.assertEqual(third.updated, 1)
+            self.assertEqual(third.inserted, 0)
+            rows = summarize_ask_self_indexes(db)["indexes"]
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0]["head_sha"], "sha2")
+
+    def test_harness_without_index_is_recorded_unbuilt(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repos"
+            root.mkdir()
+            _make_ask_self_repo(
+                root, "skeleton", build_index=False,
+                github_owner="Acme", github_repo="skeleton",
+            )
+            db = self._db(Path(tmp))
+
+            sync_ask_self_indexes(db, roots=[root], device_id="testdev")
+            row = summarize_ask_self_indexes(db)["indexes"][0]
+            self.assertFalse(row["index_built"])
+            # Falls back to harness github.owner/repo when no index/remote exists.
+            self.assertEqual(row["repo_full_name"], "Acme/skeleton")
+
+    def test_watched_join(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repos"
+            root.mkdir()
+            _make_ask_self_repo(root, "widget")  # remote -> Acme/widget
+            db = self._db(Path(tmp))
+
+            # Make Acme/widget "watched" via the pushed-repos discovery source.
+            now = datetime.now(timezone.utc).isoformat()
+            conn = sqlite3.connect(str(db))
+            from rebalance.ingest.db import run_migrations
+            run_migrations(conn)
+            conn.execute(
+                "INSERT INTO github_pushed_repos "
+                "(repo_full_name, pushed_at, first_seen_at, last_seen_at) VALUES (?,?,?,?)",
+                ("Acme/widget", now, now, now),
+            )
+            conn.commit()
+            conn.close()
+
+            sync_ask_self_indexes(db, roots=[root], device_id="testdev")
+            out = summarize_ask_self_indexes(db)
+            self.assertTrue(out["indexes"][0]["watched"])
+            self.assertEqual(out["summary"]["watched"], 1)
+            self.assertEqual(out["summary"]["built"], 1)
+            self.assertEqual(out["summary"]["devices"], ["testdev"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_focus5_scan.py
+++ b/tests/test_focus5_scan.py
@@ -1,0 +1,337 @@
+"""Tests for the Focus 5 device-local collector (rebalance.ingest.focus5_scan).
+
+Split by what each layer needs:
+  - ranking + status parsing are PURE — unit-tested with hand-built inputs so
+    the dirty-first vs my_work vs any_touch behavior (and mode switching) is
+    proven without touching git or the disk.
+  - discovery / probe / sync / summarize need real git, so they run against
+    throwaway temp repos.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+from rebalance.ingest.focus5_scan import (
+    RepoSignals,
+    _parse_status,
+    iter_git_repos,
+    probe_repo_signals,
+    rank_repos,
+    resolve_ranking_strategy,
+    summarize_focus5,
+    sync_focus5,
+)
+
+NOW = 1_700_000_000  # fixed "now" epoch for deterministic recency math
+HOUR = 3600
+DAY = 86400
+
+
+def _sig(name: str, **over) -> RepoSignals:
+    """Build a RepoSignals with sensible clean-repo defaults; override per test."""
+    base = dict(
+        device_id="dev", local_path=f"/repos/{name}", repo_name=name,
+        repo_full_name=None, branch="main", upstream=None, has_upstream=False,
+        ahead=0, behind=0, modified_count=0, untracked_count=0, is_dirty=False,
+        last_commit_at=None, last_commit_ts=None, my_last_commit_ts=None,
+        head_reflog_ts=None, index_mtime_ts=None, remote_url=None,
+        probed_at="2026-06-05T00:00:00Z",
+    )
+    base.update(over)
+    return RepoSignals(**base)
+
+
+# ---------------------------------------------------------------------------
+# Pure: status parsing
+# ---------------------------------------------------------------------------
+
+class ParseStatusTests(unittest.TestCase):
+    def test_clean_with_upstream(self) -> None:
+        out = (
+            "# branch.oid abc\n# branch.head main\n"
+            "# branch.upstream origin/main\n# branch.ab +0 -0\n"
+        )
+        h = _parse_status(out)
+        self.assertEqual(h["branch"], "main")
+        self.assertTrue(h["has_upstream"])
+        self.assertEqual((h["ahead"], h["behind"]), (0, 0))
+        self.assertFalse(h["is_dirty"])
+
+    def test_dirty_counts_modified_and_untracked(self) -> None:
+        out = (
+            "# branch.head main\n"
+            "1 .M N... 100644 100644 100644 aaa bbb file_a\n"
+            "2 R. N... 100644 100644 100644 ccc ddd R100 new old\n"
+            "? untracked.txt\n? another.txt\n"
+        )
+        h = _parse_status(out)
+        self.assertEqual(h["modified_count"], 2)   # the "1 " and "2 " lines
+        self.assertEqual(h["untracked_count"], 2)  # the two "? " lines
+        self.assertTrue(h["is_dirty"])
+
+    def test_ahead_behind(self) -> None:
+        out = "# branch.head main\n# branch.upstream origin/main\n# branch.ab +3 -7\n"
+        h = _parse_status(out)
+        self.assertEqual((h["ahead"], h["behind"]), (3, 7))
+
+    def test_detached_and_no_upstream(self) -> None:
+        h = _parse_status("# branch.head (detached)\n")
+        self.assertIsNone(h["branch"])
+        self.assertFalse(h["has_upstream"])
+
+    def test_empty_output_is_safe_default(self) -> None:
+        h = _parse_status("")  # git failure path → all defaults
+        self.assertFalse(h["is_dirty"])
+        self.assertIsNone(h["branch"])
+
+
+# ---------------------------------------------------------------------------
+# Pure: ranking strategies + the swappable seam
+# ---------------------------------------------------------------------------
+
+class RankingTests(unittest.TestCase):
+    def test_dirty_first_forces_wip_above_newer_clean(self) -> None:
+        # A clean repo I committed to 1h ago vs my dirty repo last committed 5d ago.
+        clean = _sig("clean", my_last_commit_ts=NOW - HOUR)
+        dirty = _sig("dirty", is_dirty=True, modified_count=3,
+                     my_last_commit_ts=NOW - 5 * DAY)
+        ranked = rank_repos([clean, dirty], mode="dirty_first", now_ts=NOW)
+        self.assertEqual([r.signals.repo_name for r in ranked], ["dirty", "clean"])
+        self.assertIn("modified", ranked[0].reason)
+
+    def test_my_work_excludes_never_committed_clean_clone(self) -> None:
+        # Dormant third-party clone: someone else's recent commit, none of mine,
+        # clean tree. The spike's failure case — must NOT be eligible.
+        clone = _sig("vendor_clone", last_commit_ts=NOW - HOUR, my_last_commit_ts=None)
+        mine = _sig("mine", my_last_commit_ts=NOW - 2 * DAY)
+        ranked = rank_repos([clone, mine], mode="my_work", now_ts=NOW)
+        self.assertEqual([r.signals.repo_name for r in ranked], ["mine"])
+
+    def test_any_touch_includes_everything(self) -> None:
+        clone = _sig("vendor_clone", index_mtime_ts=NOW, my_last_commit_ts=None)
+        mine = _sig("mine", my_last_commit_ts=NOW - 2 * DAY)
+        ranked = rank_repos([clone, mine], mode="any_touch", now_ts=NOW)
+        names = {r.signals.repo_name for r in ranked}
+        self.assertEqual(names, {"vendor_clone", "mine"})
+        # index-mtime activity dominates under the (noisy) any_touch mode.
+        self.assertEqual(ranked[0].signals.repo_name, "vendor_clone")
+
+    def test_mode_switch_reranks_same_signals(self) -> None:
+        # Same inputs, different mode → different roster. Proves the seam.
+        signals = [
+            _sig("vendor_clone", index_mtime_ts=NOW, last_commit_ts=NOW - HOUR),
+            _sig("wip", is_dirty=True, my_last_commit_ts=NOW - 3 * DAY),
+        ]
+        top_dirty = rank_repos(signals, mode="dirty_first", now_ts=NOW)[0]
+        top_touch = rank_repos(signals, mode="any_touch", now_ts=NOW)[0]
+        self.assertEqual(top_dirty.signals.repo_name, "wip")
+        self.assertEqual(top_touch.signals.repo_name, "vendor_clone")
+
+    def test_unknown_mode_raises_with_valid_set(self) -> None:
+        with self.assertRaises(ValueError) as ctx:
+            resolve_ranking_strategy("bogus")
+        self.assertIn("dirty_first", str(ctx.exception))
+
+    def test_limit_caps_roster(self) -> None:
+        sigs = [_sig(f"r{i}", is_dirty=True, my_last_commit_ts=NOW - i * HOUR)
+                for i in range(8)]
+        self.assertEqual(len(rank_repos(sigs, mode="dirty_first", now_ts=NOW, limit=5)), 5)
+
+
+# ---------------------------------------------------------------------------
+# Real git helpers
+# ---------------------------------------------------------------------------
+
+def _run(cwd: Path, *args: str, env: dict | None = None) -> None:
+    subprocess.run(args, cwd=cwd, check=True, capture_output=True, text=True, env=env)
+
+
+def _make_git_repo(
+    root: Path, name: str, *, user_email: str = "me@example.com",
+    author_email: str | None = None, commit: bool = True,
+    dirty: bool = False, untracked: bool = False,
+) -> Path:
+    """Create a real git repo under *root*. author_email defaults to user_email."""
+    repo = root / name
+    repo.mkdir(parents=True)
+    _run(repo, "git", "init", "-q", "-b", "main")
+    _run(repo, "git", "config", "user.email", user_email)
+    _run(repo, "git", "config", "user.name", "Test User")
+    if commit:
+        (repo / "file.txt").write_text("hello", encoding="utf-8")
+        _run(repo, "git", "add", ".")
+        ae = author_email or user_email
+        env = {
+            **os.environ,
+            "GIT_AUTHOR_EMAIL": ae, "GIT_AUTHOR_NAME": "Author",
+            "GIT_COMMITTER_EMAIL": user_email, "GIT_COMMITTER_NAME": "Committer",
+        }
+        _run(repo, "git", "commit", "-q", "-m", "init", env=env)
+    if dirty:
+        (repo / "file.txt").write_text("changed", encoding="utf-8")
+    if untracked:
+        (repo / "untracked.txt").write_text("new", encoding="utf-8")
+    return repo
+
+
+def _db(tmp: Path) -> Path:
+    db = tmp / "rebalance.db"
+    sqlite3.connect(str(db)).close()
+    return db
+
+
+# ---------------------------------------------------------------------------
+# Real git: discovery
+# ---------------------------------------------------------------------------
+
+class DiscoveryTests(unittest.TestCase):
+    def test_finds_repos_prunes_noise_and_stops_at_boundary(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _make_git_repo(root, "alpha")
+            _make_git_repo(root / "nested", "beta")
+            # Noise that must be pruned, not descended into.
+            (root / "node_modules" / "junk").mkdir(parents=True)
+            # A repo checked out *inside* alpha's tree must NOT be yielded
+            # separately (we stop at the first repo boundary).
+            _make_git_repo(root / "alpha", "vendored")
+
+            found = sorted(p.name for p in iter_git_repos([root]))
+            self.assertEqual(found, ["alpha", "beta"])
+
+    def test_overlapping_roots_dedupe(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _make_git_repo(root / "nested", "beta")
+            twice = list(iter_git_repos([root, root / "nested"]))
+            self.assertEqual(len({p for p in twice}), 1)
+
+
+# ---------------------------------------------------------------------------
+# Real git: probe signals
+# ---------------------------------------------------------------------------
+
+class ProbeTests(unittest.TestCase):
+    def test_probe_reads_dirty_and_my_commit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = _make_git_repo(Path(tmp), "wip", dirty=True, untracked=True)
+            s = probe_repo_signals(repo, device_id="dev", probed_at="t")
+            self.assertEqual(s.branch, "main")
+            self.assertTrue(s.is_dirty)
+            self.assertEqual(s.modified_count, 1)
+            self.assertEqual(s.untracked_count, 1)
+            self.assertIsNotNone(s.my_last_commit_ts)  # I authored the commit
+            self.assertIsNotNone(s.last_commit_ts)
+
+    def test_probe_distinguishes_foreign_author(self) -> None:
+        # Commit authored by someone else → my_last_commit_ts stays None, so the
+        # repo is only eligible when dirty. This is the identity-matching guard.
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = _make_git_repo(
+                Path(tmp), "clone", user_email="me@example.com",
+                author_email="someoneelse@upstream.com",
+            )
+            s = probe_repo_signals(repo, device_id="dev", probed_at="t")
+            self.assertIsNotNone(s.last_commit_ts)     # a commit exists
+            self.assertIsNone(s.my_last_commit_ts)     # but not authored by me
+
+    def test_probe_on_non_repo_is_safe(self) -> None:
+        # A `.git` that isn't a real repo (git failure path): no crash, defaults.
+        with tempfile.TemporaryDirectory() as tmp:
+            bogus = Path(tmp) / "broken"
+            (bogus / ".git").mkdir(parents=True)
+            s = probe_repo_signals(bogus, device_id="dev", probed_at="t")
+            self.assertFalse(s.is_dirty)
+            self.assertIsNone(s.branch)
+            self.assertIsNone(s.my_last_commit_ts)
+
+
+# ---------------------------------------------------------------------------
+# Real git: sync + summarize (the read contract)
+# ---------------------------------------------------------------------------
+
+class SyncSummarizeTests(unittest.TestCase):
+    def test_sync_ranks_persists_and_surfaces_off_roster(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repos"
+            root.mkdir()
+            _make_git_repo(root, "wip", dirty=True)      # at-risk → roster
+            _make_git_repo(root, "also_dirty", untracked=True)  # at-risk, off-roster (limit=1)
+            db = _db(Path(tmp))
+
+            result = sync_focus5(
+                db, roots=[root], device_id="dev", mode="dirty_first", limit=1,
+            )
+            self.assertEqual(result.discovered, 2)
+            self.assertEqual(result.roster_size, 1)
+            self.assertEqual(result.ranking_mode, "dirty_first")
+
+            out = summarize_focus5(db, device_id="dev")
+            self.assertEqual(len(out["roster"]), 1)
+            self.assertEqual(out["roster"][0]["repo_name"], "wip")
+            self.assertTrue(out["roster"][0]["is_dirty"])
+            self.assertIsNone(out["roster"][0]["newest_pr"])  # no corpus row
+            # The second dirty repo is squeezed out of the top-1 but still warned.
+            warned = {w["repo_name"] for w in out["off_roster_warnings"]}
+            self.assertIn("also_dirty", warned)
+            self.assertEqual(out["summary"]["discovered"], 2)
+
+    def test_resync_replaces_roster_without_duplicates(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repos"
+            root.mkdir()
+            _make_git_repo(root, "wip", dirty=True)
+            db = _db(Path(tmp))
+            sync_focus5(db, roots=[root], device_id="dev", mode="dirty_first")
+            sync_focus5(db, roots=[root], device_id="dev", mode="dirty_first")
+            out = summarize_focus5(db, device_id="dev")
+            self.assertEqual(len(out["roster"]), 1)  # not duplicated on re-sync
+
+    def test_newest_pr_enrichment_joins_corpus(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repos"
+            root.mkdir()
+            repo = _make_git_repo(root, "widget", dirty=True)
+            _run(repo, "git", "remote", "add", "origin",
+                 "https://github.com/Acme/widget.git")
+            db = _db(Path(tmp))
+            sync_focus5(db, roots=[root], device_id="dev", mode="dirty_first")
+
+            # Seed a PR in the GitHub corpus for Acme/widget.
+            conn = sqlite3.connect(str(db))
+            conn.row_factory = sqlite3.Row
+            from rebalance.ingest.db import run_migrations
+            run_migrations(conn)
+            now = datetime.now(timezone.utc).isoformat()
+            conn.execute(
+                "INSERT INTO github_items "
+                "(repo_full_name, item_type, number, title, state, html_url, fetched_at) "
+                "VALUES (?,?,?,?,?,?,?)",
+                ("Acme/widget", "pull_request", 42, "Add thing", "open",
+                 "https://github.com/Acme/widget/pull/42", now),
+            )
+            conn.commit()
+            conn.close()
+
+            out = summarize_focus5(db, device_id="dev")
+            pr = out["roster"][0]["newest_pr"]
+            self.assertIsNotNone(pr)
+            self.assertEqual(pr["number"], 42)
+            self.assertEqual(pr["title"], "Add thing")
+
+    def test_summarize_empty_db_is_safe(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            db = _db(Path(tmp))
+            out = summarize_focus5(db, device_id="dev")
+            self.assertEqual(out["roster"], [])
+            self.assertEqual(out["summary"]["discovered"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_focus5_scan.py
+++ b/tests/test_focus5_scan.py
@@ -23,9 +23,11 @@ from rebalance.ingest.focus5_scan import (
     iter_git_repos,
     probe_repo_signals,
     rank_repos,
+    recent_activity,
     resolve_ranking_strategy,
     summarize_focus5,
     sync_focus5,
+    vscode_url,
 )
 
 NOW = 1_700_000_000  # fixed "now" epoch for deterministic recency math
@@ -273,13 +275,16 @@ class SyncSummarizeTests(unittest.TestCase):
             self.assertEqual(result.ranking_mode, "dirty_first")
 
             out = summarize_focus5(db, device_id="dev")
+            # Both repos are dirty (tier-1); which one wins the single slot depends
+            # on commit recency, so assert the partition invariant rather than a
+            # specific winner: exactly one rostered, the other warned, no overlap.
             self.assertEqual(len(out["roster"]), 1)
-            self.assertEqual(out["roster"][0]["repo_name"], "wip")
             self.assertTrue(out["roster"][0]["is_dirty"])
             self.assertIsNone(out["roster"][0]["newest_pr"])  # no corpus row
-            # The second dirty repo is squeezed out of the top-1 but still warned.
+            rostered = {c["repo_name"] for c in out["roster"]}
             warned = {w["repo_name"] for w in out["off_roster_warnings"]}
-            self.assertIn("also_dirty", warned)
+            self.assertEqual(rostered | warned, {"wip", "also_dirty"})  # both surfaced
+            self.assertEqual(rostered & warned, set())                  # never double-counted
             self.assertEqual(out["summary"]["discovered"], 2)
 
     def test_resync_replaces_roster_without_duplicates(self) -> None:
@@ -331,6 +336,84 @@ class SyncSummarizeTests(unittest.TestCase):
             out = summarize_focus5(db, device_id="dev")
             self.assertEqual(out["roster"], [])
             self.assertEqual(out["summary"]["discovered"], 0)
+
+    def test_card_carries_activity_and_vscode_link(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repos"
+            root.mkdir()
+            repo = _make_git_repo(root, "wip", dirty=True)
+            db = _db(Path(tmp))
+            sync_focus5(db, roots=[root], device_id="dev", mode="dirty_first")
+
+            card = summarize_focus5(db, device_id="dev")["roster"][0]
+            # iter_git_repos stores the resolved path (macOS /var -> /private/var).
+            self.assertEqual(card["vscode_url"], vscode_url(str(repo.resolve())))
+            self.assertTrue(card["vscode_url"].startswith("vscode://file"))
+            # The seeded repo has exactly one "init" commit.
+            self.assertEqual(len(card["recent_activity"]), 1)
+            self.assertEqual(card["recent_activity"][0]["subject"], "init")
+
+    def test_with_activity_false_skips_git_read(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repos"
+            root.mkdir()
+            _make_git_repo(root, "wip", dirty=True)
+            db = _db(Path(tmp))
+            sync_focus5(db, roots=[root], device_id="dev", mode="dirty_first")
+            card = summarize_focus5(db, device_id="dev", with_activity=False)["roster"][0]
+            self.assertEqual(card["recent_activity"], [])
+
+
+class ReadHelperTests(unittest.TestCase):
+    def test_recent_activity_orders_newest_first(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = _make_git_repo(Path(tmp), "r")  # commit "init"
+            (repo / "f2.txt").write_text("two", encoding="utf-8")
+            _run(repo, "git", "add", ".")
+            env = {
+                **os.environ,
+                "GIT_AUTHOR_EMAIL": "me@example.com", "GIT_AUTHOR_NAME": "A",
+                "GIT_COMMITTER_EMAIL": "me@example.com", "GIT_COMMITTER_NAME": "A",
+            }
+            _run(repo, "git", "commit", "-q", "-m", "second", env=env)
+            items = recent_activity(str(repo), limit=3)
+            self.assertEqual([i["subject"] for i in items], ["second", "init"])
+
+    def test_recent_activity_on_missing_repo_is_empty(self) -> None:
+        self.assertEqual(recent_activity("/no/such/repo"), [])
+
+    def test_vscode_url_encodes_spaces(self) -> None:
+        self.assertEqual(
+            vscode_url("/Users/me/My Repos/app"),
+            "vscode://file/Users/me/My%20Repos/app",
+        )
+
+
+class WebRouteTests(unittest.TestCase):
+    def test_focus5_route_renders_seeded_roster(self) -> None:
+        # End-to-end: seed a roster, point REBALANCE_DB at it, hit the route.
+        # Pre-seeding keeps the route's lazy bootstrap from scanning the machine.
+        from rebalance.ingest.sync_snapshot import get_device_id
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repos"
+            root.mkdir()
+            _make_git_repo(root, "widget", dirty=True)
+            db = _db(Path(tmp))
+            sync_focus5(db, roots=[root], device_id=get_device_id(), mode="dirty_first")
+
+            os.environ["REBALANCE_DB"] = str(db)
+            try:
+                from fastapi.testclient import TestClient
+                from rebalance.web import app
+                resp = TestClient(app).get("/focus-5")
+            finally:
+                os.environ.pop("REBALANCE_DB", None)
+
+            self.assertEqual(resp.status_code, 200)
+            self.assertIn("widget", resp.text)
+            self.assertIn("Focus 5", resp.text)
+            self.assertIn("vscode://file", resp.text)
+            self.assertIn("f5-grid", resp.text)
 
 
 if __name__ == "__main__":

--- a/tests/test_focus5_scan.py
+++ b/tests/test_focus5_scan.py
@@ -14,13 +14,17 @@ import sqlite3
 import subprocess
 import tempfile
 import unittest
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
+
+from unittest import mock
 
 from rebalance.ingest.focus5_scan import (
     RepoSignals,
     _parse_status,
+    get_roster_meta,
     iter_git_repos,
+    live_health,
     probe_repo_signals,
     rank_repos,
     recent_activity,
@@ -363,6 +367,25 @@ class SyncSummarizeTests(unittest.TestCase):
             card = summarize_focus5(db, device_id="dev", with_activity=False)["roster"][0]
             self.assertEqual(card["recent_activity"], [])
 
+    def test_live_health_overlay_reflects_post_sync_changes(self) -> None:
+        # Sync clean, then dirty the tree. The persisted snapshot says clean, but
+        # the live overlay must report the *current* dirty state + a fresh stamp.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repos"
+            root.mkdir()
+            repo = _make_git_repo(root, "wip")  # committed, clean
+            db = _db(Path(tmp))
+            sync_focus5(db, roots=[root], device_id="dev", mode="dirty_first")
+
+            snap = summarize_focus5(db, device_id="dev", with_live_health=False)["roster"][0]
+            self.assertFalse(snap["is_dirty"])  # snapshot was clean
+
+            (repo / "file.txt").write_text("changed now", encoding="utf-8")
+            live = summarize_focus5(db, device_id="dev", with_live_health=True)["roster"][0]
+            self.assertTrue(live["is_dirty"])            # overlay sees the new edit
+            self.assertTrue(live["health_available"])
+            self.assertIsNotNone(live["health_probed_at"])
+
 
 class ReadHelperTests(unittest.TestCase):
     def test_recent_activity_orders_newest_first(self) -> None:
@@ -387,6 +410,40 @@ class ReadHelperTests(unittest.TestCase):
             vscode_url("/Users/me/My Repos/app"),
             "vscode://file/Users/me/My%20Repos/app",
         )
+
+    def test_live_health_reads_current_tree(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = _make_git_repo(Path(tmp), "r", dirty=True, untracked=True)
+            h = live_health(str(repo))
+            self.assertTrue(h["health_available"])
+            self.assertTrue(h["is_dirty"])
+            self.assertEqual(h["branch"], "main")
+            self.assertIsNotNone(h["health_probed_at"])
+
+    def test_live_health_missing_repo_is_unavailable(self) -> None:
+        h = live_health("/no/such/repo")
+        self.assertFalse(h["health_available"])
+        self.assertIsNotNone(h["health_probed_at"])  # still stamped
+
+
+class RosterMetaTests(unittest.TestCase):
+    def test_empty_db_meta(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            meta = get_roster_meta(_db(Path(tmp)), device_id="dev")
+            self.assertEqual(meta["roster_size"], 0)
+            self.assertIsNone(meta["computed_at"])
+
+    def test_meta_after_sync(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repos"
+            root.mkdir()
+            _make_git_repo(root, "wip", dirty=True)
+            db = _db(Path(tmp))
+            sync_focus5(db, roots=[root], device_id="dev", mode="dirty_first")
+            meta = get_roster_meta(db, device_id="dev")
+            self.assertEqual(meta["roster_size"], 1)
+            self.assertEqual(meta["ranking_mode"], "dirty_first")
+            self.assertIsNotNone(meta["computed_at"])
 
 
 class WebRouteTests(unittest.TestCase):
@@ -414,6 +471,57 @@ class WebRouteTests(unittest.TestCase):
             self.assertIn("Focus 5", resp.text)
             self.assertIn("vscode://file", resp.text)
             self.assertIn("f5-grid", resp.text)
+
+    def _seed(self, tmp: Path):
+        """Seed a fresh single-repo roster; return (db, device_id)."""
+        from rebalance.ingest.sync_snapshot import get_device_id
+        root = tmp / "repos"
+        root.mkdir()
+        _make_git_repo(root, "widget", dirty=True)
+        db = _db(tmp)
+        dev = get_device_id()
+        sync_focus5(db, roots=[root], device_id=dev, mode="dirty_first")
+        return db, dev
+
+    def _get(self, db: Path, url: str = "/focus-5", **kw):
+        from fastapi.testclient import TestClient
+        from rebalance.web import app
+        os.environ["REBALANCE_DB"] = str(db)
+        try:
+            return TestClient(app).get(url, **kw)
+        finally:
+            os.environ.pop("REBALANCE_DB", None)
+
+    def test_manual_refresh_recomputes_then_redirects(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            db, _ = self._seed(Path(tmp))
+            # Patch the recompute so the forced refresh doesn't scan the machine.
+            with mock.patch("rebalance.ingest.focus5_scan.sync_focus5") as m:
+                resp = self._get(db, "/focus-5?refresh=1", follow_redirects=False)
+            self.assertEqual(resp.status_code, 303)          # post/redirect/get
+            self.assertEqual(resp.headers["location"], "/focus-5")
+            self.assertTrue(m.called)                        # recompute fired
+
+    def test_fresh_roster_skips_recompute(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            db, _ = self._seed(Path(tmp))  # computed_at = just now
+            with mock.patch("rebalance.ingest.focus5_scan.sync_focus5") as m:
+                resp = self._get(db)
+            self.assertEqual(resp.status_code, 200)
+            self.assertFalse(m.called)                       # within TTL → no scan
+
+    def test_stale_roster_triggers_recompute_on_visit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            db, dev = self._seed(Path(tmp))
+            # Age the snapshot past the 24h TTL.
+            old = (datetime.now(timezone.utc) - timedelta(days=2)).isoformat()
+            conn = sqlite3.connect(str(db))
+            conn.execute("UPDATE focus5_roster SET computed_at=? WHERE device_id=?", (old, dev))
+            conn.commit(); conn.close()
+            with mock.patch("rebalance.ingest.focus5_scan.sync_focus5") as m:
+                resp = self._get(db)
+            self.assertEqual(resp.status_code, 200)
+            self.assertTrue(m.called)                        # TTL expired → recompute
 
 
 if __name__ == "__main__":

--- a/tests/test_focus5_scan.py
+++ b/tests/test_focus5_scan.py
@@ -446,6 +446,43 @@ class RosterMetaTests(unittest.TestCase):
             self.assertIsNotNone(meta["computed_at"])
 
 
+class CollectorObservabilityTests(unittest.TestCase):
+    def test_sync_result_reports_timing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repos"
+            root.mkdir()
+            _make_git_repo(root, "wip", dirty=True)
+            db = _db(Path(tmp))
+            res = sync_focus5(db, roots=[root], device_id="dev", mode="dirty_first")
+            self.assertGreater(res.elapsed_seconds, 0.0)
+            self.assertEqual(res.failed_repos, 0)
+            self.assertIn("elapsed_seconds", res.as_dict())  # surfaced to refresh_index
+
+    def test_sync_logs_timing_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repos"
+            root.mkdir()
+            _make_git_repo(root, "wip", dirty=True)
+            db = _db(Path(tmp))
+            with self.assertLogs("rebalance.ingest.focus5_scan", level="INFO") as cm:
+                sync_focus5(db, roots=[root], device_id="dev", mode="dirty_first")
+            self.assertTrue(any("focus5 sync:" in line for line in cm.output))
+
+    def test_failed_git_probe_is_logged_and_counted(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repos"
+            root.mkdir()
+            _make_git_repo(root, "ok", dirty=True)
+            # A bogus repo: a `.git` dir that isn't a real git repo → status fails.
+            (root / "broken" / ".git").mkdir(parents=True)
+            db = _db(Path(tmp))
+            with self.assertLogs("rebalance.ingest.focus5_scan", level="WARNING") as cm:
+                res = sync_focus5(db, roots=[root], device_id="dev", mode="dirty_first")
+            self.assertEqual(res.discovered, 2)
+            self.assertEqual(res.failed_repos, 1)
+            self.assertTrue(any("git status failed" in line for line in cm.output))
+
+
 class WebRouteTests(unittest.TestCase):
     def test_focus5_route_renders_seeded_roster(self) -> None:
         # End-to-end: seed a roster, point REBALANCE_DB at it, hit the route.

--- a/tests/test_web_focus5.py
+++ b/tests/test_web_focus5.py
@@ -7,8 +7,13 @@ dict and assert the rendered HTML, with no DB or git. The full stack (collector
 from __future__ import annotations
 
 import unittest
+from datetime import datetime, timedelta, timezone
 
-from rebalance.web import _focus5_body, _rel_time
+from rebalance.web import _focus5_body, _rel_time, _roster_stale
+
+
+def _now_iso(**delta) -> str:
+    return (datetime.now(timezone.utc) - timedelta(**delta)).isoformat()
 
 
 def _card(**over) -> dict:
@@ -22,6 +27,7 @@ def _card(**over) -> dict:
         remote_url="https://github.com/Org/rebalance-OS.git",
         repo_full_name="Org/rebalance-OS",
         newest_pr=None, recent_activity=[],
+        health_available=True, health_probed_at=_now_iso(minutes=0),
     )
     base.update(over)
     return base
@@ -30,8 +36,9 @@ def _card(**over) -> dict:
 def _data(roster, **over) -> dict:
     d = dict(
         roster=roster, off_roster_warnings=[],
-        computed_at="2026-06-05T00:00:00+00:00", ranking_mode="dirty_first",
-        summary={"discovered": 21, "roster_size": len(roster), "off_roster_attention": 0},
+        computed_at=_now_iso(hours=1), ranking_mode="dirty_first",
+        summary={"discovered": 21, "roster_size": len(roster),
+                 "off_roster_attention": len(over.get("off_roster_warnings", []))},
     )
     d.update(over)
     return d
@@ -101,6 +108,56 @@ class FocusBodyTests(unittest.TestCase):
         body = _focus5_body(_data([card]))
         self.assertIn("clean", body)
         self.assertIn("your commit 1h ago", body)
+
+    def test_has_refresh_button_and_live_marker(self) -> None:
+        body = _focus5_body(_data([_card()]))
+        self.assertIn("/focus-5?refresh=1", body)          # manual refresh control
+        self.assertIn("tree health checked live", body)    # freshness marker
+
+    def test_fresh_roster_not_flagged_stale(self) -> None:
+        body = _focus5_body(_data([_card()], computed_at=_now_iso(hours=2)))
+        self.assertNotIn("⚠ stale", body)
+
+    def test_old_roster_flagged_stale(self) -> None:
+        body = _focus5_body(_data([_card()], computed_at=_now_iso(days=2)))
+        self.assertIn("⚠ stale", body)
+
+    def test_warning_strip_lists_off_roster_repos(self) -> None:
+        warns = [
+            {"repo_name": "side-proj", "local_path": "/x/side-proj", "repo_full_name": None,
+             "branch": "main", "ahead": 3, "modified_count": 0, "untracked_count": 0,
+             "is_dirty": False, "probed_at": _now_iso(hours=1)},
+            {"repo_name": "scratch", "local_path": "/x/scratch", "repo_full_name": None,
+             "branch": "main", "ahead": 0, "modified_count": 2, "untracked_count": 1,
+             "is_dirty": True, "probed_at": _now_iso(hours=1)},
+        ]
+        body = _focus5_body(_data([_card()], off_roster_warnings=warns))
+        self.assertIn("f5-warn", body)
+        self.assertIn("side-proj", body)
+        self.assertIn("3 unpushed", body)
+        self.assertIn("scratch", body)
+        self.assertIn("2 modified", body)
+
+    def test_no_warning_strip_when_all_clear(self) -> None:
+        body = _focus5_body(_data([_card()]))  # no off-roster warnings
+        self.assertNotIn("f5-warn", body)
+
+    def test_unavailable_health_renders_safely(self) -> None:
+        card = _card(health_available=False)
+        body = _focus5_body(_data([card]))
+        self.assertIn("unavailable", body)
+
+
+class RosterStaleTests(unittest.TestCase):
+    def test_missing_is_stale(self) -> None:
+        self.assertTrue(_roster_stale(None))
+        self.assertTrue(_roster_stale("not-a-date"))
+
+    def test_recent_is_fresh(self) -> None:
+        self.assertFalse(_roster_stale(_now_iso(hours=1)))
+
+    def test_old_is_stale(self) -> None:
+        self.assertTrue(_roster_stale(_now_iso(days=2)))
 
 
 class RelTimeTests(unittest.TestCase):

--- a/tests/test_web_focus5.py
+++ b/tests/test_web_focus5.py
@@ -1,0 +1,117 @@
+"""Tests for the Focus 5 web view renderer (rebalance.web._focus5_body).
+
+These are pure: they feed _focus5_body a hand-built summarize_focus5()-shaped
+dict and assert the rendered HTML, with no DB or git. The full stack (collector
+-> route) is covered by the TestClient case in test_focus5_scan.py.
+"""
+from __future__ import annotations
+
+import unittest
+
+from rebalance.web import _focus5_body, _rel_time
+
+
+def _card(**over) -> dict:
+    base = dict(
+        position=1, repo_name="rebalance-OS",
+        local_path="/Users/me/dev/rebalance-OS",
+        vscode_url="vscode://file/Users/me/dev/rebalance-OS",
+        rank_reason="5 modified, 7 untracked",
+        is_dirty=True, modified_count=5, untracked_count=7,
+        branch="development", has_upstream=True, ahead=2, behind=0,
+        remote_url="https://github.com/Org/rebalance-OS.git",
+        repo_full_name="Org/rebalance-OS",
+        newest_pr=None, recent_activity=[],
+    )
+    base.update(over)
+    return base
+
+
+def _data(roster, **over) -> dict:
+    d = dict(
+        roster=roster, off_roster_warnings=[],
+        computed_at="2026-06-05T00:00:00+00:00", ranking_mode="dirty_first",
+        summary={"discovered": 21, "roster_size": len(roster), "off_roster_attention": 0},
+    )
+    d.update(over)
+    return d
+
+
+class FocusBodyTests(unittest.TestCase):
+    def test_empty_roster_shows_guidance(self) -> None:
+        body = _focus5_body(_data([]))
+        self.assertIn("No active repos found", body)
+        self.assertNotIn("f5-grid", body)
+
+    def test_renders_card_with_vscode_link_and_health(self) -> None:
+        body = _focus5_body(_data([_card()]))
+        self.assertIn("f5-grid", body)
+        self.assertIn("rebalance-OS", body)
+        self.assertIn("vscode://file/Users/me/dev/rebalance-OS", body)  # Open in VS Code
+        self.assertIn("5 modified", body)
+        self.assertIn("development", body)         # branch
+        self.assertIn("↑2 ↓0", body)               # ahead/behind drift
+        self.assertIn("dirty_first", body)         # roster meta
+        self.assertIn("#1", body)                  # position
+
+    def test_renders_newest_pr_link(self) -> None:
+        card = _card(newest_pr={
+            "number": 54, "title": "Focus 5 Phase 1", "state": "open",
+            "html_url": "https://github.com/Org/rebalance-OS/pull/54",
+            "is_draft": False, "is_merged": False,
+        })
+        body = _focus5_body(_data([card]))
+        self.assertIn("#54", body)
+        self.assertIn("Focus 5 Phase 1", body)
+        self.assertIn("/pull/54", body)
+
+    def test_pr_fallback_states_are_explicit(self) -> None:
+        synced = _focus5_body(_data([_card(newest_pr=None, repo_full_name="Org/x")]))
+        self.assertIn("no open PR synced yet", synced)
+        nongh = _focus5_body(_data([_card(repo_full_name=None, remote_url="git@gitlab.com:x/y.git")]))
+        self.assertIn("non-GitHub remote", nongh)
+        local = _focus5_body(_data([_card(repo_full_name=None, remote_url=None)]))
+        self.assertIn("no remote configured", local)
+
+    def test_renders_recent_activity(self) -> None:
+        card = _card(recent_activity=[
+            {"sha": "abc1234", "subject": "feat: add thing",
+             "committed_at": "2026-06-05T00:00:00+00:00", "author_email": "me@x"},
+        ])
+        body = _focus5_body(_data([card]))
+        self.assertIn("feat: add thing", body)
+        self.assertIn("abc1234", body)
+
+    def test_html_is_escaped(self) -> None:
+        # A hostile PR title / commit subject must not inject markup.
+        card = _card(
+            newest_pr={"number": 1, "title": "<script>x</script>", "state": "open",
+                       "html_url": "https://h/pull/1", "is_draft": False, "is_merged": False},
+            recent_activity=[{"sha": "d", "subject": "<b>boom</b>",
+                              "committed_at": "2026-06-05T00:00:00+00:00", "author_email": "m"}],
+        )
+        body = _focus5_body(_data([card]))
+        self.assertNotIn("<script>x</script>", body)
+        self.assertIn("&lt;script&gt;", body)
+        self.assertNotIn("<b>boom</b>", body)
+
+    def test_clean_repo_shows_clean_health(self) -> None:
+        card = _card(is_dirty=False, modified_count=0, untracked_count=0,
+                     rank_reason="your commit 1h ago", ahead=0)
+        body = _focus5_body(_data([card]))
+        self.assertIn("clean", body)
+        self.assertIn("your commit 1h ago", body)
+
+
+class RelTimeTests(unittest.TestCase):
+    def test_handles_none_and_garbage(self) -> None:
+        self.assertEqual(_rel_time(None), "")
+        self.assertEqual(_rel_time("not-a-date"), "")
+
+    def test_formats_z_suffix(self) -> None:
+        # Should parse a trailing-Z timestamp without raising.
+        self.assertIsInstance(_rel_time("2026-06-05T00:00:00Z"), str)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Phase 0 spike + Phase 1 data layer for the **Focus 5** dashboard (`PROJECT/2-WORKING/FOCUS-5.md`), plus the **ask_self** device-local inventory that Focus 5 discovery is built on (bundled because focus5 reuses its scan-root/prune primitives and `derive_repo_full_name`).

## Phase 0 spike — caught a real ranking flaw before any code

Ran a read-only spike against the real machine. Discovery (95 ms / 21 repos), live git-health reads (~51 ms/repo), and the live-vs-cached split (full sweep ~1.2 s, top-5 ~256 ms) all validated. **One contradiction found and escalated:** ranking by `.git/index` mtime is invalid — it's bumped by `git clone`/`fetch`/`checkout`, so it surfaced dormant third-party clones (`shopify_python_api`, `hermes-agent` — never committed to) *above* the operator's own dirty WIP. Findings are recorded in the plan doc.

## Phase 1 — what's here

- **`focus5` collector** (`rebalance.ingest.focus5_scan`), registered opt-in (`included_in_all=False`) so it never slows the full refresh.
- **Bounded zero-config discovery** reusing the ask_self scan-root + prune pattern (`.git` marker); stops at repo boundaries, dedupes by resolved path.
- **Per-repo signal probe** via read-only git plumbing. Critically, "my commits" are matched against each repo's **own `user.email`**, not a hardcoded address (the operator commits under a GitHub noreply email — a hardcode would silently miss every commit).
- **Swappable ranking seam** — pure strategy functions (`dirty_first` default, `my_work`, `any_touch`) selected by the `focus5_ranking_mode` config key. **Raw signals are persisted, not a baked score**, so the roster can be re-ranked under a different mode *without re-probing git*. This is the seam that keeps a future mode change from being a refactor.
- **Migration `0003`** — `focus5_repo_signals` (also the off-roster warning cache) + `focus5_roster` (the TTL'd top-5 snapshot). `index_mtime_ts` is stored for diagnostics only, never ranked on.
- **`summarize_focus5()` read contract** — roster cards with newest-PR enrichment from the GitHub corpus (defensive: missing/unsynced/non-GitHub remotes yield `None`, never break the card) + off-roster attention warnings sourced from the cache.

## Verification

- **20 focus5 tests** + **35 neighbor tests** (ask_self, index_ops, config) green.
- Migration idempotent → schema v3, both tables created.
- Real end-to-end run with the fix: dirty `rebalance-OS` now ranks **#1**, the dormant clones are correctly dropped, and all dirty repos surface in the top 5 (nothing risky hidden).

## Decision recorded

Default ranking mode is **dirty-first** (surface uncommitted/unpushed work first), per owner decision, built as a swappable strategy so the mode can change via config alone.

## Scope note

Bundles in-progress ask_self work (`ask_self_scan.py`, migration `0002`, MCP wiring, `ASK-SELF-INVENTORY.md`) because Focus 5 depends on it — confirmed with the owner before bundling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)