### PR TITLE
release: v0.41.1 — front-door/portability/auth changelog + roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,53 @@
 > **not** reintroduce an `[Unreleased]` block — add to (or roll work into) the
 > current dated version instead. See AGENTS.md → "Versioning & Changelog".
 
+## [0.41.1] - 2026-06-21
+
+Front-door, portability, and auth-hardening cleanup — closing the remaining
+runtime-contract, test-coverage, and documentation gaps so a newcomer's
+clone-to-working path and the credential model are accurate and enforced.
+
+### Fixed
+- Semantic-maintenance commands no longer silently accept calendar/reminder
+  sources they cannot actually index. The accepted source set is now derived
+  from the live indexing stage, so the maintenance CLI and the runtime can no
+  longer drift apart, and an unsupported source is rejected with a clear error
+  instead of doing nothing.
+- Restored the test suite: a broken module import had been interrupting
+  collection and leaving continuous integration red, so the contract tests
+  were not actually running on every change.
+- The Gmail re-auth hint no longer tells operators to run a redundant migration
+  step that the setup flow already performs in one pass.
+
+### Added
+- The health check now reports posture for the Figma integration and
+  distinguishes "optional and not configured" (a clean skip) from "configured
+  but broken" — for example, files selected to sync with no token — so a
+  silently failing integration becomes visible. This immediately surfaced a
+  real, previously-silent misconfiguration.
+- CI-enforced contract tests for the credential model: secrets can no longer
+  leak back into repo-local config; migration refuses to remove a secret from
+  the legacy location until the new store has provably retained it, so an
+  unattended job can never be locked out; and auth-activity plus token-lifetime
+  metadata survive migration and token refresh (fingerprint-only, with the
+  original authorization date preserved). The dashboard re-ingest path and the
+  opt-in Figma path gained real (non-mocked) coverage.
+
+### Changed
+- Operator and newcomer documentation now matches the shipped credential model
+  everywhere: the OS keyring is primary, with a permission-locked data-only
+  fallback stored outside the repository. Retired token-format and redundant
+  migration wording were removed; the one legacy migration step that still does
+  real work is kept and scoped to that purpose.
+- The front door now states the supported platform, the cross-platform subset
+  that runs without the on-device embedding stack, and the one-time first-run
+  network access (the model download and the GitHub/Google APIs) before the
+  first install command — correcting the prior overstated platform requirement.
+- The Gmail local-account versus host-connector ingest choice now states the
+  privacy trade-off (whether data stays on the machine or routes through the
+  host cloud) and the connector precondition inline. Calendar host-connector
+  ingestion is clearly marked as planned, not shipped.
+
 ## [0.41.0] - 2026-06-18
 
 P2 **Phase 2 — v0.5 "What should we work on next"** (product milestone *v0.5*; the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,17 +25,17 @@ goal: >
 
 | What was just completed | What's next |
 |---|---|
-| **Front-door / portability / auth unification — Phases 1–6 shipped (2026-06-21).** Runtime contract closure, CI-enforced contract tests, canonical doc truthfulness, install-path clarity, and Google consumption-path trade-offs all landed against one canonical plan (1080 tests green; CI unblocked). | **Operator-only:** run `rebalance config migrate-secrets` on the ~2 remaining Macs (Phase 1 item 6); otherwise the deferred multi-operator / fleet scope, revived on trigger. |
+| **Front-door / portability / auth unification — Phases 1–6 complete, merged to `development` (PR #78, v0.41.1).** Runtime contract closure, CI-enforced contract tests, canonical doc truthfulness, install-path clarity, and Google consumption-path trade-offs all landed against one canonical plan; independently validated (Agy relay review: all 10 DoD items Approved). 1080 tests green. | **Operator-only:** run `rebalance config migrate-secrets` on the ~2 remaining Macs (Phase 1 item 6), then a `development` → `main` PR when ready; otherwise the deferred multi-operator / fleet scope. |
 
 ## Ledger
 
 ### In progress
 
-- `Unified front-door, portability & auth hardening` — Phases 1–6 complete; only the operator-only per-machine `migrate-secrets` (~2 Macs) + deferred fleet/multi-operator scope remain. → [PROJECT/2-WORKING/FRONT-DOOR-PORTABILITY-AUTH-UNIFICATION.md](PROJECT/2-WORKING/FRONT-DOOR-PORTABILITY-AUTH-UNIFICATION.md)
+_None yet._
 
 ### Completed
 
-_None yet._
+- `Unified front-door, portability & auth hardening` — Phases 1–6 complete, merged to `development` (v0.41.1, PR #78). Operator-only per-machine `migrate-secrets` (~2 Macs) + deferred fleet/multi-operator scope remain; `development` → `main` PR pending. → [PROJECT/2-WORKING/FRONT-DOOR-PORTABILITY-AUTH-UNIFICATION.md](PROJECT/2-WORKING/FRONT-DOOR-PORTABILITY-AUTH-UNIFICATION.md)
 
 ### Attempted
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rebalance-os"
-version = "0.41.0"
+version = "0.41.1"
 description = "Local-first workday operating system with MCP tools and Obsidian ingest"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -2042,7 +2042,7 @@ wheels = [
 
 [[package]]
 name = "rebalance-os"
-version = "0.35.0"
+version = "0.41.1"
 source = { editable = "." }
 dependencies = [
     { name = "keyring" },


### PR DESCRIPTION
Follow-up to #78: record the front-door/portability/auth unification per the
repo's versioning convention (AGENTS.md → every change gets a version bump).

- **Version:** 0.41.0 → 0.41.1 (PATCH — fixes + hardening) in `pyproject.toml` + `uv.lock`.
- **CHANGELOG:** new `[0.41.1]` entry in plain language (no paths/filenames per the changelog rule).
- **ROADMAP:** unified entry moved to **Completed** (merged to `development`); operator-only `migrate-secrets` + deferred fleet scope + pending `development`→`main` PR noted.

Docs + version only. Suite **1080 passed**; `rebalance doctor` green. Clean descendant of `development` (no conflicts). CI does not auto-run on dev PRs (workflow is `main`-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
