### PR TITLE
fix: re-apply post-merge fixes from the #28 beta test (timesheet timezone, read-only calendar snap)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,7 @@ snapshot-archive.md
 
 # xyz relay-automation coordination state (per-device, local)
 .tick/
+
+# Local beta-test working notes (kept locally, not part of the product)
+test-notes/
+mrt-temp/

--- a/src/rebalance/cli/calendar.py
+++ b/src/rebalance/cli/calendar.py
@@ -445,16 +445,18 @@ def calendar_snap_edges_cmd(
     days: int = typer.Option(1, "--days", help="Number of consecutive days to process (1-7)"),
     calendar_id: str = typer.Option("", "--calendar-id", help="Calendar ID (default: from config)"),
     timezone_name: str = typer.Option("", "--timezone", help="IANA timezone (default: from config)"),
-    apply: bool = typer.Option(False, "--apply", help="Actually patch Google Calendar (default: dry-run)"),
     output_format: str = typer.Option("text", "--output", "-o", help="Output format: text or json"),
 ) -> None:
-    """Detect and fix slightly overlapping calendar events.
+    """Report slightly overlapping calendar events and a clean boundary.
 
-    Trims Event 1's end to 1 minute before Event 2's start so adjacent
-    events have clean edges.  Skips all-day events and clusters of 3+
-    overlapping events (manual resolution required).
+    Read-only: this never modifies your calendar. The calendar is the system of
+    record for time tracking, so overlaps are surfaced for you to fix directly.
+    Skips all-day events and clusters of 3+ overlapping events (manual
+    resolution required).
 
-    Dry-run by default — re-run with --apply to patch Google Calendar.
+    The suggested boundary is gapless by default (snap_gap_minutes=0 in
+    calendar config). A positive snap_gap_minutes understates tracked time and
+    prints a warning.
     """
     from rebalance.ingest.calendar_config import CalendarConfig
     from rebalance.ingest.calendar_snap import snap_edges
@@ -465,10 +467,6 @@ def calendar_snap_edges_cmd(
 
     if not 1 <= days <= 7:
         raise typer.BadParameter("--days must be between 1 and 7.")
-
-    env_data = _load_google_calendar_env()
-    if apply:
-        _require_calendar_write_scope(env_data)
 
     config = CalendarConfig.load()
     resolved_calendar_id = calendar_id.strip() or config.calendar_id
@@ -485,7 +483,7 @@ def calendar_snap_edges_cmd(
         start_date=start_date,
         num_days=days,
         timezone_name=resolved_timezone,
-        apply=apply,
+        gap_minutes=config.snap_gap_minutes,
     )
 
     if normalized_output == "json":
@@ -494,8 +492,10 @@ def calendar_snap_edges_cmd(
         return
 
     # Text output
-    mode_label = "APPLIED" if result.applied else "DRY RUN"
-    typer.echo(f"\n--- Calendar Edge Snap ({mode_label}) ---\n")
+    typer.echo("\n--- Calendar Edge Overlaps (report only) ---\n")
+
+    if result.warning:
+        typer.echo(f"  ⚠️  {result.warning}\n")
 
     for day in result.days:
         typer.echo(f"  {day.date}  ({day.total_events_examined} events examined, {day.skipped_allday} all-day skipped)")
@@ -505,9 +505,8 @@ def calendar_snap_edges_cmd(
             continue
 
         for pair in day.snapped:
-            action = "Snapped" if result.applied else "Would snap"
             typer.echo(
-                f"    {action}: \"{pair.event1_summary}\" end {pair.event1_original_end} -> {pair.event1_new_end}"
+                f"    Suggested: \"{pair.event1_summary}\" end {pair.event1_original_end} -> {pair.event1_new_end}"
                 f"  (overlapped \"{pair.event2_summary}\" by {pair.overlap_minutes}m)"
             )
 
@@ -517,12 +516,10 @@ def calendar_snap_edges_cmd(
 
         typer.echo()
 
-    typer.echo(f"  Total snapped: {result.total_snapped}")
+    typer.echo(f"  Total overlaps: {result.total_snapped}")
     typer.echo(f"  Total skipped clusters: {result.total_skipped_clusters}")
     typer.echo(f"  Elapsed: {result.elapsed_seconds}s\n")
-
-    if not result.applied:
-        typer.echo("  Dry run — no changes applied. Re-run with --apply to patch Google Calendar.\n")
+    typer.echo("  Report only — your calendar was not modified. Resolve overlaps in the calendar directly.\n")
 
 
 @app.command("calendar-daily-report")

--- a/src/rebalance/ingest/calendar_config.py
+++ b/src/rebalance/ingest/calendar_config.py
@@ -80,6 +80,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
     "timezone": "",  # empty → resolved to device local timezone at load time
     "projects": [],
     "hours_format": "decimal",
+    "snap_gap_minutes": 0,  # 0 = gapless/accurate; any positive value loses time
 }
 
 
@@ -107,6 +108,10 @@ class CalendarConfig:
     projects: list[CalendarProject]
     hours_format: str  # "decimal" (default) or "hm"
     team_calendars: list[TeamCalendarEntry] = field(default_factory=list)
+    # Minutes of gap to leave when snapping an overlapping event's edge.
+    # MUST be 0 for accurate time tracking — any positive value discards that
+    # many minutes of real time on every resolved overlap (see calendar_snap).
+    snap_gap_minutes: int = 0
 
     @property
     def exclude_keywords(self) -> list[str]:
@@ -207,6 +212,7 @@ class CalendarConfig:
             timezone=data.get("timezone") or local_tz().key,
             projects=cls._load_projects(data.get("projects", DEFAULT_CONFIG["projects"])),
             hours_format=hours_fmt,
+            snap_gap_minutes=max(0, int(data.get("snap_gap_minutes", 0) or 0)),
         )
 
     def save(self, config_path: Path | None = None) -> None:
@@ -226,6 +232,7 @@ class CalendarConfig:
                     "aggregator_skip_words": self.aggregator_skip_words,
                     "timezone": self.timezone,
                     "hours_format": self.hours_format,
+                    "snap_gap_minutes": self.snap_gap_minutes,
                     "projects": [
                         {
                             "name": project.name,

--- a/src/rebalance/ingest/calendar_snap.py
+++ b/src/rebalance/ingest/calendar_snap.py
@@ -1,14 +1,25 @@
 """
