### PR TITLE
refactor(auth/collect): ponytail dedup — Part 1 (auth + collect→store)

### DIFF
--- a/AUDIT-AUTH-COLLECT-STORE-PART-1.md
+++ b/AUDIT-AUTH-COLLECT-STORE-PART-1.md
@@ -211,17 +211,18 @@ place to update OAuth refresh, no new dependencies.
 
 *Zero risk. ~1 line. Do this first; it can ship alone.*
 
-- [ ] Delete `secrets` field from the `Collector` dataclass (`index_ops.py:85`)
-- [ ] Remove `secrets` from the `Collector` docstring (`index_ops.py:73–76`)
-- [ ] Grep confirms zero `.secrets` references remain before deleting
-- [ ] `rebalance refresh_index --dry-run` still enumerates all collectors
+- [x] Delete `secrets` field from the `Collector` dataclass
+- [x] Remove `secrets` from the `Collector` docstring
+- [x] Grep confirms zero `.secrets` references remain (also removed the one
+      write-only assignment at the figma registration)
+- [x] Registry still builds — 11 collectors enumerated
 
 **QA checklist — Phase 1**
-- [ ] DRY: no remaining reference to the removed field anywhere
-- [ ] Behavior unchanged: registry still registers the same N collectors
-- [ ] Tests: existing `tests/` collect→store suite green
-- [ ] `rebalance doctor` clean
-- [ ] Anti-goal check: did **not** "tidy" adjacent fields (`kind`,
+- [x] DRY: no remaining `secrets` reference anywhere in src/tests
+- [x] Behavior unchanged: registry registers the same 11 collectors
+- [x] Tests: full suite **1002 passed, 10 skipped**
+- [x] `rebalance doctor` clean (credential/schema/projects/auth-log all OK)
+- [x] Anti-goal check: did **not** touch adjacent fields (`kind`,
       `included_in_all`) — those stay (see Phase 4)
 
 ---

--- a/AUDIT-AUTH-COLLECT-STORE-PART-1.md
+++ b/AUDIT-AUTH-COLLECT-STORE-PART-1.md
@@ -1,7 +1,7 @@
 ---
 title: "Ponytail Audit — Auth + Collect→Store (Part 1 of 2)"
 doc_type: audit + refactor-plan
-status: audit-complete · Phase 3 done (2026-06-18) · Phases 1–2 pending
+status: audit-complete · Phases 1–3 done (2026-06-18) · Phase 4 = deliberate skips
 scope:
   slice_1_auth: "GitHub PAT · Google OAuth (calendar + gmail) · Sleuth bearer · token_meta · auth_log"
   slice_2_collect_store: "Collector registry · refresh_index orchestrator · db/ package · per-source collectors"
@@ -24,7 +24,7 @@ related:
 
 | Most recently completed phase | What's next |
 |---|---|
-| **Phase 3 — Credential I/O dedup** ✅ (2026-06-18, branch `refactor/phase3-credential-io-dedup`) — done out of order, in isolation, with tests; 1002 tests green, doctor clean | **Phase 1 — Dead code & trivial wins**, then **Phase 2 — Shared helpers** (both still pending) |
+| **Phase 2 — Shared helpers** ✅ (2026-06-18, branch `refactor/phase3-credential-io-dedup`) — adapter factory + parse dedup landed; `_safe_*` consolidation deliberately skipped. All of Phases 1–3 done; 1002 tests green, doctor clean | **Part 2** — query layer · LLM synthesis · MCP surface · CLI · dashboard/pulse · scheduler (Phase 4 here is just recorded skips) |
 
 > **Read me first:** This is two documents in one. The **Audit** (top) is the
 > ground-truth read of the two slices as they stand today. The **Ponytail
@@ -231,25 +231,40 @@ place to update OAuth refresh, no new dependencies.
 
 *Low risk, mechanical. Pure dedup; same options pass through unchanged.*
 
-- [ ] Add `_make_adapter(refresh_fn)` passthrough factory; replace the 10 hand
-      adapters (`index_ops.py:1264–1434`) — ~25 LOC → ~5
-- [ ] Collapse `_safe_count`/`_safe_max`/`_safe_meta` into one
-      `_safe_query(conn, sql, params=())` (`index_ops.py:163–184`); update the
-      ~3 call sites (`index_ops.py:231–268`)
-- [ ] Extract `parse_iso8601(text)->datetime|None` into a shared
-      `ingest/` util; replace hand-rolled copies in `sleuth_reminders.py:113–128`,
-      `github_scan.py:123–125`, and calendar/gmail/figma equivalents
-- [ ] Leave a `# ponytail:` note on `_make_adapter` documenting the passthrough
-      contract (opts are filtered by each `refresh_fn`)
+- [x] Add `_dry_run_adapter(refresh_fn)` factory; replaced the **8**
+      dry_run-only adapters (sleuth, email, code, figma, semantic, sync,
+      ask_self, focus5) with one-line assignments. vault/github/calendar keep
+      their bespoke option-mapping adapters (not boilerplate).
+- [x] **Parse dedup — reused the *existing* `tz_utils.parse_utc_iso`** instead
+      of writing a new util (it already does the `Z`→`+00:00` dance, None on
+      bad/empty, naive→UTC). Migrated the two in-slice hand-rolled copies:
+      `sleuth_reminders._parse_datetime` (kept its non-str guard) and
+      `token_meta.age_text`.
+- [~] **SKIPPED `_safe_count`/`_safe_max`/`_safe_meta` → `_safe_query`.** On
+      inspection this is net-negative: the three return *different shapes*
+      (int / scalar / dict) with different defaults (0 / None / {}); a single
+      raw-row helper would push shaping into ~17 call sites — more code, not
+      less. The three tiny named helpers are already the minimal readable form.
+- [x] Factory carries a docstring documenting the dry_run-only passthrough
+      contract (bespoke sources keep their own adapter).
+
+> **Scope note:** the other hand-rolled `Z`-dance copies (`diagnose.py`,
+> `github_readiness.py`, `note_builder.py`, `pulse_health.py`) are Part-2
+> modules (query/diagnostics/render) — intentionally left for Part 2 to avoid
+> reaching outside this slice.
 
 **QA checklist — Phase 2**
-- [ ] DRY: 10 adapters → 1 factory; 3 `_safe_*` → 1; 4+ date parsers → 1
-- [ ] SOLID: each `refresh_fn` signature untouched; factory adds no new coupling
-- [ ] Observability: `index_status` counts/timestamps identical before/after
-- [ ] Correctness: ISO-8601 util preserves the `Z`→`+00:00` + tz-naive→UTC
-      behavior of every replaced parser (table-test the edge cases)
-- [ ] Tests: `tests/test_*` for sleuth/github/calendar/gmail pass unchanged
-- [ ] Anti-goal: did **not** touch upsert/diff/migration logic
+- [x] DRY: 8 adapters → 1 factory; 2 in-slice date parsers → existing
+      `parse_utc_iso`. (`_safe_*` consolidation deliberately not done — see above.)
+- [x] SOLID: each `refresh_fn` signature untouched; factory adds no new coupling
+- [x] Observability: `index_status` counts/timestamps unchanged (the `_safe_*`
+      helpers it depends on were left as-is)
+- [x] Correctness: parse behavior verified — Z-parse, non-str→None, bad/empty→
+      None/"", naive→UTC, age `6.0h` all preserved
+- [x] Tests: full suite **1002 passed, 10 skipped**; sleuth/calendar/gmail/
+      auth-log tests unchanged
+- [x] Anti-goal: did **not** touch upsert/diff/migration logic, and did **not**
+      reach into Part-2 modules for the remaining parse copies
 
 ---
 

--- a/AUDIT-AUTH-COLLECT-STORE-PART-1.md
+++ b/AUDIT-AUTH-COLLECT-STORE-PART-1.md
@@ -1,0 +1,325 @@
+---
+title: "Ponytail Audit — Auth + Collect→Store (Part 1 of 2)"
+doc_type: audit + refactor-plan
+status: audit-complete · Phase 3 done (2026-06-18) · Phases 1–2 pending
+scope:
+  slice_1_auth: "GitHub PAT · Google OAuth (calendar + gmail) · Sleuth bearer · token_meta · auth_log"
+  slice_2_collect_store: "Collector registry · refresh_index orchestrator · db/ package · per-source collectors"
+part: 1 of 2
+part_2_covers: "query layer · LLM synthesis · MCP surface · CLI · dashboard/pulse · scheduler"
+created: 2026-06-18
+owner: noel@neochro.me
+intensity: ponytail/full
+sources_surveyed:
+  - ARCHITECTURE.md
+  - ask_self RAG (codebase index)
+  - direct read of auth + collect→store source
+related:
+  - ARCHITECTURE.md
+  - PLUGINS.md
+  - PROJECT.md
+---
+
+# Ponytail Audit — Auth + Collect→Store (Part 1 of 2)
+
+| Most recently completed phase | What's next |
+|---|---|
+| **Phase 3 — Credential I/O dedup** ✅ (2026-06-18, branch `refactor/phase3-credential-io-dedup`) — done out of order, in isolation, with tests; 1002 tests green, doctor clean | **Phase 1 — Dead code & trivial wins**, then **Phase 2 — Shared helpers** (both still pending) |
+
+> **Read me first:** This is two documents in one. The **Audit** (top) is the
+> ground-truth read of the two slices as they stand today. The **Ponytail
+> Refactor** (bottom) is the *optional* plan to act on it. Headline finding:
+> **both slices are solid and conservative — there is no egregious
+> over-engineering.** The refactor is small on purpose; most of it is
+> deduplication, and the riskiest items touch a trust boundary and may not be
+> worth doing at all.
+
+---
+
+## Table of Contents
+
+- [Audit](#audit)
+  - [A1. Scope & method](#a1-scope--method)
+  - [A2. Slice 1 — Auth / credentials](#a2-slice-1--auth--credentials)
+  - [A3. Slice 2 — Collect→Store](#a3-slice-2--collectstore)
+  - [A4. Keep-as-is (do not touch)](#a4-keep-as-is-do-not-touch)
+  - [A5. Findings table (all, ranked)](#a5-findings-table-all-ranked)
+  - [A6. LOC inventory](#a6-loc-inventory)
+- [Ponytail Refactor](#ponytail-refactor)
+  - [R0. Ladder verdict](#r0-ladder-verdict)
+  - [Phase 1 — Dead code & trivial wins](#phase-1--dead-code--trivial-wins)
+  - [Phase 2 — Shared helpers (collect→store)](#phase-2--shared-helpers-collectstore)
+  - [Phase 3 — Credential I/O dedup (trust boundary)](#phase-3--credential-io-dedup-trust-boundary)
+  - [Phase 4 — Deliberately skipped (YAGNI)](#phase-4--deliberately-skipped-yagni)
+
+---
+
+# Audit
+
+## A1. Scope & method
+
+Two **sequential** slices of the core pipeline (`Signals → Ingest → SQLite → …`):
+
+1. **Auth** — the credential *gate* that must hold before any source collects.
+2. **Collect→Store** — the ingest layer: registry dispatch → per-source
+   collectors → normalize → upsert into SQLite.
+
+`auth` and `collect→store` are a genuine dependency chain (auth precedes
+collect). "Collection" and "ingest" are **not** separate stages here — in this
+repo `ingest/` is the umbrella directory that *contains* collection plus
+normalize+store, so we audit them as one slice to avoid double-counting.
+
+Method: ARCHITECTURE.md + ask_self RAG for the conceptual map, then a full read
+of the source in each slice with file:line citations.
+
+## A2. Slice 1 — Auth / credentials
+
+**What it does.** Five integrations (GitHub PAT, Google Calendar OAuth, Gmail
+OAuth, Sleuth bearer, Figma PAT) share one discipline: **keyring-primary,
+config-fallback**.
+
+- **Keyring** (macOS Keychain / Win Credential Locker / Linux Secret Service) —
+  primary store; reads/writes are best-effort and degrade to `None` instead of
+  raising (`config.py:54–74`).
+- **`temp/rbos.config`** (gitignored JSON) — duplicate copy so **launchd** jobs
+  (stripped env, no Keychain) can still authenticate. Every secret is
+  dual-written.
+- **GitHub** — three-tier read: keyring → config → `gh auth token`; validated
+  against `/user` with token-type classification.
+- **Google OAuth (calendar + gmail)** — token in keyring (JSON) + pickle-file
+  fallback (`~/.config/rebalance-os/google-{svc}-oauth`); auto-refresh on
+  expiry writes the rotated access token back to **both** stores.
+- **Sleuth** — bearer creds (base_url/token/workspace) in keyring + config, with
+  a legacy env-file fallback parsed manually.
+- **`token_meta.py`** (112 LOC) — sidecar `temp/logs/token_meta.json`: SHA-256
+  **fingerprint** of the token value (never the raw secret), `first_added_at`,
+  re-set counts. Distinguishes *rotation* (new key) from *refresh* (same key,
+  new expiry) — this is how "PAT dies every 3 days" gets diagnosed.
+- **`auth_log.py`** (372 LOC) — append-only JSONL (`temp/logs/auth_activity.jsonl`)
+  unified across collectors + launchd; readers `latest_failure_by_source()` /
+  `latest_event_by_source()` back the dashboard `/auth-log` and `rebalance doctor`.
+- **`google_oauth_client.py`** (34 LOC) — one base64'd Desktop client shared by
+  calendar + gmail; single rotation point.
+
+**Headline:** conservative and correct. The duplication problem is **two
+near-identical OAuth loaders** (`calendar.py:83–149` ≈ `gmail.py:79–147`, ~85%
+overlap) and a repeated **get/set/clear dual-store dance** per secret type.
+
+## A3. Slice 2 — Collect→Store
+
+**What it does.** A `Collector` frozen dataclass (`index_ops.py:33–85`) +
+registry dispatcher is the whole contract:
+
+- Fields: `name`, `refresh` callable `(db_path, **opts)→dict`, `requires`
+  (preconditions), `included_in_all`, `kind`
+  (`raw_source`/`derived_scan`/`projection`/`export`), `semantic_docs`
+  (optional provider), `secrets` (informational).
+- `register_collector()` (`index_ops.py:100–122`) validates name/kind, forbids
+  dupes.
+- `refresh_index()` (`index_ops.py:1040–1251`) is the single entry point:
+  normalize scope → `run_migrations()` once → per-scope loop validates
+  preconditions, calls `collector.refresh()`, catches exceptions into a
+  structured error envelope. `None`/`all` → default recipe.
+- **DB layer** (`db/connection.py:20–72`): `db_connection(path, ensure_fn)`
+  opens WAL SQLite, FK on, sqlite-vec loaded, row_factory set. Migrations are
+  forward-only, version-stamped, atomic (`db/migrate.py`).
+- **Shared collect idiom** (exemplars `sleuth_reminders.py`, `github_scan.py`):
+  fetch → normalize to dataclass → upsert by PK (SELECT → INSERT new / UPDATE
+  changed / bump `last_seen_at` if unchanged) → optional reconciliation sweep →
+  return counts.
+
+**Headline:** the registry/migration/upsert core is genuinely good. The fat is
+**boilerplate**: 10 near-identical adapter wrappers, three `_safe_*` query
+helpers that could be one, hand-rolled ISO-8601 parsing duplicated across 4+
+collectors, and one dead field on the contract.
+
+## A4. Keep-as-is (do not touch)
+
+These are correct and/or trust-boundary — **out of scope for the refactor**:
+
+- **Keyring graceful-degrade** never raises (`config.py:54–74`).
+- **Token never logged whole** — SHA-256 fingerprint only (`token_meta.py:31–33`).
+- **Dual-write keyring+config** in lockstep (launchd safety) — every setter.
+- **Best-effort `try/except` around logging** so a log failure never breaks a
+  credential write.
+- **OAuth refresh isolation** — only rotated access tokens written back; refresh
+  token used for fingerprinting (`calendar.py:123–140`, `gmail.py:119–138`).
+- **Registry pattern + `register_collector` validation** (`index_ops.py:33–154`).
+- **Migration safety** — forward-only, atomic, version-stamped (`db/migrate.py`).
+- **Upsert + diff + reconciliation correctness** — field-by-field, unchanged
+  tracking, absent-row retirement only on full fetch
+  (`sleuth_reminders.py:420–443, 573–708`).
+- **Incremental sync semantics** — multi-source repo discovery, A/B/C banding,
+  cutoff stopping (`index_ops.py:429–567`, `github_scan.py:177–218`).
+
+## A5. Findings table (all, ranked)
+
+| # | Slice | Finding | File:line | Value | Risk | Phase |
+|---|---|---|---|---|---|---|
+| 1 | collect | `Collector.secrets` field declared, never read | `index_ops.py:85` | High | None (dead) | 1 |
+| 2 | collect | 10 adapter wrappers repeat the same passthrough | `index_ops.py:1264–1434` | Med | None | 2 |
+| 3 | collect | `_safe_count`/`_safe_max`/`_safe_meta` → one `_safe_query` | `index_ops.py:163–184` | Med | Low (error paths only) | 2 |
+| 4 | collect | hand-rolled ISO-8601 parsing duplicated | `sleuth_reminders.py:113–128`, `github_scan.py:123–125`, calendar/gmail/figma | Med | None | 2 |
+| 5 | auth | get/set/clear dual-store dance repeated per secret | `config.py:191–391` (scattered) | High | **High (trust boundary)** | 3 |
+| 6 | auth | Calendar/Gmail `_load_credentials()` ~85% identical | `calendar.py:83–149`, `gmail.py:79–147` | High | **High (refresh path)** | 3 |
+| 7 | auth | GitHub get-with-source mutates on read (auto-migrate) | `config.py:191–213` | Med | Low | 4 (opt) |
+| 8 | auth | Sleuth env parse → `python-dotenv` | `config.py:1314–1347` | Low | Low + **new dep** | 4 (reject) |
+| 9 | auth | consolidate `_normalize_*` helpers | `config.py` (~100 LOC) | Low | Low | 4 (defer) |
+| 10 | auth | log swallowed exceptions at debug level | `config.py` (9 sites) | Med | Low (additive) | 4 (opt) |
+| 11 | both | `kind` metadata is near-cosmetic; repo doc it cites is missing | `index_ops.py:60–65,83,134` | Low | Low | 4 (defer) |
+| 12 | auth | GitHub repo regex strictness | `config.py:103–152` | V.Low | Low | skip |
+
+## A6. LOC inventory
+
+**Auth slice ≈ 4,000 LOC** — bulk is `config.py` **1,364** (monolith),
+`config_cmds.py` 745, `calendar.py`/`gmail.py` 421 each (842, with ~58 dup
+lines), `paths.py` 458, `auth_log.py` 372, `token_meta.py` 112,
+`google_oauth_client.py` 34.
+
+**Collect→store core ≈ 8,300 LOC** (full `ingest/` is ~23,102) — `index_ops.py`
+**1,464**, `db/semantic.py` ~1,100, `github_scan.py` 809, `sleuth_reminders.py`
+736, `calendar.py` 663, `db/schema.py` ~500, `gmail.py` 421, `registry.py` 351,
+`figma.py` 328, `db/migrate.py` 100, `db/connection.py` 73, `db/__init__.py` 55.
+
+---
+
+# Ponytail Refactor
+
+## R0. Ladder verdict
+
+Rung 1 of the ladder — *does this need to exist at all?* — applied to the
+refactor itself: **mostly no.** Nothing here is broken; this is pure
+maintenance-cost reduction. So the plan is deliberately small and **front-loads
+the free wins**:
+
+- **Phases 1–2 are worth doing** — zero/low risk, delete real boilerplate
+  (~50–60 LOC), no behavior change.
+- **Phase 3 is committed (2026-06-18) — do it with tests.** Real duplication on
+  the credential trust boundary; the trade chosen is to pay for it with mandatory
+  test coverage rather than leave the dup.
+- **Phase 4 is mostly "don't"** — including rejecting the `python-dotenv`
+  suggestion: adding a dependency to replace 8 lines of parsing is the opposite
+  of lazy, and ARCHITECTURE.md already records "parsed manually (no
+  python-dotenv)" as a deliberate choice.
+
+Estimated total payoff if Phases 1–3 land: **~110–130 LOC deleted**, one fewer
+place to update OAuth refresh, no new dependencies.
+
+---
+
+## Phase 1 — Dead code & trivial wins
+
+*Zero risk. ~1 line. Do this first; it can ship alone.*
+
+- [ ] Delete `secrets` field from the `Collector` dataclass (`index_ops.py:85`)
+- [ ] Remove `secrets` from the `Collector` docstring (`index_ops.py:73–76`)
+- [ ] Grep confirms zero `.secrets` references remain before deleting
+- [ ] `rebalance refresh_index --dry-run` still enumerates all collectors
+
+**QA checklist — Phase 1**
+- [ ] DRY: no remaining reference to the removed field anywhere
+- [ ] Behavior unchanged: registry still registers the same N collectors
+- [ ] Tests: existing `tests/` collect→store suite green
+- [ ] `rebalance doctor` clean
+- [ ] Anti-goal check: did **not** "tidy" adjacent fields (`kind`,
+      `included_in_all`) — those stay (see Phase 4)
+
+---
+
+## Phase 2 — Shared helpers (collect→store)
+
+*Low risk, mechanical. Pure dedup; same options pass through unchanged.*
+
+- [ ] Add `_make_adapter(refresh_fn)` passthrough factory; replace the 10 hand
+      adapters (`index_ops.py:1264–1434`) — ~25 LOC → ~5
+- [ ] Collapse `_safe_count`/`_safe_max`/`_safe_meta` into one
+      `_safe_query(conn, sql, params=())` (`index_ops.py:163–184`); update the
+      ~3 call sites (`index_ops.py:231–268`)
+- [ ] Extract `parse_iso8601(text)->datetime|None` into a shared
+      `ingest/` util; replace hand-rolled copies in `sleuth_reminders.py:113–128`,
+      `github_scan.py:123–125`, and calendar/gmail/figma equivalents
+- [ ] Leave a `# ponytail:` note on `_make_adapter` documenting the passthrough
+      contract (opts are filtered by each `refresh_fn`)
+
+**QA checklist — Phase 2**
+- [ ] DRY: 10 adapters → 1 factory; 3 `_safe_*` → 1; 4+ date parsers → 1
+- [ ] SOLID: each `refresh_fn` signature untouched; factory adds no new coupling
+- [ ] Observability: `index_status` counts/timestamps identical before/after
+- [ ] Correctness: ISO-8601 util preserves the `Z`→`+00:00` + tz-naive→UTC
+      behavior of every replaced parser (table-test the edge cases)
+- [ ] Tests: `tests/test_*` for sleuth/github/calendar/gmail pass unchanged
+- [ ] Anti-goal: did **not** touch upsert/diff/migration logic
+
+---
+
+## Phase 3 — Credential I/O dedup (trust boundary)
+
+*Higher risk — touches credential persistence + OAuth refresh. **Decision
+(2026-06-18): committed — do it WITH tests.** The QA checklist's test items are
+mandatory, not optional, for this phase.*
+
+- [x] Add `_set_secret_dual_store(key, value)` + `_clear_secret_dual_store(key)`
+      + `_get_secret_dual_store(key)` to `config.py` (keyring + config in
+      lockstep; callers layer their own auth_log/token_meta side effects)
+- [x] Refactor `set_/get_/clear_` for github, figma, sleuth (clear) to the
+      dual-store helpers; collapse calendar+gmail OAuth setters into shared
+      `_set_google_oauth_token_json(service, key, …)`
+- [x] Extract `oauth_common.load_credentials(OAuthService, scopes)`; point
+      `calendar._load_credentials()` and `gmail._load_credentials()` at it
+      (per-service error messages + scope rule stay local); dropped now-unused
+      `import pickle` from both collectors
+- [x] Preserve exact `creds.expired and creds.refresh_token` guard and
+      dual-write atomicity (control flow moved verbatim into oauth_common)
+
+**QA checklist — Phase 3**
+- [x] Security: token never logged whole — fingerprint path unchanged
+      (`_set_google_oauth_token_json` keys sidecar on `refresh_token`)
+- [x] Trust boundary: dual-write still lockstep; config-only path verified by
+      `test_config_only_path_when_keyring_unavailable` (keyring write fails →
+      persists to rbos.config → resolves back with source `config`)
+- [x] Refresh: `test_refresh_persists_to_both_stores` asserts rotated token
+      written to keyring (`record=False`, `source=refresh`) **and** pickle;
+      shared loader covers calendar **and** gmail
+- [x] Failure isolation: `test_set_github_token_survives_logging_failure` +
+      `test_google_oauth_set_survives_logging_failure` (raising callback does
+      not abort the write)
+- [x] launchd: config fallback path is the launchd safety net — exercised by the
+      config-only test (stripped env has no keychain → same code path)
+- [x] Tests: full suite **1002 passed, 10 skipped**; `test_calendar_helpers`
+      patch target moved to `oauth_common.pickle.load`; new
+      `tests/test_credential_dedup.py` added
+- [x] Anti-goal: did **not** touch validation, the GitHub repo regex, or
+      `_normalize_*` helpers (those remain in Phase 4)
+
+---
+
+## Phase 4 — Deliberately skipped (YAGNI)
+
+*Recorded so the next pass doesn't re-litigate them.*
+
+- [ ] **REJECT** finding #8 — do **not** add `python-dotenv` for Sleuth env
+      parsing. New dependency to replace ~8 lines; ARCHITECTURE.md already pins
+      "parsed manually (no python-dotenv)" as intentional. Hand-rolled stays.
+- [ ] **DEFER** #9 `_normalize_*` consolidation — current helpers are clear and
+      tested; revisit only if the suite grows past ~5.
+- [ ] **DEFER** #11 `kind` field — near-cosmetic but fails-safe; the doc it cites
+      (`COLLECTOR-PATH-AND-PORTABILITY-AUDIT`) is missing — fix the dangling
+      reference, don't remove the field.
+- [ ] **SKIP** #12 GitHub repo regex — explicit whitelist is defensible; the API
+      rejects bad names anyway.
+- [ ] **OPTIONAL** #7 split GitHub get-with-source read-vs-migrate — clarity only,
+      no LOC win; do only if touched for another reason.
+- [ ] **OPTIONAL** #10 log swallowed exceptions at debug level — additive
+      observability; nice-to-have, not now.
+
+**QA checklist — Phase 4**
+- [ ] Each skipped item has a one-line rationale recorded above (done)
+- [ ] Dangling doc reference (`COLLECTOR-PATH-AND-PORTABILITY-AUDIT`) either
+      created or the citation removed from `index_ops.py:62`
+- [ ] No silent scope creep: nothing from this phase got "snuck in" during 1–3
+
+---
+
+> **Part 2 (later)** — same treatment for the rest of the app: query layer
+> (`querier.py`, `semantic_index.py`, `chat.py`), LLM synthesis, MCP tool
+> surface, CLI, dashboard/pulse renderers, and the launchd scheduler fleet.

--- a/src/rebalance/ingest/calendar.py
+++ b/src/rebalance/ingest/calendar.py
@@ -15,7 +15,6 @@ for vector search but high-signal for scheduling context.
 from __future__ import annotations
 
 import json
-import pickle
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone, timedelta
@@ -83,70 +82,39 @@ def _credentials_have_scopes(creds: Any, required_scopes: list[str]) -> bool:
 def _load_credentials(required_scopes: list[str] | None = None) -> Any:
     """Load OAuth2 credentials — keyring first, pickle file as the launchd fallback.
 
-    keyring (interactive primary) ↔ the pickle file (launchd reads this; the
-    keychain is unreachable from the daily-sync's stripped environment). On
-    refresh, the rotated access token is written back to BOTH so each stays
-    current.
+    Delegates the keyring→pickle→refresh→persist-both flow to
+    :func:`rebalance.ingest.oauth_common.load_credentials`; only the
+    Calendar-specific error messages and scope-superset rule live here.
     """
-    import json as _json
-
-    from rebalance.ingest.auth_log import (
-        log_token_missing,
-        log_token_refresh_failed,
-        log_token_refreshed,
-    )
+    from rebalance.ingest import oauth_common
     from rebalance.ingest.config import (
         get_calendar_oauth_token_json,
         set_calendar_oauth_token_json,
     )
 
-    creds = None
-    blob = get_calendar_oauth_token_json()
-    if blob:
-        try:
-            from google.oauth2.credentials import Credentials
-            creds = Credentials.from_authorized_user_info(_json.loads(blob))
-        except Exception:  # noqa: BLE001 — corrupt/legacy blob → fall back to pickle
-            creds = None
+    def _missing(token_path: str) -> Exception:
+        return FileNotFoundError(
+            f"Calendar OAuth token not found (keyring empty and no file at {token_path}). "
+            "Run the OAuth flow first (see PROJECT.md — P2 Google Calendar)."
+        )
 
-    if creds is None:
-        if not TOKEN_PATH.exists():
-            log_token_missing(str(TOKEN_PATH))
-            raise FileNotFoundError(
-                f"Calendar OAuth token not found (keyring empty and no file at {TOKEN_PATH}). "
-                "Run the OAuth flow first (see PROJECT.md — P2 Google Calendar)."
-            )
-        with open(TOKEN_PATH, "rb") as f:
-            creds = pickle.load(f)
-
-    # Refresh if expired — persist the rotated access token to both stores.
-    if creds.expired and creds.refresh_token:
-        from google.auth.transport.requests import Request
-        try:
-            creds.refresh(Request())
-            # record=False: an access-token refresh is not a re-authorization.
-            set_calendar_oauth_token_json(creds.to_json(), source="refresh", record=False)
-            try:
-                with open(TOKEN_PATH, "wb") as f:
-                    pickle.dump(creds, f)
-            except OSError:
-                pass
-            log_token_refreshed(
-                expiry=creds.expiry.isoformat() if creds.expiry else None,
-                token_path=str(TOKEN_PATH),
-            )
-        except Exception as exc:
-            log_token_refresh_failed(error=str(exc), token_path=str(TOKEN_PATH))
-            raise
-
-    if required_scopes and not _credentials_have_scopes(creds, required_scopes):
-        raise PermissionError(
+    def _scope_error(creds: Any, required: list[str]) -> Exception:
+        return PermissionError(
             "Calendar OAuth token does not include the required scopes. "
-            f"Required: {required_scopes}. Current: {getattr(creds, 'scopes', []) or []}. "
+            f"Required: {required}. Current: {getattr(creds, 'scopes', []) or []}. "
             "Re-run the OAuth flow with write access enabled."
         )
 
-    return creds
+    svc = oauth_common.OAuthService(
+        name="calendar",
+        token_path=TOKEN_PATH,
+        get_token_json=get_calendar_oauth_token_json,
+        set_token_json=set_calendar_oauth_token_json,
+        has_scopes=_credentials_have_scopes,
+        missing_error=_missing,
+        scope_error=_scope_error,
+    )
+    return oauth_common.load_credentials(svc, required_scopes)
 
 
 def _build_service(required_scopes: list[str] | None = None) -> Any:

--- a/src/rebalance/ingest/config.py
+++ b/src/rebalance/ingest/config.py
@@ -100,6 +100,78 @@ def _migrate_to_keyring(config_key: str) -> str | None:
         del config[config_key]
         _write_config(config)
     return value
+
+
+# ---------------------------------------------------------------------------
+# Dual-store secret helpers — keyring (interactive primary) + rbos.config
+# (launchd safety net). Shared by the simple single-value secrets (GitHub,
+# Figma). Callers layer their own auth-log / token_meta side effects on top.
+# ---------------------------------------------------------------------------
+
+def _set_secret_dual_store(key: str, value: str) -> None:
+    """Write *value* to both the keyring and rbos.config under *key*.
+
+    keyring is best-effort (ignored if unavailable); rbos.config is the
+    launchd-reachable fallback. Both stores are kept in lockstep so unattended
+    jobs (stripped env, no keychain) can always authenticate.
+    """
+    _keyring_set(key, value)  # best-effort; ignored if unavailable
+    config = _read_config()
+    config[key] = value
+    _write_config(config)
+
+
+def _clear_secret_dual_store(key: str) -> None:
+    """Remove *key* from both the keyring and rbos.config."""
+    _keyring_delete(key)
+    config = _read_config()
+    if key in config:
+        del config[key]
+        _write_config(config)
+
+
+def _get_secret_dual_store(key: str) -> tuple[str | None, str | None]:
+    """Resolve a secret: keyring → rbos.config (auto-migrated to keyring on read).
+
+    Returns ``(value, source)`` where source is ``"keyring"``, ``"config"``, or
+    ``None`` when nothing resolves.
+    """
+    value = _keyring_get(key)
+    if value:
+        return value, "keyring"
+    # Legacy path — auto-migrate to keyring on first read.
+    value = _migrate_to_keyring(key)
+    if value:
+        return value, "config"
+    return None, None
+
+
+def _set_google_oauth_token_json(
+    service: str, key: str, token_json: str, *, source: str, record: bool
+) -> bool:
+    """Store a Google OAuth token JSON blob in keyring for *service*.
+
+    Shared by the Calendar and Gmail setters: keyring-only persistence (the
+    pickle-file fallback lives in each collector's loader). When *record* is True
+    (an explicit (re)authorization, not an automatic access-token refresh), logs a
+    ``token_set`` event + sidecar metadata keyed on the stable ``refresh_token``
+    so the authorization's age is tracked and not reset on every refresh.
+    Returns True on a successful keyring write.
+    """
+    ok = _keyring_set(key, token_json)
+    if ok and record:
+        try:  # never let logging break a credential write
+            import json as _json
+            from rebalance.ingest import auth_log, token_meta  # noqa: PLC0415
+            refresh = str((_json.loads(token_json) or {}).get("refresh_token") or "")
+            getattr(auth_log, f"log_{service}_token_set")(source=source)
+            if refresh:
+                token_meta.record_token_set(service, refresh, kind="google oauth", source=source)
+        except Exception:  # noqa: BLE001
+            pass
+    return ok
+
+
 _GITHUB_REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 
 
@@ -199,13 +271,9 @@ def get_github_token_with_source() -> tuple[str | None, str | None]:
     Resolution order: keyring → rbos.config (with auto-migration) → gh-cli.
     Explicit PATs always win over the ambient gh login.
     """
-    token = _keyring_get("github_token")
+    token, source = _get_secret_dual_store("github_token")
     if token:
-        return token, "keyring"
-    # Legacy path — auto-migrate to keyring on first read
-    token = _migrate_to_keyring("github_token")
-    if token:
-        return token, "config"
+        return token, source
     if not _hermetic():  # gh login is machine-global — hermetic mode skips it
         token = _try_gh_cli_token()
         if token:
@@ -247,10 +315,7 @@ def set_github_token(token: str, *, source: str = "manual") -> None:
     between successive deauths — is visible.
     """
     cleaned = token.strip()
-    _keyring_set("github_token", cleaned)  # best-effort; ignored if unavailable
-    config = _read_config()
-    config["github_token"] = cleaned
-    _write_config(config)
+    _set_secret_dual_store("github_token", cleaned)
     try:  # never let logging break a credential write
         from rebalance.ingest import auth_log, token_meta  # noqa: PLC0415
         kind = classify_github_token(cleaned)
@@ -263,11 +328,7 @@ def set_github_token(token: str, *, source: str = "manual") -> None:
 
 def clear_github_token() -> None:
     """Remove the stored GitHub PAT from both keyring and rbos.config."""
-    _keyring_delete("github_token")
-    config = _read_config()
-    if "github_token" in config:
-        del config["github_token"]
-        _write_config(config)
+    _clear_secret_dual_store("github_token")
 
 
 def get_vault_path() -> str | None:
@@ -351,19 +412,8 @@ def get_figma_token() -> str | None:
     rbos.config as the launchd-safe fallback. Any cleartext token still in
     rbos.config is auto-migrated into keyring on first read.
     """
-    token = _keyring_get("figma_token")
-    if token:
-        return token
-    # Legacy / launchd path — auto-migrate to keyring on first read.
-    token = _migrate_to_keyring("figma_token")
-    if token:
-        return token
-    config = _read_config()
-    value = config.get("figma_token")
-    if not isinstance(value, str):
-        return None
-    stripped = value.strip()
-    return stripped or None
+    token, _source = _get_secret_dual_store("figma_token")
+    return (token.strip() or None) if isinstance(token, str) else None
 
 
 def set_figma_token(token: str) -> None:
@@ -374,20 +424,12 @@ def set_figma_token(token: str) -> None:
     reads. Mirrors :func:`set_github_token` minus the GitHub-specific auth-log
     and gh-cli machinery.
     """
-    cleaned = token.strip()
-    _keyring_set("figma_token", cleaned)  # best-effort; ignored if unavailable
-    config = _read_config()
-    config["figma_token"] = cleaned
-    _write_config(config)
+    _set_secret_dual_store("figma_token", token.strip())
 
 
 def clear_figma_token() -> None:
     """Remove the stored Figma PAT from both keyring and rbos.config."""
-    _keyring_delete("figma_token")
-    config = _read_config()
-    if "figma_token" in config:
-        del config["figma_token"]
-        _write_config(config)
+    _clear_secret_dual_store("figma_token")
 
 
 def get_figma_file_keys() -> list[str]:
@@ -1072,18 +1114,9 @@ def set_calendar_oauth_token_json(token_json: str, *, source: str = "manual", re
     event + sidecar metadata keyed on the stable ``refresh_token`` so the
     authorization's age is tracked (and not reset on every access-token refresh).
     """
-    ok = _keyring_set("calendar_oauth_token", token_json)
-    if ok and record:
-        try:  # never let logging break a credential write
-            import json as _json
-            from rebalance.ingest import auth_log, token_meta  # noqa: PLC0415
-            refresh = str((_json.loads(token_json) or {}).get("refresh_token") or "")
-            auth_log.log_calendar_token_set(source=source)
-            if refresh:
-                token_meta.record_token_set("calendar", refresh, kind="google oauth", source=source)
-        except Exception:  # noqa: BLE001
-            pass
-    return ok
+    return _set_google_oauth_token_json(
+        "calendar", "calendar_oauth_token", token_json, source=source, record=record
+    )
 
 
 def clear_calendar_oauth_token() -> None:
@@ -1111,18 +1144,9 @@ def set_gmail_oauth_token_json(token_json: str, *, source: str = "manual", recor
     event + sidecar metadata keyed on the stable ``refresh_token`` so the
     authorization's age is tracked (and not reset on every access-token refresh).
     """
-    ok = _keyring_set("gmail_oauth_token", token_json)
-    if ok and record:
-        try:  # never let logging break a credential write
-            import json as _json
-            from rebalance.ingest import auth_log, token_meta  # noqa: PLC0415
-            refresh = str((_json.loads(token_json) or {}).get("refresh_token") or "")
-            auth_log.log_gmail_token_set(source=source)
-            if refresh:
-                token_meta.record_token_set("gmail", refresh, kind="google oauth", source=source)
-        except Exception:  # noqa: BLE001
-            pass
-    return ok
+    return _set_google_oauth_token_json(
+        "gmail", "gmail_oauth_token", token_json, source=source, record=record
+    )
 
 
 def clear_gmail_oauth_token() -> None:
@@ -1278,11 +1302,7 @@ def set_sleuth_credentials(
 
 def clear_sleuth_credentials() -> None:
     """Remove Sleuth creds from keyring + rbos.config (the env file is left alone)."""
-    _keyring_delete(SLEUTH_KEYRING_KEY)
-    config = _read_config()
-    if SLEUTH_KEYRING_KEY in config:
-        del config[SLEUTH_KEYRING_KEY]
-        _write_config(config)
+    _clear_secret_dual_store(SLEUTH_KEYRING_KEY)
 
 
 def get_sleuth_credentials(which: str = "production") -> dict[str, str]:

--- a/src/rebalance/ingest/gmail.py
+++ b/src/rebalance/ingest/gmail.py
@@ -22,7 +22,6 @@ cannot — so this path works for public cloners where ADC did not.
 from __future__ import annotations
 
 import json
-import pickle
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -79,72 +78,40 @@ def _credentials_have_scopes(creds: Any, required_scopes: list[str]) -> bool:
 def _load_credentials(required_scopes: list[str] | None = None) -> Any:
     """Load OAuth2 credentials — keyring first, pickle file as the launchd fallback.
 
-    Mirrors :func:`rebalance.ingest.calendar._load_credentials`: keyring
-    (interactive primary) ↔ the pickle file (launchd reads this; the keychain
-    is unreachable from the daily-sync's stripped environment). On refresh, the
-    rotated access token is written back to BOTH so each stays current.
+    Delegates the keyring→pickle→refresh→persist-both flow to
+    :func:`rebalance.ingest.oauth_common.load_credentials`; only the
+    Gmail-specific error messages and scope rule live here.
     """
-    import json as _json
-
-    from rebalance.ingest.auth_log import (
-        log_token_missing,
-        log_token_refresh_failed,
-        log_token_refreshed,
-    )
+    from rebalance.ingest import oauth_common
     from rebalance.ingest.config import (
         get_gmail_oauth_token_json,
         set_gmail_oauth_token_json,
     )
 
-    creds = None
-    blob = get_gmail_oauth_token_json()
-    if blob:
-        try:
-            from google.oauth2.credentials import Credentials
-            creds = Credentials.from_authorized_user_info(_json.loads(blob))
-        except Exception:  # noqa: BLE001 — corrupt/legacy blob → fall back to pickle
-            creds = None
+    def _missing(token_path: str) -> Exception:
+        return GmailAuthError(
+            f"Gmail OAuth token not found (keyring empty and no file at {token_path}).\n"
+            f"  Run: {GMAIL_SETUP_HINT}\n"
+            "  Or switch to the Gmail MCP connector: `gmail_ingest_method=mcp`."
+        )
 
-    if creds is None:
-        if not TOKEN_PATH.exists():
-            log_token_missing(str(TOKEN_PATH), source="gmail")
-            raise GmailAuthError(
-                f"Gmail OAuth token not found (keyring empty and no file at {TOKEN_PATH}).\n"
-                f"  Run: {GMAIL_SETUP_HINT}\n"
-                "  Or switch to the Gmail MCP connector: `gmail_ingest_method=mcp`."
-            )
-        with open(TOKEN_PATH, "rb") as f:
-            creds = pickle.load(f)
-
-    # Refresh if expired — persist the rotated access token to both stores.
-    if creds.expired and creds.refresh_token:
-        from google.auth.transport.requests import Request
-        try:
-            creds.refresh(Request())
-            # record=False: an access-token refresh is not a re-authorization.
-            set_gmail_oauth_token_json(creds.to_json(), source="refresh", record=False)
-            try:
-                with open(TOKEN_PATH, "wb") as f:
-                    pickle.dump(creds, f)
-            except OSError:
-                pass
-            log_token_refreshed(
-                expiry=creds.expiry.isoformat() if creds.expiry else None,
-                token_path=str(TOKEN_PATH),
-                source="gmail",
-            )
-        except Exception as exc:
-            log_token_refresh_failed(error=str(exc), token_path=str(TOKEN_PATH), source="gmail")
-            raise
-
-    if required_scopes and not _credentials_have_scopes(creds, required_scopes):
-        raise GmailAuthError(
+    def _scope_error(creds: Any, required: list[str]) -> Exception:
+        return GmailAuthError(
             "Gmail OAuth token does not include the required scope "
-            f"({', '.join(required_scopes)}). Current: {getattr(creds, 'scopes', []) or []}.\n"
+            f"({', '.join(required)}). Current: {getattr(creds, 'scopes', []) or []}.\n"
             f"  Re-run: {GMAIL_SETUP_HINT}"
         )
 
-    return creds
+    svc = oauth_common.OAuthService(
+        name="gmail",
+        token_path=TOKEN_PATH,
+        get_token_json=get_gmail_oauth_token_json,
+        set_token_json=set_gmail_oauth_token_json,
+        has_scopes=_credentials_have_scopes,
+        missing_error=_missing,
+        scope_error=_scope_error,
+    )
+    return oauth_common.load_credentials(svc, required_scopes)
 
 
 def _build_service() -> Any:

--- a/src/rebalance/ingest/index_ops.py
+++ b/src/rebalance/ingest/index_ops.py
@@ -1256,6 +1256,18 @@ def refresh_index(
 # single source of truth for the ingest pipelines — these adapters are 3-line
 # shims.
 
+def _dry_run_adapter(refresh_fn: Callable[..., dict[str, Any]]) -> Callable[..., dict[str, Any]]:
+    """Adapter for a refresh fn whose only option is ``dry_run``.
+
+    Most stage/source refreshes take no per-source options beyond ``dry_run``;
+    this replaces a separate near-identical two-line adapter for each of them.
+    Sources with bespoke option mapping (vault, github, calendar) keep their own.
+    """
+    def adapter(db_path: Path, **opts: Any) -> dict[str, Any]:
+        return refresh_fn(db_path, dry_run=opts["dry_run"])
+    return adapter
+
+
 def _vault_adapter(db_path: Path, **opts: Any) -> dict[str, Any]:
     vault_path = opts.get("vault_path")
     assert vault_path is not None, "vault collector requires vault_path"
@@ -1276,24 +1288,11 @@ def _calendar_adapter(db_path: Path, **opts: Any) -> dict[str, Any]:
     return _refresh_calendar(db_path, since_days=opts["since_days"], dry_run=opts["dry_run"])
 
 
-def _sleuth_adapter(db_path: Path, **opts: Any) -> dict[str, Any]:
-    return _refresh_sleuth(db_path, dry_run=opts["dry_run"])
-
-
-def _email_adapter(db_path: Path, **opts: Any) -> dict[str, Any]:
-    return _refresh_email(db_path, dry_run=opts["dry_run"])
-
-
-def _code_adapter(db_path: Path, **opts: Any) -> dict[str, Any]:
-    return _refresh_code(db_path, dry_run=opts["dry_run"])
-
-
-def _figma_adapter(db_path: Path, **opts: Any) -> dict[str, Any]:
-    return _refresh_figma(db_path, dry_run=opts["dry_run"])
-
-
-def _semantic_adapter(db_path: Path, **opts: Any) -> dict[str, Any]:
-    return _refresh_semantic_only(db_path, dry_run=opts["dry_run"])
+_sleuth_adapter = _dry_run_adapter(_refresh_sleuth)
+_email_adapter = _dry_run_adapter(_refresh_email)
+_code_adapter = _dry_run_adapter(_refresh_code)
+_figma_adapter = _dry_run_adapter(_refresh_figma)
+_semantic_adapter = _dry_run_adapter(_refresh_semantic_only)
 
 
 def _refresh_sync(database_path: Path, *, dry_run: bool) -> dict[str, Any]:
@@ -1353,8 +1352,7 @@ def _refresh_sync(database_path: Path, *, dry_run: bool) -> dict[str, Any]:
     }
 
 
-def _sync_adapter(db_path: Path, **opts: Any) -> dict[str, Any]:
-    return _refresh_sync(db_path, dry_run=opts["dry_run"])
+_sync_adapter = _dry_run_adapter(_refresh_sync)
 
 
 def _refresh_ask_self(database_path: Path, *, dry_run: bool) -> dict[str, Any]:
@@ -1387,8 +1385,7 @@ def _refresh_ask_self(database_path: Path, *, dry_run: bool) -> dict[str, Any]:
     return {"scope": "ask_self", "dry_run": False, **result.as_dict()}
 
 
-def _ask_self_adapter(db_path: Path, **opts: Any) -> dict[str, Any]:
-    return _refresh_ask_self(db_path, dry_run=opts["dry_run"])
+_ask_self_adapter = _dry_run_adapter(_refresh_ask_self)
 
 
 def _refresh_focus5(database_path: Path, *, dry_run: bool) -> dict[str, Any]:
@@ -1425,8 +1422,7 @@ def _refresh_focus5(database_path: Path, *, dry_run: bool) -> dict[str, Any]:
     return {"scope": "focus5", "dry_run": False, **result.as_dict()}
 
 
-def _focus5_adapter(db_path: Path, **opts: Any) -> dict[str, Any]:
-    return _refresh_focus5(db_path, dry_run=opts["dry_run"])
+_focus5_adapter = _dry_run_adapter(_refresh_focus5)
 
 
 register_collector(Collector("vault", _vault_adapter, requires=("vault_path",)))

--- a/src/rebalance/ingest/index_ops.py
+++ b/src/rebalance/ingest/index_ops.py
@@ -70,10 +70,6 @@ class Collector:
         ``backfill_semantic_documents`` iterates it instead of an if-ladder
         branch. ``None`` (default) preserves the legacy vault/github/email/code
         ladder unchanged.
-    secrets:
-        Optional names of secret config keys this collector consumes (e.g.
-        ``("figma_token",)``). Informational metadata for tooling; not used by
-        the dispatcher itself.
     """
 
     name: str
@@ -82,7 +78,6 @@ class Collector:
     included_in_all: bool = True
     kind: str = "raw_source"
     semantic_docs: Callable[[Any], Iterable["SemanticDoc"]] | None = None
-    secrets: tuple[str, ...] = ()
 
 
 # A Collector that also exposes a ``semantic_docs`` provider is the spine of a
@@ -1457,7 +1452,6 @@ register_collector(
         "figma",
         _figma_adapter,
         requires=("figma_token",),
-        secrets=("figma_token", "figma_file_keys"),
         semantic_docs=figma_semantic_docs,
         included_in_all=False,
     )

--- a/src/rebalance/ingest/oauth_common.py
+++ b/src/rebalance/ingest/oauth_common.py
@@ -1,0 +1,94 @@
+"""Shared Google OAuth credential loading for the calendar + gmail collectors.
+
+Both collectors store an OAuth token in the keyring (interactive primary) with a
+pickle-file fallback that launchd can read, and on expiry they refresh the access
+token and write it back to BOTH stores. The control flow is identical; only these
+differ per service and are passed in via :class:`OAuthService`:
+
+  - the keyring getter/setter for the token JSON,
+  - the launchd-reachable pickle ``token_path``,
+  - the auth-log ``name`` (source label),
+  - the scope-superset rule (``has_scopes``),
+  - the exception raised on a missing token / insufficient scope.
+
+Owning the keyring→pickle→refresh→persist-both flow once means there is a single
+place to reason about (and fix) credential loading, instead of two copies that
+drift apart.
+"""
+
+from __future__ import annotations
+
+import json
+import pickle
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+
+@dataclass(frozen=True)
+class OAuthService:
+    name: str  # auth-log source label, e.g. "calendar" / "gmail"
+    token_path: Path  # launchd-reachable pickle fallback
+    get_token_json: Callable[[], str | None]
+    set_token_json: Callable[..., bool]  # (token_json, *, source, record) -> bool
+    has_scopes: Callable[[Any, list[str]], bool]
+    missing_error: Callable[[str], Exception]  # (token_path_str) -> Exception
+    scope_error: Callable[[Any, list[str]], Exception]  # (creds, required) -> Exception
+
+
+def load_credentials(svc: OAuthService, required_scopes: list[str] | None = None) -> Any:
+    """Load OAuth2 credentials — keyring first, pickle file as the launchd fallback.
+
+    keyring (interactive primary) ↔ the pickle file (launchd reads this; the
+    keychain is unreachable from the daily-sync's stripped environment). On
+    refresh, the rotated access token is written back to BOTH so each stays
+    current. Raises ``svc.missing_error`` if no token resolves and
+    ``svc.scope_error`` if the token lacks a required scope.
+    """
+    from rebalance.ingest.auth_log import (
+        log_token_missing,
+        log_token_refresh_failed,
+        log_token_refreshed,
+    )
+
+    creds = None
+    blob = svc.get_token_json()
+    if blob:
+        try:
+            from google.oauth2.credentials import Credentials
+            creds = Credentials.from_authorized_user_info(json.loads(blob))
+        except Exception:  # noqa: BLE001 — corrupt/legacy blob → fall back to pickle
+            creds = None
+
+    if creds is None:
+        if not svc.token_path.exists():
+            log_token_missing(str(svc.token_path), source=svc.name)
+            raise svc.missing_error(str(svc.token_path))
+        with open(svc.token_path, "rb") as f:
+            creds = pickle.load(f)
+
+    # Refresh if expired — persist the rotated access token to both stores.
+    if creds.expired and creds.refresh_token:
+        from google.auth.transport.requests import Request
+        try:
+            creds.refresh(Request())
+            # record=False: an access-token refresh is not a re-authorization.
+            svc.set_token_json(creds.to_json(), source="refresh", record=False)
+            try:
+                with open(svc.token_path, "wb") as f:
+                    pickle.dump(creds, f)
+            except OSError:
+                pass
+            log_token_refreshed(
+                expiry=creds.expiry.isoformat() if creds.expiry else None,
+                token_path=str(svc.token_path),
+                source=svc.name,
+            )
+        except Exception as exc:
+            log_token_refresh_failed(error=str(exc), token_path=str(svc.token_path), source=svc.name)
+            raise
+
+    if required_scopes and not svc.has_scopes(creds, required_scopes):
+        raise svc.scope_error(creds, required_scopes)
+
+    return creds

--- a/src/rebalance/ingest/sleuth_reminders.py
+++ b/src/rebalance/ingest/sleuth_reminders.py
@@ -34,6 +34,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from rebalance.tz_utils import parse_utc_iso
+
 HTTP_TIMEOUT_SECONDS = 30
 USER_AGENT = "rebalance-os/0.1"
 
@@ -111,21 +113,8 @@ class SleuthSyncResult:
 
 
 def _parse_datetime(value: Any) -> datetime | None:
-    if not isinstance(value, str):
-        return None
-    text = value.strip()
-    if not text:
-        return None
-    # datetime.fromisoformat doesn't accept the trailing "Z" before Python 3.11.
-    if text.endswith("Z"):
-        text = text[:-1] + "+00:00"
-    try:
-        parsed = datetime.fromisoformat(text)
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=timezone.utc)
-    return parsed
+    # parse_utc_iso handles the trailing-Z dance + naive→UTC; guard non-str here.
+    return parse_utc_iso(value) if isinstance(value, str) else None
 
 
 def _optional_str(value: Any) -> str | None:

--- a/src/rebalance/ingest/token_meta.py
+++ b/src/rebalance/ingest/token_meta.py
@@ -20,6 +20,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from rebalance.tz_utils import parse_utc_iso
+
 
 def _meta_path() -> Path:
     from rebalance.paths import resolve_project_root
@@ -96,17 +98,9 @@ def current_token_meta(service: str) -> dict[str, Any] | None:
 
 def age_text(iso_ts: str | None, *, now: datetime | None = None) -> str:
     """Compact age like ``6d`` / ``3.2h`` for a stored ISO timestamp; '' if unknown."""
-    if not iso_ts:
+    dt = parse_utc_iso(iso_ts)  # handles trailing-Z + naive→UTC; None on bad/empty
+    if dt is None:
         return ""
-    raw = iso_ts.strip()
-    if raw.endswith("Z"):
-        raw = raw[:-1] + "+00:00"
-    try:
-        dt = datetime.fromisoformat(raw)
-    except ValueError:
-        return ""
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
     now = now or datetime.now(timezone.utc)
     secs = max((now - dt).total_seconds(), 0.0)
     return f"{secs / 86400:.0f}d" if secs >= 86400 else f"{secs / 3600:.1f}h"

--- a/tests/test_calendar_helpers.py
+++ b/tests/test_calendar_helpers.py
@@ -173,7 +173,7 @@ class CalendarAuthAndWriteTests(unittest.TestCase):
         self.assertTrue(calendar._credentials_have_scopes(creds, [calendar.CALENDAR_WRITE_SCOPE]))
 
     @patch("rebalance.ingest.config.get_calendar_oauth_token_json", return_value=None)
-    @patch("rebalance.ingest.calendar.pickle.load")
+    @patch("rebalance.ingest.oauth_common.pickle.load")
     @patch("builtins.open")
     @patch("pathlib.Path.exists", return_value=True)
     def test_load_credentials_rejects_missing_scope(self, _exists: MagicMock, _open_file: MagicMock, mock_pickle: MagicMock, _no_keyring: MagicMock) -> None:

--- a/tests/test_credential_dedup.py
+++ b/tests/test_credential_dedup.py
@@ -1,0 +1,177 @@
+"""Phase 3 — credential I/O dedup regression tests.
+
+Covers the shared helpers introduced when the per-secret get/set/clear dance and
+the Calendar/Gmail OAuth loaders were collapsed:
+
+  - ``config._set/_clear/_get_secret_dual_store`` (GitHub/Figma/Sleuth backbone)
+  - ``config._set_google_oauth_token_json`` (Calendar/Gmail setter backbone)
+  - ``oauth_common.load_credentials`` (Calendar/Gmail loader backbone)
+
+The trust-boundary invariants these protect: keyring + rbos.config stay in
+lockstep, the config-only path works when the keyring is unavailable (launchd),
+logging failures never abort a credential write, and an access-token refresh
+persists to BOTH stores.
+"""
+
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from rebalance.ingest import config, oauth_common
+
+
+def _mem_config(cfg: dict):
+    """Patch config's keyring + rbos.config I/O to in-memory dicts."""
+    kr: dict = {}
+    return (
+        patch.object(config, "_keyring_set", side_effect=lambda k, v: kr.__setitem__(k, v) or True),
+        patch.object(config, "_keyring_get", side_effect=lambda k: kr.get(k)),
+        patch.object(config, "_keyring_delete", side_effect=lambda k: kr.pop(k, None) is not None),
+        patch.object(config, "_read_config", side_effect=lambda: dict(cfg)),
+        patch.object(config, "_write_config", side_effect=lambda c: (cfg.clear(), cfg.update(c))),
+        kr,
+    )
+
+
+class DualStoreSecretTests(unittest.TestCase):
+    def test_set_writes_both_keyring_and_config(self) -> None:
+        cfg: dict = {}
+        ms, mg, md, mr, mw, kr = _mem_config(cfg)
+        with ms, mg, md, mr, mw:
+            config._set_secret_dual_store("k", "v")
+        self.assertEqual(kr.get("k"), "v")
+        self.assertEqual(cfg.get("k"), "v")
+
+    def test_config_only_path_when_keyring_unavailable(self) -> None:
+        # keyring write fails → secret must still persist to rbos.config and
+        # resolve back (this is the launchd safety net).
+        cfg: dict = {}
+        with patch.object(config, "_keyring_set", return_value=False), \
+             patch.object(config, "_keyring_get", return_value=None), \
+             patch.object(config, "_read_config", side_effect=lambda: dict(cfg)), \
+             patch.object(config, "_write_config", side_effect=lambda c: (cfg.clear(), cfg.update(c))):
+            config._set_secret_dual_store("github_token", "ghp_x")
+            self.assertEqual(cfg.get("github_token"), "ghp_x")
+            value, source = config._get_secret_dual_store("github_token")
+        self.assertEqual(value, "ghp_x")
+        self.assertEqual(source, "config")
+
+    def test_clear_removes_from_both(self) -> None:
+        cfg: dict = {"k": "v"}
+        ms, mg, md, mr, mw, kr = _mem_config(cfg)
+        kr["k"] = "v"
+        with ms, mg, md, mr, mw:
+            config._clear_secret_dual_store("k")
+        self.assertNotIn("k", kr)
+        self.assertNotIn("k", cfg)
+
+
+class CallbackIsolationTests(unittest.TestCase):
+    def test_set_github_token_survives_logging_failure(self) -> None:
+        cfg: dict = {}
+        with patch.object(config, "_keyring_set", return_value=False), \
+             patch.object(config, "_read_config", side_effect=lambda: dict(cfg)), \
+             patch.object(config, "_write_config", side_effect=lambda c: (cfg.clear(), cfg.update(c))), \
+             patch("rebalance.ingest.auth_log.log_github_token_set", side_effect=RuntimeError("boom")), \
+             patch("rebalance.ingest.token_meta.record_token_set"):
+            config.set_github_token("ghp_y")  # must not raise
+        self.assertEqual(cfg.get("github_token"), "ghp_y")
+
+    def test_google_oauth_set_survives_logging_failure(self) -> None:
+        blob = '{"refresh_token": "rt"}'
+        with patch.object(config, "_keyring_set", return_value=True), \
+             patch("rebalance.ingest.auth_log.log_calendar_token_set", side_effect=RuntimeError("boom")), \
+             patch("rebalance.ingest.token_meta.record_token_set"):
+            ok = config.set_calendar_oauth_token_json(blob, source="manual", record=True)
+        self.assertTrue(ok)  # write succeeded despite the logging blow-up
+
+
+class GoogleOAuthSetterTests(unittest.TestCase):
+    def test_sidecar_keyed_on_refresh_token_per_service(self) -> None:
+        blob = '{"refresh_token": "rt_g"}'
+        with patch.object(config, "_keyring_set", return_value=True), \
+             patch("rebalance.ingest.auth_log.log_gmail_token_set") as logev, \
+             patch("rebalance.ingest.token_meta.record_token_set") as sidecar:
+            config.set_gmail_oauth_token_json(blob, source="manual", record=True)
+        logev.assert_called_once()
+        self.assertEqual(sidecar.call_args.args[0], "gmail")
+        self.assertEqual(sidecar.call_args.args[1], "rt_g")
+
+    def test_record_false_skips_logging(self) -> None:
+        blob = '{"refresh_token": "rt_g"}'
+        with patch.object(config, "_keyring_set", return_value=True), \
+             patch("rebalance.ingest.auth_log.log_gmail_token_set") as logev, \
+             patch("rebalance.ingest.token_meta.record_token_set") as sidecar:
+            config.set_gmail_oauth_token_json(blob, source="refresh", record=False)
+        logev.assert_not_called()
+        sidecar.assert_not_called()
+
+
+class OAuthCommonLoaderTests(unittest.TestCase):
+    def _svc(self, **over):
+        base = dict(
+            name="calendar",
+            token_path=Path("/tmp/rbos-test-token"),
+            get_token_json=lambda: None,
+            set_token_json=MagicMock(return_value=True),
+            has_scopes=lambda c, r: True,
+            missing_error=lambda p: ValueError(f"missing:{p}"),
+            scope_error=lambda c, r: RuntimeError("bad-scope"),
+        )
+        base.update(over)
+        return oauth_common.OAuthService(**base)
+
+    def test_refresh_persists_to_both_stores(self) -> None:
+        class Creds:
+            expired = True
+            refresh_token = "rt"
+            scopes = ["s"]
+            expiry = None
+
+            def refresh(self, _request):
+                self.expired = False
+
+            def to_json(self):
+                return '{"refresh_token": "rt"}'
+
+        creds = Creds()
+        set_token = MagicMock(return_value=True)
+        svc = self._svc(set_token_json=set_token)
+
+        with patch("pathlib.Path.exists", return_value=True), \
+             patch("builtins.open", MagicMock()), \
+             patch("rebalance.ingest.oauth_common.pickle.load", return_value=creds), \
+             patch("rebalance.ingest.oauth_common.pickle.dump") as pdump, \
+             patch("google.auth.transport.requests.Request"), \
+             patch("rebalance.ingest.auth_log.log_token_refreshed"):
+            out = oauth_common.load_credentials(svc, required_scopes=["s"])
+
+        self.assertIs(out, creds)
+        # keyring store written as a refresh (not a re-auth)...
+        set_token.assert_called_once()
+        self.assertEqual(set_token.call_args.kwargs.get("record"), False)
+        self.assertEqual(set_token.call_args.kwargs.get("source"), "refresh")
+        # ...and the pickle fallback written too.
+        pdump.assert_called_once()
+
+    def test_missing_token_raises_service_error(self) -> None:
+        svc = self._svc(missing_error=lambda p: ValueError("missing"))
+        with patch("pathlib.Path.exists", return_value=False), \
+             patch("rebalance.ingest.auth_log.log_token_missing"):
+            with self.assertRaises(ValueError):
+                oauth_common.load_credentials(svc, required_scopes=["s"])
+
+    def test_insufficient_scope_raises_service_error(self) -> None:
+        creds = type("C", (), {"expired": False, "refresh_token": "rt", "scopes": ["narrow"]})()
+        svc = self._svc(
+            get_token_json=lambda: '{"refresh_token": "rt"}',
+            has_scopes=lambda c, r: False,
+            scope_error=lambda c, r: RuntimeError("bad-scope"),
+        )
+        with patch("google.oauth2.credentials.Credentials.from_authorized_user_info", return_value=creds):
+            with self.assertRaises(RuntimeError):
+                oauth_common.load_credentials(svc, required_scopes=["wide"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Ponytail audit + refactor of the **auth** and **collect→store** slices (Part 1 of 2). Audit doc with the full findings + phased plan is included: `AUDIT-AUTH-COLLECT-STORE-PART-1.md`.

Headline: both slices were already solid — this is incremental dedup/cleanup, no behavior change. ~110 LOC of drift-prone duplication removed; no new dependencies.

## Commits (landed in dependency order 3 → 1 → 2)

- **Phase 3 — credential I/O dedup** (`37b2c1f`)
  - New `ingest/oauth_common.py`: `load_credentials(OAuthService)` owns the keyring→pickle→refresh→persist-both flow once; the ~85%-identical Calendar/Gmail loaders delegate to it (per-service error messages + scope rules stay local). Dropped now-unused `import pickle` from both.
  - `config.py`: `_set/_clear/_get_secret_dual_store` (keyring+config lockstep, launchd fallback) and `_set_google_oauth_token_json`; GitHub/Figma/Sleuth + both Google OAuth setters route through them.
  - New `tests/test_credential_dedup.py`: config-only path when keyring unavailable, refresh persists to both stores, logging-failure isolation, per-service sidecar keying.
- **Phase 1 — dead code** (`b783951`): removed the write-only `Collector.secrets` field (set once, read nowhere).
- **Phase 2 — shared helpers** (`79501a1`): `_dry_run_adapter()` collapses the 8 identical dry-run-only collector adapters; `sleuth_reminders`/`token_meta` now reuse the existing `tz_utils.parse_utc_iso` instead of hand-rolling the trailing-Z dance. Deliberately **skipped** `_safe_*` consolidation (net-negative — three return shapes, would push shaping into ~17 call sites).

## Verification

- Full suite: **1002 passed, 10 skipped**
- `rebalance doctor`: clean (pre-existing sleuth/collector staleness WARNs only)
- Behavior preserved verbatim (e.g. calendar's default auth-log `source` "calendar" matched by `OAuthService.name`)

## Notes

- Branch name (`refactor/phase3-credential-io-dedup`) is a slight misnomer — it carries Phases 1–3, not just Phase 3.
- **Part 2** (query/LLM/MCP/CLI/dashboard/scheduler) is not in this PR — paused, to be done separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)