### PR TITLE
Chat with your data — Phase 1 (hybrid FTS+RRF) + Phase 2 (native code corpus)

### DIFF
--- a/PROJECT/2-WORKING/CHAT-WITH-DATA.md
+++ b/PROJECT/2-WORKING/CHAT-WITH-DATA.md
@@ -19,7 +19,7 @@ non_goals: replacing ask(); a general chatbot; cloud inference; multi-user
 
 | ✅ Most recently completed | ▶️ What's next |
 |---|---|
-| **Phase 0 — Federation spike, complete** *(2026-06-05)*: `chat_with_data` ships (citations-first, RRF merge), wired to a dashboard **Filter\|Ask** search-bar switch via `POST /api/chat`. ask_self federation gated on availability (the mlx-embeddings gotcha → uses the rebalance venv). Eval (`scripts/chat_eval.py`, 10 questions): **federated 7/10 vs work-only 4/10**, ~2.1 s median, and federation surfaces *real code* (`index_ops.py`, `sleuth_reminders.py`) the work corpus never did. **Decision: federation is worth it.** | **Phase 1 — Hybrid retrieval**: add an FTS5 lexical index beside vec0 and fuse (RRF), to close the 3 exact-match misses (`auth_log`, `web.py`/`pulse_server`, `config`/keyring) that semantic-only ranking lost. |
+| **Phase 1 — Hybrid retrieval, built** *(2026-06-06)*: FTS5 lexical index (`semantic_documents_fts`) beside vec0, trigger-synced + version-guarded rebuild, fused with the vector ranking via RRF in `semantic_index.query(hybrid=True)`; exposed on `semantic_query`. 8 tests; 517 green. **Honest finding: hybrid did NOT move the code-question eval (work 4/10, federated 7/10, unchanged).** It can't — the *work* corpus has no code, and where it has relevant text the vector search already finds it. The infrastructure is correct and is the substrate Phase 2 needs. *(Earlier: Phase 0 federation spike — federated 7/10 vs 4/10, see scorecard.)* | **Phase 2 — Native code corpus**: index the source tree as `source_type="code"`; the now-working hybrid FTS then surfaces the exact files (`auth_log.py`, `web.py`, `config`) the eval misses — the wins Phase 1 couldn't deliver alone. |
 
 ## Table of Contents
 
@@ -108,12 +108,18 @@ work-only Ask stay snappy.
 Goal: stop losing exact-identifier questions. Add a lexical index beside the
 existing vec0 embeddings and fuse.
 
-- [ ] Add an FTS5 virtual table over `semantic_documents` (content + key metadata).
-- [ ] Keep FTS in sync with the existing incremental upsert/delete in `semantic_index` (same write path).
-- [ ] Implement RRF fusion of ANN results + FTS results in `query()` (flag-guarded; ANN-only remains the fallback).
-- [ ] Expose hybrid via `chat_with_data` and (behind a flag) `semantic_query`.
-- [ ] Regression eval: the subset of exact-match questions ANN-only fails (paths, class names, config keys, a pasted stack-trace line) — hybrid must beat ANN-only on these.
-- [ ] No latency regression beyond an agreed budget on the work corpus.
+- [x] Add an FTS5 table (`semantic_documents_fts`, standalone — title+body) over `semantic_documents`. (External-content variant was flaky on backfill; standalone is robust.)
+- [x] Keep FTS in sync via INSERT/UPDATE/DELETE triggers + a one-time backfill; **version-guarded rebuild** (`fts_version` in `semantic_embedding_meta`) drops/recreates a stale or incompatible FTS table.
+- [x] RRF fusion of ANN + FTS in `query(hybrid=True)`; ANN-only fallback when `hybrid=False` or FTS5/lexical-terms are unavailable. Query tokenizer aligned to FTS5 (underscores split).
+- [x] Exposed via `chat_with_data` (default) and the `semantic_query` MCP tool (`hybrid` flag).
+- [~] Regression eval: **hybrid did NOT beat ANN-only on the eval** (work 4/10, federated 7/10 — both unchanged; A/B on the real corpus ≈ identical). Root cause is corpus, not method: the work corpus contains no code, so lexical search can't surface `auth_log.py`/`web.py`; where relevant text exists, the vector ranking already covers it. → the exact-match wins require **Phase 2** (code in the corpus).
+- [x] No latency regression: work-corpus median ~37 ms (was ~32 ms); federated dominated by ask_self (~2 s).
+
+> **Phase 1 conclusion:** the hybrid infrastructure is correct, tested, and on by
+> default — but on its own it doesn't fix the code-question misses. It's the
+> substrate that makes Phase 2 pay off: once the source tree is indexed
+> (`source_type="code"`), the same FTS will surface exact identifiers/paths the
+> vector index alone ranks poorly.
 
 ## Phase 2 — Native code corpus (conditional)
 

--- a/PROJECT/2-WORKING/CHAT-WITH-DATA.md
+++ b/PROJECT/2-WORKING/CHAT-WITH-DATA.md
@@ -7,8 +7,8 @@ owner: noel
 tool_surface: chat_with_data(query, scope, top_k, skip_synthesis) — new MCP tool, NOT an extension of ask()
 depends_on: semantic_index (vec0 ANN), index_ops incremental refresh, semantic_query MCP tool, ask_self code/doc RAG
 phases: 0 spike · 1 hybrid retrieval · 2 native code corpus · 3 synthesis · 4 surface/UX
-phases_done: 0 (federation spike — 7/10 federated vs 4/10 work-only)
-phases_next: Phase 1 — Hybrid retrieval (FTS5 + vec, RRF) to close exact-match misses
+phases_done: 0 (federation 7/10) · 1 (hybrid FTS+RRF) · 2 (native code corpus — 10/10, native-only ~39ms)
+phases_next: Phase 3 (opt-in synthesis) / Phase 4 (surface & UX) — both optional; core retrieval is done
 decision_gates:
   - Phase 0 recall@k + latency → decide federate-vs-build-native
   - Phase 2 runs only if federation is insufficient or ask_self proves too fragile
@@ -19,7 +19,7 @@ non_goals: replacing ask(); a general chatbot; cloud inference; multi-user
 
 | ✅ Most recently completed | ▶️ What's next |
 |---|---|
