### PR TITLE
fix(web): Focus 5 page no longer blocks on a 30s git scan

### DIFF
--- a/src/rebalance/web.py
+++ b/src/rebalance/web.py
@@ -530,10 +530,13 @@ def focus5_page(refresh: bool = False):
                 "Run <code>rebalance refresh-index</code> first.</div>")
         return _page("Focus 5", body, active="focus5", wide=True)
 
-    # Recompute the roster when forced, never built, or past its 24h TTL. The
-    # meta check is a cheap DB read so we don't pay the live-probe render twice.
+    # Recompute the roster only when forced (↻ Refresh) or never built — NOT on a
+    # stale TTL. sync_focus5() is a ~30s synchronous device-local git scan; running
+    # it inline on a stale page load blocked the request and made the page look
+    # broken. A stale roster now renders instantly with the "⚠ stale" badge; the
+    # operator re-ranks on demand via the Refresh button (?refresh=1).
     meta = get_roster_meta(db)
-    if refresh or not meta["roster_size"] or _roster_stale(meta["computed_at"]):
+    if refresh or not meta["roster_size"]:
         try:
             sync_focus5(db)
         except Exception:  # noqa: BLE001 — a scan failure must not 500 the page

--- a/tests/test_focus5_scan.py
+++ b/tests/test_focus5_scan.py
@@ -573,7 +573,10 @@ class WebRouteTests(unittest.TestCase):
             self.assertEqual(resp.status_code, 200)
             self.assertFalse(m.called)                       # within TTL → no scan
 
-    def test_stale_roster_triggers_recompute_on_visit(self) -> None:
+    def test_stale_roster_serves_cached_without_blocking_scan(self) -> None:
+        # sync_focus5() is a ~30s synchronous git scan; a stale page load must NOT
+        # run it inline (that made the page look broken). Serve the cached roster
+        # instantly with the "⚠ stale" badge; recompute only on explicit Refresh.
         with tempfile.TemporaryDirectory() as tmp:
             db, dev = self._seed(Path(tmp))
             # Age the snapshot past the 24h TTL.
@@ -584,7 +587,8 @@ class WebRouteTests(unittest.TestCase):
             with mock.patch("rebalance.ingest.focus5_scan.sync_focus5") as m:
                 resp = self._get(db)
             self.assertEqual(resp.status_code, 200)
-            self.assertTrue(m.called)                        # TTL expired → recompute
+            self.assertFalse(m.called)                       # stale → no inline scan
+            self.assertIn("⚠ stale", resp.text)             # but the staleness is surfaced
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_web_focus5.py
+++ b/tests/test_web_focus5.py
@@ -203,5 +203,44 @@ class OpenButtonTests(unittest.TestCase):
         self.assertIn("f5-hide", body)                 # ✕ still present
 
 
+class RouteScanTriggerTests(unittest.TestCase):
+    """focus5_page must NOT run the ~30s synchronous sync_focus5 git scan on a
+    stale page load — only on an explicit Refresh or a never-built roster."""
+
+    def _load(self, *, refresh: bool, roster_size: int, computed_at):
+        from unittest.mock import patch
+        from rebalance import web
+
+        meta = {"roster_size": roster_size, "computed_at": computed_at}
+        with patch("rebalance.paths.resolve_database_path", return_value="db"), \
+             patch("rebalance.ingest.focus5_scan.get_roster_meta", return_value=meta), \
+             patch("rebalance.ingest.focus5_scan.summarize_focus5", return_value={"roster": []}), \
+             patch("rebalance.ingest.focus5_scan.sync_focus5") as scan, \
+             patch("rebalance.web._focus5_body", return_value=""), \
+             patch("rebalance.web._page", return_value="OK"):
+            web.focus5_page(refresh=refresh)
+        return scan
+
+    def test_stale_roster_does_not_trigger_blocking_scan(self) -> None:
+        scan = self._load(refresh=False, roster_size=5, computed_at=_now_iso(days=2))
+        scan.assert_not_called()
+
+    def test_never_built_roster_triggers_first_scan(self) -> None:
+        scan = self._load(refresh=False, roster_size=0, computed_at=None)
+        scan.assert_called_once()
+
+    def test_explicit_refresh_triggers_scan(self) -> None:
+        from unittest.mock import patch
+        from rebalance import web
+
+        meta = {"roster_size": 5, "computed_at": _now_iso(days=2)}
+        with patch("rebalance.paths.resolve_database_path", return_value="db"), \
+             patch("rebalance.ingest.focus5_scan.get_roster_meta", return_value=meta), \
+             patch("rebalance.ingest.focus5_scan.sync_focus5") as scan, \
+             patch("rebalance.ingest.focus5_scan.summarize_focus5", return_value={"roster": []}):
+            web.focus5_page(refresh=True)  # returns a redirect before render
+        scan.assert_called_once()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

The Focus 5 web page appeared to "not load." Root cause: `/focus-5` ran `sync_focus5()` — a ~30s synchronous device-local git scan — **inline in the request handler** whenever the roster was past its 24h TTL. Focus 5 is opt-in (not in the daily sync), so the roster expires every 24h and the next visitor's browser blocked for the full scan (measured: 36s).

Not related to PR #71 — the web Focus 5 path is independent of the auth/collect refactor.

## Fix

One-condition change in `focus5_page()` ([web.py:536](src/rebalance/web.py#L536)): recompute only on an explicit Refresh (`?refresh=1`) or a never-built roster — **not** on a stale TTL. A stale roster now renders instantly from cache with the existing "⚠ stale" badge; the operator re-ranks on demand via the Refresh button.

## Tests

- Updated the route test that pinned the old behavior → now asserts stale ⇒ no inline scan + stale badge still shown.
- Added `RouteScanTriggerTests` covering stale / never-built / explicit-refresh paths.
- Full suite: **1005 passed, 10 skipped**.
- Verified live: pulse-server reloaded, `/focus-5` returns 200 immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)