### PR TITLE
feat(sidebar): match show-reminders sections/labels in reminders sidebar (v0.39.3)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -59,7 +59,10 @@
       "Write(tests/**)",
       "Write(PROJECT/**)",
       "Bash(REBALANCE_NO_KEYRING=1 .venv/bin/python -c ' *)",
-      "Edit(/.claude/skills/welcome/**)"
+      "Edit(/.claude/skills/welcome/**)",
+      "Bash(sed -n 34,38p PROJECT.md)",
+      "Bash(sed -n 290,294p PROJECT.md)",
+      "Bash(sed -n 654,658p PROJECT.md)"
     ]
   }
 }

--- a/.claude/skills/welcome/SKILL.md
+++ b/.claude/skills/welcome/SKILL.md
@@ -48,9 +48,13 @@ Render the `stages` array every turn, in order, as a checklist:
 Dispatch on the stage's `executor` field:
 
 - `mcp:<tool>` — call that MCP tool. For `setup_github_token`, first send the
-  user to https://github.com/settings/tokens (repo:read scope), have them
-  paste the PAT as the tool argument, and report the validation result
-  (login + scopes) back.
+  user to https://github.com/settings/tokens — classic token with the `repo`
+  scope, or a fine-grained token with Repository access changed from the
+  "Public repositories" default to All/selected repos (read-only Contents +
+  Metadata). Have them paste the PAT as the tool argument and report the
+  validation result (login + scopes) back. If the result carries a
+  `visibility_warning`, surface it verbatim — a public-only token silently
+  hides their private work from discovery.
 - `cli:<command>` — run it with Bash from the repo root, substituting
   `<path>`-style placeholders with values the user gives you.
 - `script:<path>` — run `.venv/bin/python <path>` in the background if it

--- a/.claude/skills/welcome/demo-transcript.md
+++ b/.claude/skills/welcome/demo-transcript.md
@@ -29,14 +29,16 @@ Where does your Obsidian vault live? I'll configure it for you.
 
 **Agent:** *(runs `rebalance config set-vault-path "~/Documents/Noel Saw"`,
 re-checks status)* Done — vault verified. Next: your GitHub PAT. Create one at
-https://github.com/settings/tokens with `repo:read` scope, then paste it
+https://github.com/settings/tokens — classic token with the `repo` scope, or
+a fine-grained token with Repository access changed from the "Public
+repositories" default to All/selected repos — then paste it
 **as the tool argument when I call setup_github_token** — don't paste it into
 the chat.
 
 **You:** *(provides token via the tool prompt)*
 
-**Agent:** Validated — logged in as `noelsaw1`, repo:read confirmed, stored
-keyring-first. Google Calendar next (optional) — set it up now, or skip? You
+**Agent:** Validated — logged in as `noelsaw1`, `repo` scope confirmed
+(private repos visible), stored keyring-first. Google Calendar next (optional) — set it up now, or skip? You
 can add it any time by running /welcome again.
 
 **You:** skip for now

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -160,7 +160,7 @@ Project Registry ────▶ registry.py +              MD registry → proj
 
 | Source | Secret store | Mechanism |
 |---|---|---|
-| GitHub | OS keyring + `temp/rbos.config` fallback; `gh` CLI as last-resort read fallback | PAT with `repo:read`; persisted to both keyring and config for launchd reachability |
+| GitHub | OS keyring + `temp/rbos.config` fallback; `gh` CLI as last-resort read fallback | PAT: classic `repo` scope, or fine-grained with All-repos read-only Contents/Metadata (public-only tokens hide private work); persisted to both keyring and config for launchd reachability |
 | Google Calendar | `google-calendar.env` (client credentials) via `resolve_secret_path()` + pickled OAuth user-token at `resolve_oauth_token_path("calendar")` → `~/.config/rebalance-os/google-calendar-oauth` | OAuth 2.0 user consent |
 | Sleuth | `~/secrets/sleuth-web-api-development.env` (mode 600) | Bearer token, 64-hex |
 | Gmail | Desktop OAuth token in keyring + `~/.config/rebalance-os/google-gmail-oauth` fallback, or MCP push-ingest mode | `gmail.readonly` desktop OAuth, or agent-pushed `ingest_gmail_messages` path when `gmail_ingest_method=mcp` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@
 > **not** reintroduce an `[Unreleased]` block — add to (or roll work into) the
 > current dated version instead. See AGENTS.md → "Versioning & Changelog".
 