-| **Phase 1 — Hybrid retrieval, built** *(2026-06-06)*: FTS5 lexical index (`semantic_documents_fts`) beside vec0, trigger-synced + version-guarded rebuild, fused with the vector ranking via RRF in `semantic_index.query(hybrid=True)`; exposed on `semantic_query`. 8 tests; 517 green. **Honest finding: hybrid did NOT move the code-question eval (work 4/10, federated 7/10, unchanged).** It can't — the *work* corpus has no code, and where it has relevant text the vector search already finds it. The infrastructure is correct and is the substrate Phase 2 needs. *(Earlier: Phase 0 federation spike — federated 7/10 vs 4/10, see scorecard.)* | **Phase 2 — Native code corpus**: index the source tree as `source_type="code"`; the now-working hybrid FTS then surfaces the exact files (`auth_log.py`, `web.py`, `config`) the eval misses — the wins Phase 1 couldn't deliver alone. |
+| **Phase 2 — Native code corpus, complete** *(2026-06-06)*: a code collector AST-chunks the source tree (957 chunks, indexed in **0.51 s**) into `source_type="code"`; the Phase 1 hybrid FTS surfaces it. **Result: recall@8 = 10/10** (was 7/10 federated, 4/10 work-only). And **native-only — no ask_self — also hits 10/10 at ~39 ms median** (~50× faster than the 2.1 s federation). So ask_self federation is now *optional*; the native corpus is faster, dependency-free, and stays fresh via the standard refresh. 523 tests green. *(Phase 0: federation 7/10. Phase 1: hybrid infra, no eval move alone.)* | **Phase 3 — Synthesis (opt-in)** and/or **Phase 4 — Surface/UX**: the dashboard `Ask` already benefits (scope=`all` now includes native code). Optional: grounded LLM synthesis on top of citations; `rebalance chat` CLI; clickable `path:symbol` citations. |
 
 ## Table of Contents
 
@@ -123,16 +123,21 @@ existing vec0 embeddings and fuse.
 
 ## Phase 2 — Native code corpus (conditional)
 
-Runs only if Phase 0 shows federation is insufficient, or ask_self proves too
-fragile to depend on.
+Built because Phase 1 showed the corpus (not the method) was the limiter.
 
-- [ ] Add `"code"` to the allowed `source_type` set in `semantic_index._normalize_sources`.
-- [ ] Code collector walks the local source tree; chunk by module / class / function.
-- [ ] Populate `metadata_json`: `path, language, symbol, parent_symbol, imports, git_sha`.
-- [ ] Wire incremental refresh into `index_ops` (mirrors vault/github: add/update/delete by source_pk).
-- [ ] Hybrid retrieval (Phase 1) covers code chunks too.
-- [ ] `chat_with_data(scope="code")` returns native results; ask_self federation becomes optional.
-- [ ] Eval: code-recall on the Phase-0 question set improves vs federation.
+- [x] Added `"code"` to the allowed `source_type` set (`_normalize_sources`) — opt-in, not in the default "all".
+- [x] Code collector (`code_collector.py`) walks `src/`+`scripts/`, AST-chunks Python by top-level function / class + a module header chunk.
+- [x] `metadata_json`: `path, symbol, parent_symbol, language, start_line`. Change detection by content-hash + file mtime (unchanged files stay `unchanged`).
+- [x] `sync_code_documents` wired into `backfill_semantic_documents(source_types=["code"])`; incremental upsert/delete by `source_pk` (`path::symbol`). FTS auto-syncs via triggers.
+- [x] Hybrid retrieval covers code chunks (FTS over title `path :: symbol` + body — no embeddings required for the lexical win).
+- [x] `chat_with_data` scope routing: `work`/`code`/`all` select native sources; ask_self added for `code`/`all` but **now optional**.
+- [x] **Eval: recall@8 = 10/10** (federated *and* native-only); native-only ~39 ms vs federated ~2.1 s. Closed the 3 misses (`auth_log`, `web.py`, `config`).
+- [~] *Follow-up:* code chunks are FTS-searchable immediately; embedding them (for the vector half) is optional and deferred — FTS alone already gets 10/10.
+
+> **Phase 2 conclusion:** the native code corpus is the decisive lever. Combined
+> with Phase 1's hybrid FTS it reaches 10/10 with no external dependency and at
+> ~50× lower latency than federation — so ask_self becomes a fallback, not a
+> requirement. The dashboard `Ask` (scope=`all`) inherits this for free.
 
 ## Phase 3 — Synthesis layer (opt-in)
 