-Google Calendar edge-snapping — detect slightly overlapping timed events
-and trim Event 1's end to 1 minute before Event 2's start so adjacent
-events have clean boundaries.
+Google Calendar edge-snapping — detect slightly overlapping timed events and
+report a clean boundary between them.
+
+This module is detection/reporting only. It never modifies the calendar: the
+calendar is the system of record for time tracking, and writing computed edges
+back to it would alter source data. Overlaps are surfaced so a human can fix
+them in the calendar directly.
+
+Time-accuracy note:
+  When two events overlap, the suggested boundary trims Event 1's end to
+  ``Event 2's start - snap_gap_minutes``. ``snap_gap_minutes`` defaults to 0,
+  which makes the boundary contiguous (no gap, no time lost). Any positive
+  value leaves an unrecorded gap of that many minutes on every resolved
+  overlap — i.e. it silently discards real time. Keep it at 0 for accurate
+  time calculations; a non-zero value is reported back as a warning.
 
 Rules:
-  - Only 2-event overlaps are auto-resolved. 3+ event clusters are
+  - Only 2-event overlaps get a suggested boundary. 3+ event clusters are
     skipped and reported for manual cleanup.
   - All-day events are ignored entirely.
   - Operates day-by-day, with a batch mode up to 7 days.
-  - Dry-run by default; pass apply=True to actually patch Google Calendar.
 """
 
 from __future__ import annotations
@@ -20,7 +31,6 @@ from typing import Any
 
 from rebalance.ingest.calendar import (
     CALENDAR_READONLY_SCOPE,
-    CALENDAR_WRITE_SCOPE,
     _build_service,
 )
 from rebalance.ingest.calendar_helpers import parse_calendar_dt
@@ -38,7 +48,7 @@ class OverlapPair:
     event1_id: str
     event1_summary: str
     event1_original_end: str  # ISO datetime
-    event1_new_end: str  # ISO datetime (Event2.start - 1 minute)
+    event1_new_end: str  # ISO datetime (Event2.start - snap_gap_minutes; gapless at 0)
     event2_id: str
     event2_summary: str
     event2_start: str  # ISO datetime
@@ -67,12 +77,16 @@ class SnapDayResult:
 
 @dataclass
 class SnapEdgesResult:
-    """Aggregate result across all requested days."""
+    """Aggregate result across all requested days.
+
+    Detection/reporting only — the calendar is never modified.
+    """
 
     days: list[SnapDayResult] = field(default_factory=list)
     total_snapped: int = 0
     total_skipped_clusters: int = 0
-    applied: bool = False
+    gap_minutes: int = 0
+    warning: str = ""
     elapsed_seconds: float = 0.0
 
 
@@ -88,8 +102,13 @@ def _is_allday_event(event: dict[str, Any]) -> bool:
 
 def _detect_overlaps(
     events: list[dict[str, Any]],
+    gap_minutes: int = 0,
 ) -> tuple[list[OverlapPair], list[SkippedCluster], int]:
     """Detect overlapping event pairs from a sorted list of timed events.