+## [0.39.2] - 2026-06-11
+
+### Changed
+- **Sidebar reminders now match the "show reminders" Slack command** — same sections (Due Today → Due after today → Due within last 7 days → Due older than 7 days), same chronological sort, same global A/B/C labels, and resolved assignee display names. The sidebar reads `display.*` fields from the published git-pulse file (which Sleuth's v1.4.184+ export already pre-renders) instead of extracting raw `reminder_message_text` from SQLite. Falls back to the previous flat SQLite list when the published file is unavailable. Addresses the follow-up noted in sleuth-app CHANGELOG v1.4.184.
+- `fetch_sleuth_display_sections()` added to [scripts/dashboard.py](scripts/dashboard.py): reads the local published JSON, recomputes `ageDays` from `createdOn`, returns `(sections, total)` bucketed in `sectionOrder` sequence.
+- `build_nav_data` in [scripts/pulse_web.py](scripts/pulse_web.py) gains a `sleuth_sections` parameter; when present, renders section sub-headers and canonical reminder lines (`{label}.) {summary} ({N}d old) · {assigneeName}` with Slack permalink). Flat `sleuth_rows` fallback path unchanged.
+- Stream badge count reflects the full published total when sections are available (previously capped at 6).
+
+### Fixed
+
+- **PAT guidance named a nonexistent scope (`repo:read`) — user-reported.**
+  GitHub classic tokens have no read-only repo scope, so users hunting for
+  "repo:read" landed on `public_repo` or the fine-grained "Public
+  repositories" default — making their private work silently invisible to
+  discovery and github-scan. All six doc sites (README, ARCHITECTURE,
+  PROJECT ×3, /welcome skill + demo transcript) now give correct guidance:
+  classic `repo` scope, or fine-grained with All-repos read-only
+  Contents/Metadata. PROJECT.md's threat-model line restated honestly
+  (classic `repo` is read/write — treat as sensitive). `setup_github_token`
+  now returns a `visibility_warning` when a valid token likely can't see
+  private repos (classic without `repo`; fine-grained default-trap
+  advisory), and the welcome agent surfaces it verbatim at setup time.
+
 ## [0.39.1] - 2026-06-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 > **not** reintroduce an `[Unreleased]` block — add to (or roll work into) the
 > current dated version instead. See AGENTS.md → "Versioning & Changelog".
 
-## [0.39.2] - 2026-06-11
+## [0.39.3] - 2026-06-12
 
 ### Changed
 - **Sidebar reminders now match the "show reminders" Slack command** — same sections (Due Today → Due after today → Due within last 7 days → Due older than 7 days), same chronological sort, same global A/B/C labels, and resolved assignee display names. The sidebar reads `display.*` fields from the published git-pulse file (which Sleuth's v1.4.184+ export already pre-renders) instead of extracting raw `reminder_message_text` from SQLite. Falls back to the previous flat SQLite list when the published file is unavailable. Addresses the follow-up noted in sleuth-app CHANGELOG v1.4.184.

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -33,7 +33,7 @@ All decisions that create divergence between tiers should be flagged explicitly 
 ## Assumptions
 
 - **Obsidian Vault**: Local folder with clean MD files; frontmatter, headings, tags, and links are well-structured for parsing. Vault size <10k notes to keep embedding feasible on macOS hardware.
-- **Local Setup**: macOS with `mlx-embeddings` (local fork at `WP-DB-Toolkit/mlx-embeddings`) for Qwen3 embeddings via Apple Silicon MLX; optional Ollama/LM Studio for local LLM synthesis; Python 3.12+ with sqlite-vec extension; GitHub PAT with repo:read scope.
+- **Local Setup**: macOS with `mlx-embeddings` (local fork at `WP-DB-Toolkit/mlx-embeddings`) for Qwen3 embeddings via Apple Silicon MLX; optional Ollama/LM Studio for local LLM synthesis; Python 3.12+ with sqlite-vec extension; GitHub PAT (classic `repo` scope, or fine-grained with All-repos read-only Contents/Metadata — public-only tokens hide private work).
 - **GitHub Usage**: 5-6 active repos; PAT stored securely in gitignored config (see Secrets Strategy); activity tracked via API (commits, PRs, issues last 30-90 days).
 - **Google Calendar**: `gcalcli` installed and OAuth2-authenticated; today's agenda pulled via CLI subprocess call.
 - **Project Registry Source**: `Projects/00-project-registry.md` in the Obsidian vault is the human-editable source of truth for project metadata.
@@ -289,7 +289,7 @@ The host agent (not the server) drives this flow by calling MCP tools:
 1. **Check state** — Agent calls `onboarding_status`. If all steps complete, skip onboarding. If any step is incomplete, agent walks the user through remaining steps in order.
 
 2. **GitHub PAT** (first because it's the fastest high-signal bootstrap):
-   - Agent asks user for a PAT with `repo:read` scope.
+   - Agent asks user for a PAT — classic `repo` scope, or fine-grained with Repository access set to All/selected repos (read-only Contents + Metadata; the "Public repositories" default hides private work).
    - Agent calls `setup_github_token` with the PAT.
    - Tool validates against GitHub `/user` endpoint, confirms minimum scope, stores in `temp/rbos.config` (gitignored, repo root — see Secrets Strategy).
    - If validation fails: tool returns error detail, agent prompts replacement.
@@ -653,7 +653,7 @@ Once built, the MCP host becomes the conversational interface to the assembled o
 
 - Config stored at `temp/rbos.config` (JSON, plaintext) relative to **repo root** — not vault root. These are separate locations; do not conflate them.
 - `temp/` is listed in `.gitignore` — never committed
-- PAT scope is read-only (`repo:read`), so exposure impact is low
+- PAT exposure impact depends on token type: a classic `repo` token grants read/write to all repos (GitHub has no read-only private scope on classic tokens) — treat it as sensitive; a fine-grained token with read-only Contents/Metadata genuinely limits blast radius. Keyring-first storage either way.
 - CLI commands:
   - `rebalance config set-github-token <PAT>` — store PAT
   - `rebalance config get-github-token` — check config (masked output)

--- a/README.md
+++ b/README.md
@@ -188,7 +188,9 @@ The manual steps below remain for reference and for environments without an MCP 
 - macOS with Apple Silicon (M1+)
 - Python 3.13 recommended for the local MLX embeddings stack
 - An Obsidian vault (local folder with `.md` files)
-- A GitHub Personal Access Token with `repo:read` scope ([create one here](https://github.com/settings/tokens))
+- A GitHub Personal Access Token ([create one here](https://github.com/settings/tokens)) — either:
+  - **classic token** with the `repo` scope (GitHub offers no read-only private scope on classic tokens; `public_repo` alone makes your private work invisible to discovery), or
+  - **fine-grained token** — change *Repository access* from the default **"Public repositories"** to *All repositories* (or the ones you work in), with read-only **Contents** and **Metadata** permissions.
 - Claude Code (CLI or VS Code extension)
 
 ### Step 1 — Clone and install

--- a/scripts/dashboard.py
+++ b/scripts/dashboard.py
@@ -642,6 +642,86 @@ def fetch_sleuth_due(limit: int = 4) -> list[dict[str, Any]]:
     return out
 
 
+def fetch_sleuth_display_sections() -> tuple[list[dict[str, Any]], int]:
+    """Read the published Sleuth reminders file and return (sections, total).
+
+    Each section is {sectionKey, sectionLabel, reminders: [{label, summary,
+    assigneeName, permalink, ageDays, shouldPostOn}]}, ordered per
+    display.sectionOrder. ageDays is recomputed from createdOn at call time.
+
+    Returns ([], 0) on any error (missing file, bad config, etc.).
+    """
+    try:
+        from rebalance.ingest.config import get_sleuth_credentials
+        from rebalance.ingest.sleuth_reminders import (
+            _local_source_path,
+            _read_payload_from_file,
+        )
+    except ImportError:
+        return [], 0
+
+    try:
+        env = get_sleuth_credentials("production")
+        base_url = env.get("SLEUTH_WEB_API_BASE_URL", "")
+        file_path = _local_source_path(base_url)
+        if file_path is None:
+            return [], 0
+        data = _read_payload_from_file(file_path)
+    except Exception:
+        return [], 0
+
+    top_display = data.get("display") or {}
+    # sectionOrder is [{key, label}, ...] in the published file
+    section_order_raw = top_display.get("sectionOrder") or []
+    section_order = [
+        s["key"] for s in section_order_raw if isinstance(s, dict) and s.get("key")
+    ] or ["dueToday", "dueUpcoming", "dueLastWeek", "dueOlder"]
+
+    reminders_raw = data.get("reminders") or []
+    now_utc = datetime.now(timezone.utc)
+
+    sections_by_key: dict[str, dict[str, Any]] = {}
+    for r in reminders_raw:
+        disp = r.get("display") or {}
+        section_key = disp.get("sectionKey")
+        if not section_key:
+            continue
+
+        created_on = r.get("createdOn") or ""
+        try:
+            created_dt = datetime.fromisoformat(created_on.replace("Z", "+00:00"))
+            age_days = max(0, int((now_utc - created_dt).total_seconds() / 86400))
+        except (ValueError, TypeError, AttributeError):
+            age_days = int(disp.get("ageDays") or 0)
+
+        entry = {
+            "label":        disp.get("label", ""),
+            "summary":      disp.get("summary", ""),
+            "assigneeName": disp.get("assigneeName", ""),
+            "permalink":    disp.get("permalink", ""),
+            "sectionLabel": disp.get("sectionLabel", section_key),
+            "sectionKey":   section_key,
+            "ageDays":      age_days,
+            "shouldPostOn": r.get("shouldPostOn"),
+        }
+
+        if section_key not in sections_by_key:
+            sections_by_key[section_key] = {
+                "sectionKey":   section_key,
+                "sectionLabel": disp.get("sectionLabel", section_key),
+                "reminders":    [],
+            }
+        sections_by_key[section_key]["reminders"].append(entry)
+
+    result = [
+        sections_by_key[key]
+        for key in section_order
+        if key in sections_by_key and sections_by_key[key]["reminders"]
+    ]
+    total = sum(len(s["reminders"]) for s in result)
+    return result, total
+
+
 def fetch_recent_emails(limit: int = 30) -> list[dict[str, Any]]:
     try:
         with db_connection(DB_PATH) as conn:

--- a/scripts/pulse_web.py
+++ b/scripts/pulse_web.py
@@ -47,6 +47,7 @@ from dashboard import (  # type: ignore  # noqa: E402
     fetch_recent_figma,
     fetch_recent_github,
     fetch_repo_activity_counts,
+    fetch_sleuth_display_sections,
     fetch_sleuth_due,
     fetch_vault_recent,
     fetch_watched_summary,
@@ -1264,6 +1265,7 @@ def build_nav_data(
     cal_rows: list[dict[str, Any]],
     sleuth_rows: list[dict[str, Any]],
     sleuth_synced: bool,
+    sleuth_sections: list[dict[str, Any]] | None = None,
     streams: list[dict[str, Any]],
     drift_total: int,
     semantic_total: int,
@@ -1278,6 +1280,11 @@ def build_nav_data(
     Sleuth helpers and the DB-derived rows). The pure shell that frames these
     strings lives in :func:`rebalance.web_components.render_sidebar`, which keeps
     that module stdlib-only.
+
+    When ``sleuth_sections`` is provided (from ``fetch_sleuth_display_sections``),
+    reminders are rendered with the same section/label/assignee format as the
+    Slack "show reminders" command. Falls back to the flat ``sleuth_rows`` path
+    when the published file is unavailable.
     """
     cal_items = []
     for ev in cal_rows:
@@ -1294,29 +1301,66 @@ def build_nav_data(
         cal_items.append('<li class="side-row empty"><div class="side-row-meta">No upcoming events.</div></li>')
 
     sleuth_items = []
-    for s in sleuth_rows:
-        msg = compact_sleuth_reminder(s.get("reminder_message_text") or "")
-        msg = _truncate(msg, 90)
-        when = _format_dt_short(s.get("should_post_on"), tz=tz) if s.get("should_post_on") else ""
-        role = "from me" if s.get("sleuth_role") == "assigned_by_me" else "for me"
-        meta_bits = [b for b in [when, role] if b]
-        slack_url = build_slack_url(s)
-        body = f"""
-            <div class="side-row-title">{_esc(msg)}</div>
-            <div class="side-row-meta">{_esc(' · '.join(meta_bits))}</div>
-        """
-        if slack_url:
-            sleuth_items.append(f"""
+    if sleuth_sections:
+        # Published-file path: section headers + canonical "show reminders" format.
+        _SUBSECTION_LI = (
+            "style='font-size:10.5px;text-transform:uppercase;letter-spacing:.06em;"
+            "color:var(--fg-dim);padding:10px 8px 3px;pointer-events:none;'"
+        )
+        for section in sleuth_sections:
+            section_label = section.get("sectionLabel", "")
+            sleuth_items.append(
+                f"<li {_SUBSECTION_LI}>{_esc(section_label)}</li>"
+            )
+            for r in section.get("reminders") or []:
+                label    = r.get("label", "")
+                summary  = _truncate(r.get("summary", ""), 90)
+                age_days = int(r.get("ageDays") or 0)
+                assignee = r.get("assigneeName", "")
+                permalink = r.get("permalink", "")
+                due_str  = _format_dt_short(r.get("shouldPostOn"), tz=tz) if r.get("shouldPostOn") else ""
+
+                age_part  = f" ({age_days}d old)" if age_days else ""
+                title_txt = f"{label}.) {summary}{age_part}" if label else f"{summary}{age_part}"
+                meta_bits = [b for b in [due_str, assignee] if b]
+                body = (
+                    f"<div class='side-row-title'>{_esc(title_txt)}</div>"
+                    f"<div class='side-row-meta'>{_esc(' · '.join(meta_bits))}</div>"
+                )
+                if permalink:
+                    sleuth_items.append(
+                        f"<li class='side-row has-link'>"
+                        f"<a class='side-row-link' href='{_esc(permalink)}' "
+                        f"target='_blank' rel='noopener noreferrer' title='Open in Slack'>"
+                        f"{body}</a></li>"
+                    )
+                else:
+                    sleuth_items.append(f"<li class='side-row'>{body}</li>")
+    else:
+        # Fallback: flat list from SQLite (no display fields available).
+        for s in sleuth_rows:
+            msg = compact_sleuth_reminder(s.get("reminder_message_text") or "")
+            msg = _truncate(msg, 90)
+            when = _format_dt_short(s.get("should_post_on"), tz=tz) if s.get("should_post_on") else ""
+            role = "from me" if s.get("sleuth_role") == "assigned_by_me" else "for me"
+            meta_bits = [b for b in [when, role] if b]
+            slack_url = build_slack_url(s)
+            body = f"""
+                <div class="side-row-title">{_esc(msg)}</div>
+                <div class="side-row-meta">{_esc(' · '.join(meta_bits))}</div>
+            """
+            if slack_url:
+                sleuth_items.append(f"""
           <li class="side-row has-link">
             <a class="side-row-link" href="{_esc(slack_url)}" target="_blank" rel="noopener noreferrer" title="Open in Slack">
               {body}
             </a>
           </li>
-            """)
-        else:
-            sleuth_items.append(f"""
+                """)
+            else:
+                sleuth_items.append(f"""
           <li class="side-row">{body}</li>
-            """)
+                """)
     if not sleuth_items:
         if sleuth_synced:
             # Genuinely empty — Sleuth synced and there is nothing pending.
@@ -2570,7 +2614,9 @@ def build_page(*, goals_path: Path, vault_path: Path | None, refresh_seconds: in
     org_activity_rows = fetch_org_activity(days=org_activity_days)
     vault_rows = fetch_vault_recent(limit=6)
     cal_rows = fetch_calendar_upcoming(now, limit=6)
-    sleuth_rows = fetch_sleuth_due(limit=6)
+    sleuth_sections, sleuth_total = fetch_sleuth_display_sections()
+    # Fallback to the DB-backed flat list when the published file is unavailable.
+    sleuth_rows = fetch_sleuth_due(limit=6) if not sleuth_sections else []
     email_rows = fetch_recent_emails(limit=30)
     figma_rows = fetch_recent_figma(limit=12)
     repo_pie_days = 7
@@ -2586,13 +2632,14 @@ def build_page(*, goals_path: Path, vault_path: Path | None, refresh_seconds: in
     )
 
     in_progress = sum(1 for g in goals if not g["done"])
+    _sleuth_count = sleuth_total if sleuth_sections else len(sleuth_rows)
     streams = build_stream_rows(
         status,
         live_counts={
             "github": len(gh_rows),
             "vault": len(vault_rows),
             "calendar": len(cal_rows),
-            "sleuth": len(sleuth_rows),
+            "sleuth": _sleuth_count,
             "email": len(email_rows),
         },
     )
@@ -2626,6 +2673,7 @@ def build_page(*, goals_path: Path, vault_path: Path | None, refresh_seconds: in
         cal_rows=cal_rows,
         sleuth_rows=sleuth_rows,
         sleuth_synced=sleuth_synced,
+        sleuth_sections=sleuth_sections or None,
         streams=streams,
         drift_total=drift_total,
         semantic_total=semantic_total,

--- a/src/rebalance/__init__.py
+++ b/src/rebalance/__init__.py
@@ -28,7 +28,7 @@ import logging
 import os
 
 __all__ = ["__version__"]
-__version__ = "0.39.1"
+__version__ = "0.39.2"
 
 
 def _configure_logging() -> None:

--- a/src/rebalance/ingest/github_scan.py
+++ b/src/rebalance/ingest/github_scan.py
@@ -325,6 +325,39 @@ def validate_github_token(token: str) -> dict[str, Any]:
     return {"valid": False, "login": "", "scopes": [], "error": f"HTTP {status}", "status": status}
 
 
+def token_visibility_warning(token: str, scopes: list[str]) -> str | None:
+    """Warn when a valid token likely can't see private repositories.
+
+    The docs used to name a nonexistent ``repo:read`` scope, which steered
+    users to public-only tokens (classic ``public_repo``, or the fine-grained
+    "Public repositories" default) — discovery then silently missed all
+    their private work. Heuristics:
+
+    - classic tokens report scopes via ``x-oauth-scopes``: anything without
+      ``repo`` is public-only for our purposes
+    - fine-grained tokens (``github_pat_``) report NO scopes header, so
+      visibility can't be verified remotely — surface the default-trap
+      advisory instead
+    """
+    if scopes:  # classic token — scopes are authoritative
+        if "repo" in scopes:
+            return None
+        return (
+            f"classic token without the `repo` scope (has: {', '.join(scopes)}) — "
+            "private repositories are INVISIBLE to discovery and github-scan. "
+            "Re-issue with the `repo` scope, or use a fine-grained token with "
+            "All-repos read-only Contents/Metadata."
+        )
+    if token.startswith("github_pat_"):
+        return (
+            "fine-grained token — GitHub doesn't expose its repository access "
+            "remotely. Confirm Repository access was changed from the default "
+            "'Public repositories' to All/selected repositories, or your "
+            "private work stays invisible to discovery."
+        )
+    return None  # gho_/other ambient tokens: no scopes header, no verdict
+
+
 def resolve_working_token(primary_token: str) -> str:
     """Return a GitHub token that currently authenticates, falling back to gh CLI.
 

--- a/src/rebalance/mcp/tools/onboarding.py
+++ b/src/rebalance/mcp/tools/onboarding.py
@@ -79,12 +79,20 @@ def register(mcp: FastMCP, database_path: Path) -> None:
         """
         Validate a GitHub PAT against the /user endpoint and store it.
 
-        Returns validation result with login and scopes.  If invalid,
-        the token is not stored.
+        Returns validation result with login and scopes. If invalid, the
+        token is not stored. A ``visibility_warning`` field is set when the
+        token likely cannot see private repositories (classic token without
+        ``repo``, or a fine-grained token that may still have the
+        public-only default) — surface it to the user verbatim.
         """
+        from rebalance.ingest.github_scan import token_visibility_warning
+
         result = validate_github_token(token)
         if result["valid"]:
             set_github_token(token)
+            warning = token_visibility_warning(token, result.get("scopes", []))
+            if warning:
+                result["visibility_warning"] = warning
         return result
 
     @mcp.tool()

--- a/tests/test_config_github_token.py
+++ b/tests/test_config_github_token.py
@@ -320,3 +320,31 @@ class ConfigPathResolutionTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TokenVisibilityWarningTests(unittest.TestCase):
+    """The docs' nonexistent `repo:read` scope steered users to public-only
+    tokens; setup now warns when a valid token likely can't see private repos."""
+
+    def test_classic_repo_scope_is_clean(self):
+        from rebalance.ingest.github_scan import token_visibility_warning
+
+        self.assertIsNone(token_visibility_warning("ghp_x", ["repo", "read:org"]))
+
+    def test_classic_public_only_warns(self):
+        from rebalance.ingest.github_scan import token_visibility_warning
+
+        warning = token_visibility_warning("ghp_x", ["public_repo"])
+        self.assertIn("INVISIBLE", warning)
+        self.assertIn("public_repo", warning)
+
+    def test_fine_grained_gets_default_trap_advisory(self):
+        from rebalance.ingest.github_scan import token_visibility_warning
+
+        warning = token_visibility_warning("github_pat_x", [])
+        self.assertIn("Public repositories", warning)
+
+    def test_ambient_tokens_without_scopes_get_no_verdict(self):
+        from rebalance.ingest.github_scan import token_visibility_warning
+
+        self.assertIsNone(token_visibility_warning("gho_x", []))


### PR DESCRIPTION
## Summary
- Sidebar reminders now render with the same four due-date sections (Due Today → Due after today → Due within last 7 days → Due older than 7 days), global A/B/C labels, and resolved assignee display names as the Slack `show reminders` command
- Reads `display.*` fields from the published git-pulse JSON (Sleuth v1.4.184+ already pre-renders these) instead of extracting raw `reminder_message_text` from SQLite
- Stream badge count now reflects the full published total (previously capped at 6)
- Falls back gracefully to the existing flat SQLite list when the published file is unavailable

## Changes
- `fetch_sleuth_display_sections()` added to `scripts/dashboard.py`: reads local published JSON, recomputes `ageDays` live from `createdOn`, returns `(sections, total)` in `sectionOrder`
- `build_nav_data` in `scripts/pulse_web.py` gains optional `sleuth_sections` parameter with new section-aware rendering path; old `sleuth_rows` fallback unchanged

## Test plan
- [ ] 844 existing tests pass (`uv run pytest tests/ --ignore=tests/test_pulse_warning_watch.py`)
- [ ] Sidebar visually shows section headers and A/B/C labels matching Slack output
- [ ] Fallback works when `SLEUTH_WEB_API_BASE_URL` is not a local file path

🤖 Generated with [Claude Code](https://claude.com/claude-code)