--- a/src/rebalance/chat.py
+++ b/src/rebalance/chat.py
@@ -41,9 +41,23 @@ def _citation_from_semantic(row: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _default_work_query(database_path: Path, query: str, top_k: int) -> list[dict[str, Any]]:
+WORK_SOURCES = ("vault", "github", "email")
+
+
+def _semantic_sources_for_scope(scope: str) -> list[str]:
+    """Which native semantic_index source_types to query for a scope."""
+    if scope == "work":
+        return list(WORK_SOURCES)
+    if scope == "code":
+        return ["code"]
+    return [*WORK_SOURCES, "code"]  # all
+
+
+def _default_semantic_query(
+    database_path: Path, query: str, top_k: int, sources: list[str]
+) -> list[dict[str, Any]]:
     from rebalance.ingest.semantic_index import query as _q
-    return _q(database_path, query, top_k=top_k)
+    return _q(database_path, query, top_k=top_k, source_filter=sources)
 
 
 # ---------------------------------------------------------------------------
@@ -126,16 +140,20 @@ def chat_with_data(
     scope: str = "all",
     top_k: int = 8,
     skip_synthesis: bool = True,
-    work_query_fn: Callable[[Path, str, int], list[dict[str, Any]]] | None = None,
+    work_query_fn: Callable[[Path, str, int, list[str]], list[dict[str, Any]]] | None = None,
 ) -> dict[str, Any]:
     """Retrieve citations for *query* across the requested *scope*.
+
+    Scope selects native semantic_index sources — ``work`` (vault/github/email),
+    ``code`` (the indexed source tree), ``all`` (both) — and adds the federated
+    ask_self code/doc index for ``code``/``all`` when available.
 
     Returns a JSON-able dict:
         {query, scope, citations: [{source,title,path,preview,score,kind}],
          used_sources: [...], elapsed_ms, answer}
 
     ``answer`` is always None while ``skip_synthesis`` is True (Phase 0).
-    *work_query_fn* is an injection point for tests so they need no embed model.
+    *work_query_fn(db, query, top_k, sources)* is an injection point for tests.
     """
     start = time.monotonic()
     scope = (scope or "all").strip().lower()
@@ -151,13 +169,13 @@ def chat_with_data(
     used: list[str] = []
     result_lists: list[list[dict[str, Any]]] = []
 
-    # Native work corpus (vault / github / email): work + all.
-    if scope in ("all", "work"):
-        qfn = work_query_fn or _default_work_query
-        work = [_citation_from_semantic(r) for r in qfn(database_path, text, top_k)]
-        if work:
-            result_lists.append(work)
-            used.append("semantic_index")
+    # Native semantic index — scope picks the source_types (work / code / both).
+    qfn = work_query_fn or _default_semantic_query
+    sources = _semantic_sources_for_scope(scope)
+    native = [_citation_from_semantic(r) for r in qfn(database_path, text, top_k, sources)]
+    if native:
+        result_lists.append(native)
+        used.append("semantic_index")
 
     # Federated code/docs corpus via ask_self: code + all (gated on availability).
     if scope in ("all", "code") and ask_self_available():

--- a/src/rebalance/ingest/code_collector.py
+++ b/src/rebalance/ingest/code_collector.py
@@ -1,0 +1,100 @@
+"""Native code-corpus collector for the unified semantic index.
+
+Phase 2 of PROJECT/2-WORKING/CHAT-WITH-DATA.md. Walks the repo source tree and
+AST-chunks Python modules by top-level function and class (plus a module header
+chunk), yielding records that ``semantic_index.sync_code_documents`` upserts as
+``source_type="code"``. This gives the Phase 1 hybrid FTS real code to surface
+(``auth_log.py``, ``web.py``, …) that the work corpus never contained.
+
+Pure stdlib (``ast``) — no third-party parser. Non-Python files and files that
+fail to parse are skipped (they simply don't contribute chunks).
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Iterator
+
+DEFAULT_INCLUDE_DIRS = ("src", "scripts")
+SKIP_DIR_NAMES = frozenset({
+    ".venv", "venv", "node_modules", ".git", "__pycache__", "temp",
+    "build", "dist", ".mypy_cache", ".pytest_cache", ".ruff_cache",
+})
+
+
+@dataclass(frozen=True)
+class CodeChunk:
+    path: str          # repo-relative POSIX path
+    symbol: str        # function/class name, or "<module>"
+    parent_symbol: str
+    doc_kind: str      # function | class | module
+    language: str      # always "python" for now
+    body: str          # source segment
+    start_line: int
+    mtime_iso: str     # source file mtime (stable change key)
+
+
+def iter_python_files(
+    repo_root: Path, include_dirs: Iterable[str] = DEFAULT_INCLUDE_DIRS
+) -> Iterator[Path]:
+    for d in include_dirs:
+        base = repo_root / d
+        if not base.is_dir():
+            continue
+        for p in base.rglob("*.py"):
+            if any(part in SKIP_DIR_NAMES for part in p.parts):
+                continue
+            yield p
+
+
+def chunk_python_source(rel_path: str, source: str, mtime_iso: str) -> list[CodeChunk]:
+    """Chunk one module's source into function/class/module records."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+
+    chunks: list[CodeChunk] = []
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            segment = ast.get_source_segment(source, node) or ""
+            if not segment.strip():
+                continue
+            kind = "class" if isinstance(node, ast.ClassDef) else "function"
+            chunks.append(CodeChunk(
+                path=rel_path, symbol=node.name, parent_symbol="", doc_kind=kind,
+                language="python", body=segment, start_line=node.lineno, mtime_iso=mtime_iso,
+            ))
+
+    # Module header chunk: docstring + import lines — captures "what this file is".
+    doc = ast.get_docstring(tree) or ""
+    import_lines = [
+        ln for ln in source.splitlines()[:60]
+        if ln.startswith(("import ", "from "))
+    ]
+    header = "\n".join(filter(None, [doc, "\n".join(import_lines)])).strip()
+    if header:
+        chunks.append(CodeChunk(
+            path=rel_path, symbol="<module>", parent_symbol="", doc_kind="module",
+            language="python", body=header, start_line=1, mtime_iso=mtime_iso,
+        ))
+    return chunks
+
+
+def collect_code_chunks(
+    repo_root: Path, include_dirs: Iterable[str] = DEFAULT_INCLUDE_DIRS
+) -> list[CodeChunk]:
+    """Walk *repo_root* and return all code chunks under *include_dirs*."""
+    out: list[CodeChunk] = []
+    for p in iter_python_files(repo_root, include_dirs):
+        try:
+            source = p.read_text(encoding="utf-8")
+            mtime_iso = datetime.fromtimestamp(p.stat().st_mtime, tz=timezone.utc).isoformat()
+        except (OSError, UnicodeDecodeError):
+            continue
+        rel = p.relative_to(repo_root).as_posix()
+        out.extend(chunk_python_source(rel, source, mtime_iso))
+    return out

--- a/src/rebalance/ingest/db/schema.py
+++ b/src/rebalance/ingest/db/schema.py
@@ -139,6 +139,65 @@ def ensure_semantic_schema(conn: sqlite3.Connection) -> None:
             value   TEXT NOT NULL
         )
     """)
+
+    # Phase 1 hybrid retrieval: an FTS5 lexical index over title+body, beside the
+    # vec0 ANN index. A standalone FTS5 table (keeps its own copy of title+body —
+    # robust, vs the external-content variant whose backfill proved flaky here),
+    # kept in sync with semantic_documents by triggers and joined back on
+    # ``rowid = semantic_documents.id``. Fused with the vector ranking via RRF in
+    # semantic_index.query(). Degrades to ANN-only if FTS5 is unavailable.
+    # Bump FTS_VERSION to force a clean drop+rebuild of the FTS table on every DB
+    # (e.g. if its definition changes). Guards against a stale/incompatible FTS
+    # table that an older code path may have left with rows but an empty index.
+    FTS_VERSION = "1"
+    try:
+        _row = conn.execute(
+            "SELECT value FROM semantic_embedding_meta WHERE key='fts_version'"
+        ).fetchone()
+        if (_row[0] if _row else None) != FTS_VERSION:
+            conn.execute("DROP TABLE IF EXISTS semantic_documents_fts")
+            for _t in ("ai", "ad", "au"):
+                conn.execute(f"DROP TRIGGER IF EXISTS semantic_documents_fts_{_t}")
+        conn.execute(
+            "CREATE VIRTUAL TABLE IF NOT EXISTS semantic_documents_fts USING fts5(title, body)"
+        )
+        conn.execute("""
+            CREATE TRIGGER IF NOT EXISTS semantic_documents_fts_ai
+            AFTER INSERT ON semantic_documents BEGIN
+                INSERT INTO semantic_documents_fts(rowid, title, body)
+                VALUES (new.id, new.title, new.body);
+            END
+        """)
+        conn.execute("""
+            CREATE TRIGGER IF NOT EXISTS semantic_documents_fts_ad
+            AFTER DELETE ON semantic_documents BEGIN
+                DELETE FROM semantic_documents_fts WHERE rowid = old.id;
+            END
+        """)
+        conn.execute("""
+            CREATE TRIGGER IF NOT EXISTS semantic_documents_fts_au
+            AFTER UPDATE ON semantic_documents BEGIN
+                DELETE FROM semantic_documents_fts WHERE rowid = old.id;
+                INSERT INTO semantic_documents_fts(rowid, title, body)
+                VALUES (new.id, new.title, new.body);
+            END
+        """)
+        # One-time backfill for DBs that already had documents before the FTS
+        # table existed (triggers only catch writes from here on).
+        fts_n = conn.execute("SELECT count(*) FROM semantic_documents_fts").fetchone()[0]
+        doc_n = conn.execute("SELECT count(*) FROM semantic_documents").fetchone()[0]
+        if fts_n == 0 and doc_n > 0:
+            conn.execute(
+                "INSERT INTO semantic_documents_fts(rowid, title, body) "
+                "SELECT id, title, body FROM semantic_documents"
+            )
+        conn.execute(
+            "INSERT OR REPLACE INTO semantic_embedding_meta(key, value) VALUES('fts_version', ?)",
+            (FTS_VERSION,),
+        )
+    except sqlite3.DatabaseError:
+        pass  # FTS5 not compiled in — hybrid retrieval falls back to ANN-only
+
     conn.commit()
 
 

--- a/src/rebalance/ingest/db/semantic.py
+++ b/src/rebalance/ingest/db/semantic.py
@@ -7,6 +7,7 @@ source-table reads that feed the backfill. This module owns the column layout.
 
 from __future__ import annotations
 
+import re
 import sqlite3
 from typing import Sequence
 
@@ -466,3 +467,85 @@ def search_semantic_documents(
         """,
         params,
     ).fetchall()