+
+    ``gap_minutes`` is the gap left between a resolved pair (Event 1's
+    suggested end = Event 2's start - gap_minutes). Defaults to 0 (contiguous,
+    no time lost); any positive value discards that many minutes per overlap.
 
     Returns (overlap_pairs, skipped_clusters, skipped_allday_count).
     """
@@ -155,7 +174,7 @@ def _detect_overlaps(
                 )
                 continue
 
-            new_end_dt = ev2_start_dt - timedelta(minutes=1)
+            new_end_dt = ev2_start_dt - timedelta(minutes=gap_minutes)
             overlap_mins = int((ev1_end_dt - ev2_start_dt).total_seconds() / 60)  # raw-ok: one-off calc
 
             # Preserve timezone from original event
@@ -226,30 +245,6 @@ def _fetch_day_events(
     return all_events
 
 
-def _patch_event_end(
-    service: Any,
-    calendar_id: str,
-    event_id: str,
-    new_end_iso: str,
-    original_end_timezone: str | None = None,
-) -> dict[str, Any]:
-    """Patch a single event's end time via the Google Calendar API."""
-    end_body: dict[str, str] = {"dateTime": new_end_iso}
-    if original_end_timezone:
-        end_body["timeZone"] = original_end_timezone
-
-    return (
-        service.events()
-        .patch(
-            calendarId=calendar_id,
-            eventId=event_id,
-            body={"end": end_body},
-            sendUpdates="none",
-        )
-        .execute()
-    )
-
-
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -261,28 +256,11 @@ def snap_day_edges(
     target_date: date,
     timezone_name: str,
     *,
-    apply: bool = False,
+    gap_minutes: int = 0,
 ) -> SnapDayResult:
-    """Detect and optionally fix overlapping edges for a single day."""
+    """Detect overlapping edges for a single day (read-only; never patches)."""
     events = _fetch_day_events(service, calendar_id, target_date, timezone_name)