+
+
+def _fts_match_query(query_text: str) -> str:
+    """Turn a natural-language query into a safe FTS5 MATCH expression.
+
+    Alphanumeric tokens (len ≥ 2), each double-quoted to neutralize FTS5 operator
+    syntax, OR-ed for recall. Underscores are split (matching FTS5's unicode61
+    tokenizer), so ``auth_log`` in the query becomes ``"auth" OR "log"`` and
+    matches the same tokens the content was indexed under.
+    """
+    tokens = re.findall(r"[A-Za-z0-9]{2,}", query_text or "")
+    if not tokens:
+        return ""
+    # de-dupe while preserving order, cap to keep the MATCH expression bounded
+    seen: dict[str, None] = {}
+    for t in tokens:
+        seen.setdefault(t.lower(), None)
+    return " OR ".join(f'"{t}"' for t in list(seen)[:24])
+
+
+def search_semantic_documents_fts(
+    conn: sqlite3.Connection,
+    query_text: str,
+    top_k: int,
+    source_types: Sequence[str],
+    *,
+    updated_after: str | None = None,
+    repo: str | None = None,
+) -> list[sqlite3.Row]:
+    """Lexical (FTS5) search over title+body, best (lowest bm25) first.
+
+    Same column shape as :func:`search_semantic_documents` so the two can be
+    fused uniformly — ``distance`` is NULL here; ``fts_rank`` carries the bm25
+    score. Returns ``[]`` if the query has no usable terms or FTS5 is missing.
+    """
+    match = _fts_match_query(query_text)
+    if not match:
+        return []
+
+    placeholders = ", ".join("?" for _ in source_types)
+    params: list = [match, *source_types]
+
+    extra_clauses = []
+    if updated_after:
+        extra_clauses.append("AND sd.updated_at >= ?")
+        params.append(updated_after)
+    if repo:
+        extra_clauses.append(
+            "AND (sd.source_type != 'github' OR "
+            "LOWER(JSON_EXTRACT(sd.metadata_json, '$.repo_full_name')) = LOWER(?))"
+        )
+        params.append(repo)
+    params.append(top_k)
+    extra_sql = "\n          ".join(extra_clauses)
+
+    try:
+        return conn.execute(
+            f"""
+            SELECT
+                sd.id AS doc_id,
+                NULL AS distance,
+                sd.source_type,
+                sd.source_table,
+                sd.source_pk,
+                sd.doc_kind,
+                sd.title,
+                SUBSTR(sd.body, 1, 400) AS body_preview,
+                sd.metadata_json,
+                sd.updated_at,
+                bm25(semantic_documents_fts) AS fts_rank
+            FROM semantic_documents_fts
+            JOIN semantic_documents sd ON sd.id = semantic_documents_fts.rowid
+            WHERE semantic_documents_fts MATCH ?
+              AND sd.source_type IN ({placeholders})
+              {extra_sql}
+            ORDER BY fts_rank
+            LIMIT ?
+            """,
+            params,
+        ).fetchall()
+    except sqlite3.DatabaseError:
+        return []  # FTS5 unavailable or malformed match → ANN-only upstream

--- a/src/rebalance/ingest/db/semantic.py
+++ b/src/rebalance/ingest/db/semantic.py
@@ -147,10 +147,13 @@ def delete_semantic_documents(
     conn: sqlite3.Connection, doc_ids: list[int]
 ) -> None:
     """Delete ``semantic_embeddings`` + ``semantic_documents`` rows for *doc_ids*."""
-    conn.executemany(
-        "DELETE FROM semantic_embeddings WHERE rowid = ?",
-        [(doc_id,) for doc_id in doc_ids],
-    )
+    try:
+        conn.executemany(
+            "DELETE FROM semantic_embeddings WHERE rowid = ?",
+            [(doc_id,) for doc_id in doc_ids],
+        )
+    except sqlite3.OperationalError:
+        pass  # vec0 unavailable (FTS-only / no sqlite-vec) — no embeddings to clear
     conn.executemany(
         "DELETE FROM semantic_documents WHERE id = ?",
         [(doc_id,) for doc_id in doc_ids],

--- a/src/rebalance/ingest/index_ops.py
+++ b/src/rebalance/ingest/index_ops.py
@@ -673,6 +673,33 @@ def _refresh_sleuth(database_path: Path, *, dry_run: bool) -> dict[str, Any]:
     return {"scope": "sleuth", "dry_run": False, **result.as_dict()}
 
 
+def _refresh_code(database_path: Path, *, dry_run: bool) -> dict[str, Any]:
+    """Refresh the native code corpus (source_type='code') from the source tree.
+
+    FTS-only: the AST collector + backfill keep ``semantic_documents`` and the
+    trigger-synced FTS index current. Embedding code chunks (the vector half) is
+    intentionally skipped here — the hybrid FTS already answers code questions,
+    and embedding ~1k chunks every refresh would be slow for little gain.
+    """
+    if dry_run:
+        return {"scope": "code", "dry_run": True, "steps": ["semantic_backfill(source=['code'])"]}
+
+    from rebalance.ingest.semantic_index import backfill_semantic_documents
+
+    backfill = backfill_semantic_documents(database_path, source_types=["code"])
+    return {
+        "scope": "code",
+        "dry_run": False,
+        "semantic_backfill": {
+            "total": backfill.total_documents,
+            "inserted": backfill.inserted_count,
+            "updated": backfill.updated_count,
+            "deleted": backfill.deleted_count,
+            "elapsed_seconds": backfill.elapsed_seconds,
+        },
+    }
+
+
 def _refresh_email(database_path: Path, *, dry_run: bool) -> dict[str, Any]:
     from rebalance.ingest.config import get_gmail_ingest_method
 
@@ -1002,6 +1029,10 @@ def _email_adapter(db_path: Path, **opts: Any) -> dict[str, Any]:
     return _refresh_email(db_path, dry_run=opts["dry_run"])
 
 
+def _code_adapter(db_path: Path, **opts: Any) -> dict[str, Any]:
+    return _refresh_code(db_path, dry_run=opts["dry_run"])
+
+
 def _semantic_adapter(db_path: Path, **opts: Any) -> dict[str, Any]:
     return _refresh_semantic_only(db_path, dry_run=opts["dry_run"])
 
@@ -1072,5 +1103,6 @@ register_collector(Collector("github", _github_adapter, requires=("github_token"
 register_collector(Collector("calendar", _calendar_adapter))
 register_collector(Collector("sleuth", _sleuth_adapter))
 register_collector(Collector("email", _email_adapter))
+register_collector(Collector("code", _code_adapter))
 register_collector(Collector("semantic", _semantic_adapter))
 register_collector(Collector("sync", _sync_adapter))

--- a/src/rebalance/ingest/semantic_index.py
+++ b/src/rebalance/ingest/semantic_index.py
@@ -73,7 +73,7 @@ def _normalize_sources(source_types: Iterable[str] | None) -> tuple[str, ...]:
             continue
         if item == "all":
             return ("vault", "github", "email")
-        if item not in {"vault", "github", "calendar", "sleuth", "email"}:
+        if item not in {"vault", "github", "calendar", "sleuth", "email", "code"}:
             raise ValueError(f"Unsupported source type: {value}")
         if item not in normalized:
             normalized.append(item)
@@ -330,13 +330,67 @@ def sync_email_documents(conn: Any) -> dict[str, int]:
     }
 
 
+def sync_code_documents(conn: Any, repo_root: Path) -> dict[str, int]:
+    """Backfill semantic documents from the local source tree (source_type='code').
+
+    Unlike the other syncs, the source is the *filesystem*, not a DB table — the
+    code collector walks ``repo_root`` and AST-chunks Python modules. Change
+    detection is by content hash + file mtime, so unchanged files stay
+    ``unchanged`` across runs (no needless re-embed).
+    """
+    ensure_semantic_schema(conn)
+    from rebalance.ingest.code_collector import collect_code_chunks
+
+    chunks = collect_code_chunks(Path(repo_root))
+    inserted = updated = unchanged = 0
+    seen_source_pks: set[str] = set()
+    for ch in chunks:
+        source_pk = f"{ch.path}::{ch.symbol}"
+        seen_source_pks.add(source_pk)
+        _, state = upsert_document(
+            conn,
+            source_type="code",
+            source_table="code",
+            source_pk=source_pk,
+            doc_kind=ch.doc_kind,
+            title=f"{ch.path} :: {ch.symbol}",
+            body=ch.body,
+            metadata={
+                "path": ch.path,
+                "symbol": ch.symbol,
+                "parent_symbol": ch.parent_symbol,
+                "language": ch.language,
+                "start_line": ch.start_line,
+            },
+            created_at=ch.mtime_iso,
+            updated_at=ch.mtime_iso,
+        )
+        if state == "inserted":
+            inserted += 1
+        elif state == "updated":
+            updated += 1
+        else:
+            unchanged += 1
+
+    deleted = _delete_missing_docs(conn, source_type="code", seen_source_pks=seen_source_pks)
+    return {
+        "total": len(chunks),
+        "inserted": inserted,
+        "updated": updated,
+        "unchanged": unchanged,
+        "deleted": deleted,
+    }
+
+
 def backfill_semantic_documents(
     database_path: Path,
     *,
     source_types: Iterable[str] | None = None,
     repo_full_name: str = "",
+    repo_root: Path | None = None,
 ) -> SemanticBackfillResult:
-    """Populate ``semantic_documents`` from existing source tables."""
+    """Populate ``semantic_documents`` from existing source tables (+ the source
+    tree when ``code`` is requested)."""
     start = time.monotonic()
     selected_sources = _normalize_sources(source_types)
     inserted = updated = unchanged = deleted = total = 0
@@ -363,6 +417,14 @@ def backfill_semantic_documents(
             from rebalance.ingest.db import ensure_email_schema
             ensure_email_schema(conn)
             result = sync_email_documents(conn)
+            inserted += result["inserted"]
+            updated += result["updated"]
+            unchanged += result["unchanged"]
+            deleted += result["deleted"]
+            total += result["total"]
+        if "code" in selected_sources:
+            root = repo_root or Path(__file__).resolve().parents[3]  # …/rebalance-OS/
+            result = sync_code_documents(conn, root)
             inserted += result["inserted"]
             updated += result["updated"]
             unchanged += result["unchanged"]

--- a/src/rebalance/ingest/semantic_index.py
+++ b/src/rebalance/ingest/semantic_index.py
@@ -460,6 +460,27 @@ def embed_pending(
     )
 
 
+def _rrf_fuse(
+    result_lists: list[list[Any]], top_k: int, *, k: int = 60
+) -> list[Any]:
+    """Reciprocal-rank fusion of ranked row lists, keyed on ``doc_id``.
+
+    Rank-based, so the vector (distance) and lexical (bm25) scales never have to
+    be compared. Dedupe by doc_id; when a doc is in both lists, keep the row that
+    carries a ``distance`` (the vector hit) so a similarity score can be shown.
+    """
+    scores: dict[Any, float] = {}
+    rowmap: dict[Any, Any] = {}
+    for rows in result_lists:
+        for rank, row in enumerate(rows):
+            doc_id = row["doc_id"]
+            scores[doc_id] = scores.get(doc_id, 0.0) + 1.0 / (k + rank + 1)
+            if doc_id not in rowmap or row["distance"] is not None:
+                rowmap[doc_id] = row
+    ordered = sorted(scores, key=lambda d: -scores[d])
+    return [rowmap[d] for d in ordered[:top_k]]
+
+
 def query(
     database_path: Path,
     query_text: str,
@@ -470,6 +491,7 @@ def query(
     updated_after: str | None = None,
     repo: str | None = None,
     embed_texts: EmbedTexts | None = None,
+    hybrid: bool = True,
 ) -> list[dict[str, Any]]:
     """Semantic search across the unified semantic index.
 
@@ -477,21 +499,36 @@ def query(
         updated_after: ISO-8601 string (e.g. ``"2026-05-01"``); exclude docs
                        updated before this date/time.
         repo: Restrict github results to one repo (``owner/name``).
+        hybrid: Fuse the vector (ANN) ranking with an FTS5 lexical ranking via
+                RRF — better recall on exact identifiers/paths/config keys. Set
+                False for pure ANN (also the automatic fallback when FTS5 is
+                unavailable or the query has no lexical terms).
     """
     selected_sources = _normalize_sources(source_filter)
     embed_fn = embed_texts or _default_embed_texts
     query_vec = _vec_to_bytes(embed_fn([query_text], model_name)[0])
+    # Fetch a deeper pool per retriever so RRF has material to fuse.
+    pool = max(top_k * 4, 24) if hybrid else top_k
 
     with db_connection(database_path, ensure_semantic_schema) as conn:
-        rows = sem.search_semantic_documents(
-            conn, query_vec, top_k, selected_sources,
-            updated_after=updated_after,
-            repo=repo,
+        vec_rows = sem.search_semantic_documents(
+            conn, query_vec, pool, selected_sources,
+            updated_after=updated_after, repo=repo,
         )
+        fts_rows = (
+            sem.search_semantic_documents_fts(
+                conn, query_text, pool, selected_sources,
+                updated_after=updated_after, repo=repo,
+            )
+            if hybrid else []
+        )
+
+    rows = _rrf_fuse([vec_rows, fts_rows], top_k) if fts_rows else vec_rows[:top_k]
 
     results: list[dict[str, Any]] = []
     for row in rows:
         metadata = json.loads(row["metadata_json"]) if row["metadata_json"] else {}
+        distance = row["distance"]
         results.append(
             {
                 "doc_id": row["doc_id"],
@@ -503,7 +540,7 @@ def query(
                 "body_preview": row["body_preview"],
                 "metadata": metadata,
                 "updated_at": row["updated_at"],
-                "similarity_score": round(1.0 - row["distance"], 4),
+                "similarity_score": round(1.0 - distance, 4) if distance is not None else None,
             }
         )
     return results

--- a/src/rebalance/mcp/tools/index.py
+++ b/src/rebalance/mcp/tools/index.py
@@ -171,6 +171,7 @@ def register(mcp: FastMCP, database_path: Path) -> None:
         top_k: int = 10,
         updated_after: str | None = None,
         repo: str | None = None,
+        hybrid: bool = True,
     ) -> list[dict[str, Any]]:
         """
         Vector search across the unified semantic index (vault chunks +
@@ -200,4 +201,5 @@ def register(mcp: FastMCP, database_path: Path) -> None:
             source_filter=sources,
             updated_after=updated_after,
             repo=repo,
+            hybrid=hybrid,
         )

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from rebalance.chat import _rrf_merge, chat_with_data
 
 
-def _fake_rows(_db, _query, top_k):
+def _fake_rows(_db, _query, top_k, _sources=None):
     rows = [
         {"source_type": "github", "title": "PR #12", "doc_kind": "pr",
          "body_preview": "fix the thing", "source_pk": "owner/repo#12",
@@ -46,7 +46,7 @@ class ChatWithDataTests(unittest.TestCase):
         self.assertEqual(out["scope"], "all")
 
     def test_preview_truncated(self) -> None:
-        def big(_db, _q, k):
+        def big(_db, _q, k, _sources=None):
             return [{"source_type": "vault", "title": "t", "body_preview": "x" * 500,
                      "source_pk": "p", "metadata": {}, "similarity_score": 0.5}]
         out = chat_with_data(self.DB, "q", work_query_fn=big)

--- a/tests/test_code_collector.py
+++ b/tests/test_code_collector.py
@@ -1,0 +1,103 @@
+"""Tests for the Phase 2 native code corpus: collector + sync_code_documents."""
+
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+
+from rebalance.ingest.code_collector import chunk_python_source, collect_code_chunks
+from rebalance.ingest.db import semantic as sem
+from rebalance.ingest.db.schema import ensure_semantic_schema
+from rebalance.ingest.semantic_index import sync_code_documents
+
+SAMPLE = '''"""Module that logs auth failures across collectors."""
+import os
+from pathlib import Path
+
+
+def log_auth_failure(msg):
+    return os.environ.get(msg)
+
+
+class AuthLogger:
+    def write(self):
+        return None
+'''
+
+
+class ChunkTests(unittest.TestCase):
+    def test_extracts_function_class_module(self) -> None:
+        chunks = chunk_python_source("a/auth_log.py", SAMPLE, "2026-06-06T00:00:00+00:00")
+        got = {(c.symbol, c.doc_kind) for c in chunks}
+        self.assertIn(("log_auth_failure", "function"), got)
+        self.assertIn(("AuthLogger", "class"), got)
+        self.assertIn(("<module>", "module"), got)
+        module = next(c for c in chunks if c.doc_kind == "module")
+        self.assertIn("logs auth failures", module.body)
+        self.assertIn("import os", module.body)
+
+    def test_syntax_error_yields_nothing(self) -> None:
+        self.assertEqual(chunk_python_source("x.py", "def (:", "t"), [])
+
+
+class CollectTests(unittest.TestCase):
+    def test_walks_include_dirs_and_skips_venv(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "src" / "pkg").mkdir(parents=True)
+            (root / "src" / "pkg" / "mod.py").write_text("def f():\n    return 1\n")
+            (root / ".venv").mkdir()
+            (root / ".venv" / "junk.py").write_text("def g():\n    return 2\n")
+            chunks = collect_code_chunks(root, include_dirs=("src",))
+            paths = {c.path for c in chunks}
+            self.assertIn("src/pkg/mod.py", paths)
+            self.assertFalse(any(".venv" in p for p in paths))
+
+
+class SyncCodeTests(unittest.TestCase):
+    def _repo(self, tmp: str) -> Path:
+        root = Path(tmp)
+        (root / "src").mkdir()
+        (root / "src" / "auth_log.py").write_text(SAMPLE)
+        return root
+
+    def test_sync_upserts_and_fts_finds_code(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self._repo(tmp)
+            c = sqlite3.connect(":memory:"); c.row_factory = sqlite3.Row
+            ensure_semantic_schema(c)
+            res = sync_code_documents(c, root)
+            self.assertGreaterEqual(res["inserted"], 3)  # fn + class + module
+            self.assertEqual(res["updated"], 0)
+            # FTS surfaces the code by identifier and by filename
+            hits = sem.search_semantic_documents_fts(c, "log_auth_failure", 5, ["code"])
+            self.assertTrue(any("auth_log.py" in (r["title"] or "") for r in hits))
+
+    def test_rerun_is_unchanged(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self._repo(tmp)
+            c = sqlite3.connect(":memory:"); c.row_factory = sqlite3.Row
+            ensure_semantic_schema(c)
+            sync_code_documents(c, root)
+            res2 = sync_code_documents(c, root)
+            self.assertEqual(res2["inserted"], 0)
+            self.assertEqual(res2["updated"], 0)
+            self.assertEqual(res2["deleted"], 0)
+
+    def test_deleted_symbol_is_removed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self._repo(tmp)
+            c = sqlite3.connect(":memory:"); c.row_factory = sqlite3.Row
+            ensure_semantic_schema(c)
+            sync_code_documents(c, root)
+            (root / "src" / "auth_log.py").write_text('def kept():\n    return 1\n')
+            res = sync_code_documents(c, root)
+            self.assertGreaterEqual(res["deleted"], 1)  # log_auth_failure/AuthLogger gone
+            remaining = {r["source_pk"] for r in sem.semantic_documents_for_source(c, "code")}
+            self.assertNotIn("src/auth_log.py::log_auth_failure", remaining)
+            self.assertNotIn("src/auth_log.py::AuthLogger", remaining)
+            self.assertIn("src/auth_log.py::kept", remaining)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_collector_registry.py
+++ b/tests/test_collector_registry.py
@@ -32,7 +32,7 @@ class CollectorRegistryTests(unittest.TestCase):
         names = _all_scope_names()
         self.assertEqual(
             sorted(names),
-            sorted(["vault", "github", "calendar", "sleuth", "email", "semantic", "sync"]),
+            sorted(["vault", "github", "calendar", "sleuth", "email", "code", "semantic", "sync"]),
         )
 
     def test_register_new_collector_then_unregister(self) -> None:

--- a/tests/test_semantic_hybrid.py
+++ b/tests/test_semantic_hybrid.py
@@ -1,0 +1,97 @@
+"""Tests for Phase 1 hybrid retrieval: FTS5 lexical index + RRF fusion."""
+
+import sqlite3
+import unittest
+
+from rebalance.ingest.db import semantic as sem
+from rebalance.ingest.db.schema import ensure_semantic_schema
+from rebalance.ingest.db.semantic import _fts_match_query
+from rebalance.ingest.semantic_index import _rrf_fuse
+
+
+def _conn() -> sqlite3.Connection:
+    c = sqlite3.connect(":memory:")
+    c.row_factory = sqlite3.Row
+    ensure_semantic_schema(c)
+    return c
+
+
+def _add(c, i, source_type, title, body, pk="p"):
+    c.execute(
+        "INSERT INTO semantic_documents(id,source_type,source_table,source_pk,doc_kind,"
+        "title,body,content_hash,metadata_json,created_at,updated_at) "
+        "VALUES(?,?,?,?,?,?,?,?,?,?,?)",
+        (i, source_type, source_type, f"{pk}{i}", "doc", title, body, "h", "{}",
+         "2026-06-06", "2026-06-06"),
+    )
+    c.commit()
+
+
+class FtsMatchQueryTests(unittest.TestCase):
+    def test_tokenizes_and_quotes(self) -> None:
+        # underscores split (FTS5 unicode61), de-duped, lowercased
+        self.assertEqual(_fts_match_query("pulse_web.py generates"), '"pulse" OR "web" OR "py" OR "generates"')
+
+    def test_drops_single_chars_and_empty(self) -> None:
+        self.assertEqual(_fts_match_query("a b cc"), '"cc"')
+        self.assertEqual(_fts_match_query("   "), "")
+        self.assertEqual(_fts_match_query("!!! ??"), "")
+
+
+class FtsSearchTests(unittest.TestCase):
+    def test_finds_by_lexical_token_and_respects_source(self) -> None:
+        c = _conn()
+        _add(c, 1, "vault", "auth notes", "the auth_log module logs auth failures")
+        _add(c, 2, "github", "refactor", "general logging cleanup")
+        hits = sem.search_semantic_documents_fts(c, "which module logs auth failures", 5, ["vault", "github"])
+        self.assertEqual([r["doc_id"] for r in hits][:1], [1])
+        # source filter excludes vault
+        only_gh = sem.search_semantic_documents_fts(c, "auth failures", 5, ["github"])
+        self.assertTrue(all(r["source_type"] == "github" for r in only_gh))
+
+    def test_triggers_keep_fts_in_sync(self) -> None:
+        c = _conn()
+        _add(c, 1, "vault", "t", "alpha auth_log beta")
+        self.assertEqual(len(sem.search_semantic_documents_fts(c, "auth_log", 5, ["vault"])), 1)
+        c.execute("DELETE FROM semantic_documents WHERE id=1"); c.commit()
+        self.assertEqual(sem.search_semantic_documents_fts(c, "auth_log", 5, ["vault"]), [])
+        # update re-indexes
+        _add(c, 2, "vault", "t2", "nothing relevant")
+        c.execute("UPDATE semantic_documents SET body='now mentions widget' WHERE id=2"); c.commit()
+        self.assertEqual(len(sem.search_semantic_documents_fts(c, "widget", 5, ["vault"])), 1)
+
+    def test_backfill_rebuilds_for_preexisting_docs(self) -> None:
+        # Simulate a DB that had docs before the FTS table existed: insert with
+        # the FTS triggers dropped, then re-run ensure_semantic_schema → rebuild.
+        c = _conn()
+        c.execute("DROP TABLE semantic_documents_fts")
+        for trig in ("ai", "ad", "au"):
+            c.execute(f"DROP TRIGGER IF EXISTS semantic_documents_fts_{trig}")
+        _add(c, 1, "vault", "t", "preexisting auth_log content")
+        ensure_semantic_schema(c)  # should create FTS + backfill
+        self.assertEqual(len(sem.search_semantic_documents_fts(c, "auth_log", 5, ["vault"])), 1)
+
+    def test_empty_query_returns_empty(self) -> None:
+        c = _conn()
+        _add(c, 1, "vault", "t", "body")
+        self.assertEqual(sem.search_semantic_documents_fts(c, "!! ??", 5, ["vault"]), [])
+
+
+class RrfFuseTests(unittest.TestCase):
+    def test_shared_doc_ranks_top_and_prefers_vector_row(self) -> None:
+        vec = [{"doc_id": 1, "distance": 0.1}, {"doc_id": 2, "distance": 0.2}]
+        fts = [{"doc_id": 2, "distance": None}, {"doc_id": 3, "distance": None}]
+        fused = _rrf_fuse([vec, fts], top_k=10)
+        ids = [r["doc_id"] for r in fused]
+        self.assertEqual(ids[0], 2)              # in both lists → highest fused score
+        self.assertEqual(set(ids), {1, 2, 3})    # deduped
+        # doc 2 kept as the vector row (carries a distance for scoring)
+        self.assertEqual(next(r for r in fused if r["doc_id"] == 2)["distance"], 0.2)
+
+    def test_respects_top_k(self) -> None:
+        vec = [{"doc_id": i, "distance": 0.1 * i} for i in range(20)]
+        self.assertEqual(len(_rrf_fuse([vec, []], top_k=5)), 5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Phases 1 & 2 of [CHAT-WITH-DATA.md](PROJECT/2-WORKING/CHAT-WITH-DATA.md). Together they take the chat eval from **7/10 → 10/10** and make it **dependency-free at ~39 ms** (vs ~2.1 s federation).

| Phase | Approach | recall@8 | latency |
|---|---|---|---|
| 0 (already merged) | ask_self federation | 7/10 | ~2.1 s |
| 1 | hybrid FTS alone | 7/10 *(no move — corpus was the limiter)* | — |
| **2** | **native code corpus + hybrid** | **10/10** | **~39 ms** |

## Phase 1 — hybrid retrieval (FTS5 + RRF)
- `semantic_documents_fts` (standalone FTS5, title+body), trigger-synced, **version-guarded rebuild** (`fts_version`) to heal a stale/incompatible table.
- `query(hybrid=True)` fetches a deeper pool from the vector (ANN) and FTS retrievers and fuses by reciprocal rank; ANN-only fallback. Query tokenizer aligned to FTS5 (underscores split).
- Exposed on the `semantic_query` MCP tool (`hybrid` flag).
- **Honest finding:** hybrid alone did *not* move the eval — the work corpus has no code. Correct infra, wrong lever without a code corpus → Phase 2.

## Phase 2 — native code corpus
- `code_collector.py`: AST-chunks `src/`+`scripts/` Python by top-level function/class + a module header chunk; metadata path/symbol/parent/language/line; change detection by content-hash + mtime.
- `source_type="code"` through `_normalize_sources`, `sync_code_documents`, the backfill dispatcher, and a registered **`code` collector** in `rebalance refresh` (FTS-only, ~0.5 s).
- `chat.py` scope routing — `work`/`code`/`all`; ask_self now **optional**.
- **Result:** native-only 10/10 @ ~39 ms (~50× faster than federation). The dashboard `Ask` (scope=`all`) inherits native code for free.

## Test plan
- `pytest tests/` → **523 passed** (new: `test_semantic_hybrid.py`, `test_code_collector.py`).
- `rebalance doctor` clean.
- `scripts/chat_eval.py --scope all` reproduces 10/10 (with or without `ASK_SELF_PATH`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)