-    pairs, skipped, allday_count = _detect_overlaps(events)
-
-    if apply:
-        for pair in pairs:
-            # Extract timezone from original event if present
-            original_tz = None
-            for ev in events:
-                if ev["id"] == pair.event1_id:
-                    original_tz = ev.get("end", {}).get("timeZone")
-                    break
-
-            _patch_event_end(
-                service,
-                calendar_id,
-                pair.event1_id,
-                pair.event1_new_end,
-                original_end_timezone=original_tz,
-            )
+    pairs, skipped, allday_count = _detect_overlaps(events, gap_minutes=gap_minutes)
 
     return SnapDayResult(
         date=target_date.isoformat(),
@@ -299,16 +277,21 @@ def snap_edges(
     start_date: date,
     num_days: int = 1,
     timezone_name: str,
-    apply: bool = False,
+    gap_minutes: int = 0,
 ) -> SnapEdgesResult:
-    """Detect and optionally fix overlapping calendar edges across multiple days.
+    """Detect overlapping calendar edges across multiple days.
+
+    Detection/reporting only — the calendar is never modified. Overlaps are
+    returned for a human to resolve in the calendar directly.
 
     Args:
         calendar_id: Google Calendar ID.
         start_date: First day to process.
         num_days: Number of consecutive days (1-7).
         timezone_name: IANA timezone for day boundaries.
-        apply: If True, patches Google Calendar. Default is dry-run.
+        gap_minutes: Gap left between a resolved pair. Keep at 0 for accurate
+            time tracking; any positive value discards that many minutes per
+            overlap and is reported back as a warning.
 
     Raises:
         ValueError: If num_days is outside 1-7.
@@ -316,22 +299,34 @@ def snap_edges(
     if not 1 <= num_days <= 7:
         raise ValueError(f"num_days must be between 1 and 7, got {num_days}")
 
+    gap_minutes = max(0, int(gap_minutes))
+
     start = time.monotonic()
-    required_scope = CALENDAR_WRITE_SCOPE if apply else CALENDAR_READONLY_SCOPE
-    service = _build_service(required_scopes=[required_scope])
+    # Read-only by design: this tool reports overlaps, it never writes to the
+    # calendar, so it only ever needs read scope.
+    service = _build_service(required_scopes=[CALENDAR_READONLY_SCOPE])
 
     days: list[SnapDayResult] = []
     for offset in range(num_days):
         target = start_date + timedelta(days=offset)
         day_result = snap_day_edges(
-            service, calendar_id, target, timezone_name, apply=apply
+            service, calendar_id, target, timezone_name, gap_minutes=gap_minutes
         )
         days.append(day_result)
+
+    warning = ""
+    if gap_minutes != 0:
+        warning = (
+            f"snap_gap_minutes={gap_minutes}: leaves a {gap_minutes}-minute "
+            "unrecorded gap on every resolved overlap, which understates tracked "
+            "time. Set snap_gap_minutes to 0 for accurate time calculations."
+        )
 
     return SnapEdgesResult(
         days=days,
         total_snapped=sum(len(d.snapped) for d in days),
         total_skipped_clusters=sum(len(d.skipped_clusters) for d in days),
-        applied=apply,
+        gap_minutes=gap_minutes,
+        warning=warning,
         elapsed_seconds=round(time.monotonic() - start, 2),
     )

--- a/src/rebalance/ingest/daily_report.py
+++ b/src/rebalance/ingest/daily_report.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import re
 from collections import Counter
 from dataclasses import dataclass, field
-from datetime import date
+from datetime import date, timedelta
 from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo
@@ -214,18 +214,37 @@ def get_day_data(
     project_matchers: list[ProjectMatcher] | None = None,
 ) -> DayData:
     """Fetch and filter events for a single day. Returns structured data for reuse."""
+    # Store UTC, compute "the day" in the user's local timezone. SQLite's
+    # DATE(start_time) coerces the stored offset to UTC, which would bucket a
+    # user's evening events into the next day. So we fetch a coarse ±1-day
+    # range (cheap), then bucket precisely by the configured-timezone local
+    # date in Python below.
+    tz = ZoneInfo(config.timezone)
+    lo = (target_date - timedelta(days=1)).isoformat()
+    hi = (target_date + timedelta(days=1)).isoformat()
     with calendar_connection(database_path) as conn:
-        date_str = target_date.isoformat()
-        rows = conn.execute(
+        candidate_rows = conn.execute(
             """SELECT summary, start_time, end_time
                FROM calendar_events
-               WHERE DATE(start_time) = ?
+               WHERE DATE(start_time) >= ? AND DATE(start_time) <= ?
                  AND calendar_id = ?
                ORDER BY start_time ASC""",
             # Operator rows are canonically stored as 'primary'; filtering on
             # config.calendar_id would miss them whenever it is non-'primary'.
-            (date_str, OPERATOR_CALENDAR_ID),
+            (lo, hi, OPERATOR_CALENDAR_ID),
         ).fetchall()
+
+    def _local_date(raw: str) -> date | None:
+        try:
+            dt = parse_calendar_dt(raw)
+        except Exception:
+            return None
+        # All-day / date-only events are naive: their date is already the local day.
+        if dt.tzinfo is None:
+            return dt.date()
+        return dt.astimezone(tz).date()
+
+    rows = [r for r in candidate_rows if _local_date(r["start_time"]) == target_date]
 
     events = [
         {

--- a/src/rebalance/mcp/tools/calendar.py
+++ b/src/rebalance/mcp/tools/calendar.py
@@ -143,21 +143,26 @@ def register(mcp: FastMCP, database_path: Path) -> None:
         days: int = 1,
         calendar_id: str = "",
         timezone_name: str = "",
-        apply: bool = False,
     ) -> dict[str, Any]:
         """
-        Detect and fix slightly overlapping calendar events by trimming
-        Event 1's end to 1 minute before Event 2's start.
+        Report slightly overlapping calendar events and a clean boundary
+        between each overlapping pair.
 
-        Dry-run by default — set apply=True to actually patch Google Calendar.
-        Skips all-day events and clusters of 3+ overlapping events.
+        Read-only: this tool never modifies your calendar. The calendar is the
+        system of record for time tracking, so overlaps are surfaced for you to
+        fix directly rather than patched automatically. Skips all-day events
+        and clusters of 3+ overlapping events (manual resolution required).
+
+        The suggested boundary is gapless by default (snap_gap_minutes=0 in
+        calendar config). A positive snap_gap_minutes leaves an unrecorded gap
+        on every overlap and understates tracked time; when set, the result
+        includes a `warning`.
 
         Args:
             date_str: Start date (YYYY-MM-DD). Defaults to today.
             days: Number of consecutive days to process (1-7).
             calendar_id: Calendar ID. Defaults to config calendar.
             timezone_name: IANA timezone. Defaults to config timezone.
-            apply: If True, patches Google Calendar. Default False (dry-run).
         """
         import dataclasses
         from datetime import date as date_cls, datetime
@@ -179,6 +184,6 @@ def register(mcp: FastMCP, database_path: Path) -> None:
             start_date=start_date,
             num_days=days,
             timezone_name=resolved_timezone,
-            apply=apply,
+            gap_minutes=config.snap_gap_minutes,
         )
         return dataclasses.asdict(result)

--- a/tests/test_calendar_snap.py
+++ b/tests/test_calendar_snap.py
@@ -1,8 +1,8 @@
-"""Tests for calendar edge-snapping: overlap detection, patch calls, and CLI."""
+"""Tests for calendar edge-snapping: overlap detection (read-only) and gapless default."""
 
 import unittest
 from datetime import date
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock
 
 from rebalance.ingest.calendar_snap import (
     OverlapPair,
@@ -10,7 +10,6 @@ from rebalance.ingest.calendar_snap import (
     SnapDayResult,
     _detect_overlaps,
     _is_allday_event,
-    _patch_event_end,
     snap_day_edges,
 )
 
@@ -88,8 +87,9 @@ class DetectOverlapsTests(unittest.TestCase):
         self.assertEqual(pairs, [])
         self.assertEqual(skipped, [])
 
-    def test_two_event_overlap(self) -> None:
-        """Classic case: Event 1 ends 3 min into Event 2."""
+    def test_two_event_overlap_gapless_default(self) -> None:
+        """Classic case: Event 1 ends 3 min into Event 2. Default is gapless —
+        Event 1's suggested end equals Event 2's start (no time lost)."""
         events = [
             _make_event("1", "Standup", "2026-04-15T09:00:00-07:00", "2026-04-15T10:03:00-07:00"),
             _make_event("2", "Planning", "2026-04-15T10:00:00-07:00", "2026-04-15T11:00:00-07:00"),
@@ -98,9 +98,19 @@ class DetectOverlapsTests(unittest.TestCase):
         self.assertEqual(len(pairs), 1)
         self.assertEqual(pairs[0].event1_id, "1")
         self.assertEqual(pairs[0].event2_id, "2")
-        self.assertEqual(pairs[0].event1_new_end, "2026-04-15T09:59:00-07:00")
+        self.assertEqual(pairs[0].event1_new_end, "2026-04-15T10:00:00-07:00")
         self.assertEqual(pairs[0].overlap_minutes, 3)
         self.assertEqual(skipped, [])
+
+    def test_gap_minutes_leaves_gap(self) -> None:
+        """A positive gap_minutes trims to that many minutes before Event 2's
+        start (the time-losing legacy behavior, now opt-in only)."""
+        events = [
+            _make_event("1", "Standup", "2026-04-15T09:00:00-07:00", "2026-04-15T10:03:00-07:00"),
+            _make_event("2", "Planning", "2026-04-15T10:00:00-07:00", "2026-04-15T11:00:00-07:00"),
+        ]
+        pairs, _, _ = _detect_overlaps(events, gap_minutes=1)
+        self.assertEqual(pairs[0].event1_new_end, "2026-04-15T09:59:00-07:00")
 
     def test_three_event_cluster_skipped(self) -> None:
         """3+ overlapping events should be skipped entirely."""
@@ -176,50 +186,7 @@ class DetectOverlapsTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# _patch_event_end
-# ---------------------------------------------------------------------------
-
-
-class PatchEventEndTests(unittest.TestCase):
-    def test_patch_called_with_correct_args(self) -> None:
-        mock_service = MagicMock()
-        mock_service.events.return_value.patch.return_value.execute.return_value = {"id": "evt-1"}
-
-        _patch_event_end(
-            mock_service,
-            "cal@example.com",
-            "evt-1",
-            "2026-04-15T09:59:00-07:00",
-        )
-
-        mock_service.events.return_value.patch.assert_called_once_with(
-            calendarId="cal@example.com",
-            eventId="evt-1",
-            body={"end": {"dateTime": "2026-04-15T09:59:00-07:00"}},
-            sendUpdates="none",
-        )
-
-    def test_patch_preserves_timezone(self) -> None:
-        mock_service = MagicMock()
-        mock_service.events.return_value.patch.return_value.execute.return_value = {"id": "evt-1"}
-
-        _patch_event_end(
-            mock_service,
-            "cal@example.com",
-            "evt-1",
-            "2026-04-15T09:59:00-07:00",
-            original_end_timezone="America/Los_Angeles",
-        )
-
-        patch_kwargs = mock_service.events.return_value.patch.call_args.kwargs
-        self.assertEqual(
-            patch_kwargs["body"]["end"]["timeZone"],
-            "America/Los_Angeles",
-        )
-
-
-# ---------------------------------------------------------------------------
-# snap_day_edges (integration with mocked API)
+# snap_day_edges (integration with mocked API) — read-only, never patches
 # ---------------------------------------------------------------------------
 
 
@@ -232,7 +199,8 @@ class SnapDayEdgesTests(unittest.TestCase):
         mock_service.events.return_value.patch.return_value.execute.return_value = {}
         return mock_service
 
-    def test_dry_run_does_not_patch(self) -> None:
+    def test_detects_overlap_without_patching(self) -> None:
+        """Overlaps are detected and reported; the calendar is never patched."""
         events = [
             _make_event("1", "A", "2026-04-15T09:00:00-07:00", "2026-04-15T10:05:00-07:00"),
             _make_event("2", "B", "2026-04-15T10:00:00-07:00", "2026-04-15T11:00:00-07:00"),
@@ -240,25 +208,13 @@ class SnapDayEdgesTests(unittest.TestCase):
         mock_service = self._mock_service_with_events(events)
 
         result = snap_day_edges(
-            mock_service, "primary", date(2026, 4, 15), "America/Los_Angeles", apply=False
+            mock_service, "primary", date(2026, 4, 15), "America/Los_Angeles"
         )
 
         self.assertEqual(len(result.snapped), 1)
+        # Gapless suggested boundary (no time lost), and NO write-back.
+        self.assertEqual(result.snapped[0].event1_new_end, "2026-04-15T10:00:00-07:00")
         mock_service.events.return_value.patch.assert_not_called()
-
-    def test_apply_calls_patch(self) -> None:
-        events = [
-            _make_event("1", "A", "2026-04-15T09:00:00-07:00", "2026-04-15T10:05:00-07:00"),
-            _make_event("2", "B", "2026-04-15T10:00:00-07:00", "2026-04-15T11:00:00-07:00"),
-        ]
-        mock_service = self._mock_service_with_events(events)
-
-        result = snap_day_edges(
-            mock_service, "primary", date(2026, 4, 15), "America/Los_Angeles", apply=True
-        )
-
-        self.assertEqual(len(result.snapped), 1)
-        mock_service.events.return_value.patch.assert_called_once()
 
     def test_no_overlaps_clean_day(self) -> None:
         events = [
@@ -274,6 +230,7 @@ class SnapDayEdgesTests(unittest.TestCase):
         self.assertEqual(len(result.snapped), 0)
         self.assertEqual(len(result.skipped_clusters), 0)
         self.assertEqual(result.total_events_examined, 2)
+        mock_service.events.return_value.patch.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why this PR exists

PR #30 merged my `fix/28-dev-install-fixes` branch into `development`, but I kept working on that branch after the merge — three fixes landed *after* the merge point, so they never made it in. I verified against current `development` that both bugs are still present, then re-applied the fixes on top of the new module layout (the CLI/MCP decomposition meant the calendar-snap commit couldn't cherry-pick cleanly, so I ported it by hand to `src/rebalance/cli/calendar.py` and `src/rebalance/mcp/tools/calendar.py`).

Two doc commits from the original branch were **deliberately dropped** — the new AGENTS.md (doctor-first guidance) and the keyring credential model in UPGRADE.md already cover them better than my originals did. Nice work on those, by the way — the doctor remediation pointers solve the exact gap I was documenting.

## What's included

### 1. Timesheet day window computed in the user's timezone, not UTC
`get_day_data` (behind the `review_timesheet` MCP tool) selected a day with `WHERE DATE(start_time) = ?`. SQLite's `DATE()` normalizes offset-bearing timestamps to UTC before extracting the date, so the daily timesheet was built on a UTC day instead of the user's local day — evening events past ~5pm PDT got bucketed onto the wrong day in both directions. Verified with real data: a 2026-05-28 query pulled in two May 27 evening events and dropped a genuine May 28 18:15 PDT event.

Fix: coarse ±1-day SQL prefetch via `DATE()`, then authoritative bucketing in Python by local date in the configured timezone.

### 2. Calendar snap: gapless by default and read-only

The old snap resolved a 2-event overlap by trimming Event 1's end to one minute **before** Event 2's start, and with `apply=True` it patched that trimmed end time directly into Google Calendar.

**What's fine about the old behavior — and kept:** reassigning the *overlapping* minutes. If Event 1 ran 2:00–3:05 and Event 2 started at 3:00, that contested 5 minutes was double-booked; giving it to Event 2 is a legitimate healing/repair step that prevents over-billing. This PR keeps that exact behavior.

**What's not fine — and removed:** two things stacked on top of that.

- **The extra "gap" minute is pure loss.** Trimming to 2:59 instead of 3:00 leaves a minute that belongs to *neither* event. Every resolved overlap donates one minute to nowhere, and the error only ever runs one direction — tracked time can only shrink, never recover. I measured this against my real calendar: over the last 5 weeks the detector found 0, 0, 0, 0, and 2 overlap pairs, so on my current habits the old behavior would shave roughly 1–2 minutes per week. Small in raw minutes — but it's a **silent, permanent, unbounded, one-directional error written into the billing record**. Once `apply=True` patched Google Calendar there was no record of the original end time, so the loss was also unauditable and unrecoverable.

- **The write-back is one agent decision away from firing.** Dry-run was the default at both entry points, but the MCP tool exposed `apply` as a plain parameter and the docstring advertised it ("set apply=True to actually patch Google Calendar"). With an AI agent in the loop, "explicit opt-in" is a single tool-call argument the *model* chooses — the human never has to be in that decision. For a tool whose output feeds billing, that's the wrong failure mode.

Fix: new `snap_gap_minutes` config, default **0** (gapless — Event 1's end snaps exactly to Event 2's start, no time lost). The tool and CLI are now **detect-and-report only**: the write-back path (`_patch_event_end`) is removed entirely rather than just defaulted off, and overlaps are surfaced for the user to resolve in the calendar — the system of record stays under human control. A positive `snap_gap_minutes` produces an explicit warning that it understates tracked time.

### 3. Gitignore for local beta-test note folders
`test-notes/` and `mrt-temp/` hold my local beta-testing working notes — not part of the product.

## Testing

- All calendar/snap/report tests pass (115 passed, 1 skipped).
- Full suite: 679 passed, 10 skipped, 2 failed — the 2 failures (`test_pulse_self_repair`) fail identically on `development` without this PR, so they're pre-existing and unrelated.
- The read-only snap was also exercised against my live calendar (5 weeks scanned) as part of measuring the gap-minute impact above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)