### PR TITLE
fix(focus5-float): slim panel — emoji tab row + wrapped status line (180px floor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 > **not** reintroduce an `[Unreleased]` block — add to (or roll work into) the
 > current dated version instead. See AGENTS.md → "Versioning & Changelog".
 
+## [0.49.0] - 2026-06-27
+
+Slimmed the Focus 5 Float panel back down after the Telemetry tab + status counter had roughly doubled its minimum width and clipped the header left/right.
+
+### Changed
+- Focus 5 Float header is now two purpose-built rows: row 1 is a compact emoji-only tab switcher (🎯 / 🧹 / 📊, with the tab names preserved as help tooltips + accessibility labels); the health light (dirty count + tinted dot) drops to row 2, the status line, alongside the repo count / freshness badges. This lets the panel shrink without the segmented tabs or status counter clipping (`ContentView.swift`).
+- Default panel size 380×560 → 200×560 and the minimum width floor 360 → 180 so the panel can sit as a slim floating strip; frame autosave bumped to `.v3` so a stale wide frame from the 360/380 layout resets once (`Focus5FloatApp.swift`). App bundle version → 0.49.0.
+
 ## [0.48.0] - 2026-06-26
 
 Added a bottom note to the Focus 5 Float macOS card: it reads a hand-written `focus5.md` from the operator's Obsidian vault and renders it under the roster, with a hint when no note exists.

--- a/macOS/Apps/Focus5Float/Sources/Focus5Float/ContentView.swift
+++ b/macOS/Apps/Focus5Float/Sources/Focus5Float/ContentView.swift
@@ -32,7 +32,10 @@ struct ContentView: View {
     // MARK: Header
 
     private var header: some View {
-        VStack(spacing: Theme.Space.s) {
+        VStack(spacing: Theme.Space.xs) {
+            // Row 1 — compact tab switcher + actions. Emoji-only labels keep the
+            // 3-segment picker narrow enough for a ~180-wide panel; the tab names
+            // live in the help tooltips + accessibility labels.
             HStack(spacing: Theme.Space.s) {
                 Picker("", selection: Binding(
                     get: { model.viewMode },
@@ -45,12 +48,16 @@ struct ContentView: View {
                         }
                     }
                 )) {
-                    Text("🎯 Focus 5").tag(ViewMode.focus5)
-                    Text("🧹 Dirty Five").tag(ViewMode.dirtyFive)
-                    Text("📊 Telemetry").tag(ViewMode.telemetry)
+                    Text("🎯").tag(ViewMode.focus5)
+                        .help("Focus 5").accessibilityLabel("Focus 5")
+                    Text("🧹").tag(ViewMode.dirtyFive)
+                        .help("Dirty Five").accessibilityLabel("Dirty Five")
+                    Text("📊").tag(ViewMode.telemetry)
+                        .help("Telemetry").accessibilityLabel("Telemetry")
                 }
                 .pickerStyle(.segmented)
                 .labelsHidden()
+                .fixedSize(horizontal: true, vertical: false)
 
                 Button {
                     Task { await model.refresh() }
@@ -73,40 +80,18 @@ struct ContentView: View {
                     .help("Start rebalance serve")
                 }
 
-                Spacer(minLength: Theme.Space.s)
-
-                // Top-right health light — adapts to the active tab.
-                if model.viewMode == .telemetry {
-                    if !model.telemetryEntries.isEmpty {
-                        let nonGreen = model.telemetryEntries.filter { $0.health != .green }.count
-                        HStack(spacing: 5) {
-                            Text("Status: \(nonGreen)")
-                                .font(Theme.caption).foregroundStyle(Theme.text2)
-                            Circle()
-                                .fill(RosterHealth.tint(dirty: nonGreen, total: model.telemetryEntries.count))
-                                .frame(width: 11, height: 11)
-                        }
-                        .help("\(nonGreen) of \(model.telemetryEntries.count) signals need attention")
-                    }
-                } else if !model.roster.isEmpty {
-                    let dirty = model.roster.filter(\.isDirty).count
-                    HStack(spacing: 5) {
-                        Text("Status: \(dirty)")
-                            .font(Theme.caption).foregroundStyle(Theme.text2)
-                        Circle()
-                            .fill(RosterHealth.tint(dirty: dirty, total: model.roster.count))
-                            .frame(width: 11, height: 11)
-                    }
-                    .help("\(dirty) of \(model.roster.count) roster repos dirty")
-                    .accessibilityLabel("Status: \(dirty) of \(model.roster.count) roster repos dirty")
-                }
+                Spacer(minLength: 0)
             }
 
+            // Row 2 — status line. Wrapped down off the tab row so the panel can
+            // shrink to ~180 wide: count/updated on the left (truncates first),
+            // the health light pinned right.
             HStack(spacing: Theme.Space.s) {
                 if model.viewMode == .telemetry {
                     if let url = model.telemetryFileURL {
                         Text(url.lastPathComponent)
-                            .font(Theme.caption).foregroundStyle(Theme.text2).lineLimit(1)
+                            .font(Theme.caption).foregroundStyle(Theme.text2)
+                            .lineLimit(1).truncationMode(.middle)
                         if !model.telemetryEntries.isEmpty {
                             Text("· \(model.telemetryEntries.count)")
                                 .font(Theme.caption).foregroundStyle(Theme.text3)
@@ -117,29 +102,58 @@ struct ContentView: View {
                     }
                 } else {
                     Text("\(model.roster.count) repos")
-                        .font(Theme.caption)
-                        .foregroundStyle(Theme.text2)
+                        .font(Theme.caption).foregroundStyle(Theme.text2).fixedSize()
                     if !model.lastUpdatedAgo.isEmpty {
-                        Text("· updated \(model.lastUpdatedAgo)")
-                            .font(Theme.caption)
-                            .foregroundStyle(Theme.text3)
+                        Text("· \(model.lastUpdatedAgo)")
+                            .font(Theme.caption).foregroundStyle(Theme.text3)
+                            .lineLimit(1).truncationMode(.tail)
                     }
-                }
-                Spacer(minLength: 0)
-                if model.viewMode != .telemetry {
                     if model.isStale {
-                        Text("⚠ stale").font(Theme.caption).foregroundStyle(Theme.diffUpdate)
+                        Text("⚠").font(Theme.caption).foregroundStyle(Theme.diffUpdate)
+                            .help("Roster is stale")
                     }
                     if model.showingCache {
-                        Text("cached \(model.cachedAgo)")
-                            .font(Theme.caption).foregroundStyle(Theme.diffUpdate)
+                        Text("cached").font(Theme.caption).foregroundStyle(Theme.diffUpdate)
+                            .help("Showing cached roster from \(model.cachedAgo)")
                     } else if model.isOffline {
                         Text("offline").font(Theme.caption).foregroundStyle(Theme.diffRemove)
                     }
                 }
+                Spacer(minLength: Theme.Space.xs)
+                healthLight
             }
         }
         .padding(Theme.Space.m)
+    }
+
+    /// The roster/telemetry health light — a dirty-count + tinted dot, adapting to
+    /// the active tab. Lives on the status row (row 2) so it no longer widens the
+    /// tab row.
+    @ViewBuilder private var healthLight: some View {
+        if model.viewMode == .telemetry {
+            if !model.telemetryEntries.isEmpty {
+                let nonGreen = model.telemetryEntries.filter { $0.health != .green }.count
+                healthBadge(count: nonGreen,
+                            tint: RosterHealth.tint(dirty: nonGreen, total: model.telemetryEntries.count),
+                            help: "\(nonGreen) of \(model.telemetryEntries.count) signals need attention")
+            }
+        } else if !model.roster.isEmpty {
+            let dirty = model.roster.filter(\.isDirty).count
+            healthBadge(count: dirty,
+                        tint: RosterHealth.tint(dirty: dirty, total: model.roster.count),
+                        help: "\(dirty) of \(model.roster.count) roster repos dirty")
+                .accessibilityLabel("Status: \(dirty) of \(model.roster.count) roster repos dirty")
+        }
+    }
+
+    private func healthBadge(count: Int, tint: Color, help: String) -> some View {
+        HStack(spacing: 5) {
+            Text("\(count)")
+                .font(Theme.caption).foregroundStyle(Theme.text2)
+            Circle().fill(tint).frame(width: 11, height: 11)
+        }
+        .fixedSize()
+        .help(help)
     }
 
     // MARK: Content

--- a/macOS/Apps/Focus5Float/Sources/Focus5Float/Focus5FloatApp.swift
+++ b/macOS/Apps/Focus5Float/Sources/Focus5Float/Focus5FloatApp.swift
@@ -149,11 +149,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     // MARK: - Panel
 
     private func buildPanel() {
-        // 380 wide gives the 3-tab header + status light room to breathe (the
-        // 360 default clipped "Focus 5" and the status counter once the Telemetry
-        // tab landed); 560 tall is a calmer default now the note hugs its content
-        // instead of reserving a slab.
-        let defaultRect = NSRect(x: 0, y: 0, width: 380, height: 560)
+        // Compact by default now the header is a slim emoji tab row over a
+        // wrapped status line: 200 wide is a comfortable starting point that can
+        // be dragged down to the 180 floor without clipping. 560 tall keeps a
+        // calm default now the note hugs its content instead of reserving a slab.
+        let defaultRect = NSRect(x: 0, y: 0, width: 200, height: 560)
 
         let hostingView = FirstMouseHostingView(rootView: ContentView(model: model))
         hostingView.frame = defaultRect
@@ -183,13 +183,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
         panel.contentView = hostingView
 
-        // Floor so the header (tabs + status) can never be squeezed into a clip.
-        panel.minSize = NSSize(width: 360, height: 320)
+        // Floor — 180 wide is the narrow target the emoji tab row + wrapped
+        // status line are built for; below that the tab row would start to clip.
+        panel.minSize = NSSize(width: 180, height: 320)
 
         // Frame autosave — remembers position & size across launches. Bumped to
-        // ".v2" to retire any stale pre-note frame that was saved oversized/clipped;
-        // the window resets once to the new default, then persists again.
-        panel.setFrameAutosaveName("Focus5FloatPanel.v2")
+        // ".v3" to retire any stale wide frame saved under the old 360/380 layout;
+        // the window resets once to the new compact default, then persists again.
+        panel.setFrameAutosaveName("Focus5FloatPanel.v3")
         if panel.frame.origin == .zero {
             panel.center()
         }

--- a/macOS/Apps/Focus5Float/make-app.sh
+++ b/macOS/Apps/Focus5Float/make-app.sh
@@ -19,7 +19,7 @@ cd "$PKG_DIR"
 APP_NAME="Focus 5 Float"
 EXEC_NAME="Focus5Float"
 BUNDLE_ID="me.neochro.Focus5Float"
-VERSION="0.48.0"
+VERSION="0.49.0"
 DIST="$PKG_DIR/dist"
 APP="$DIST/$APP_NAME.app"
 


### PR DESCRIPTION
## Why
Recent Focus 5 work (the Telemetry tab + `Status: N` counter on the header's tab row, plus a new `minSize = 360` floor) had pushed the float panel's **minimum width to ~2× its prior compact size** and **clipped the header left/right**.

## What changed
**Header → two purpose-built rows** (`ContentView.swift`):
- **Row 1** — emoji-only segmented tabs (🎯 / 🧹 / 📊), `.fixedSize` so they stay compact. Tab names preserved as `.help()` tooltips + accessibility labels (nothing lost for hover/VoiceOver).
- **Row 2 (status line)** — the health light (dirty count + tinted dot, `Status:` prefix dropped) moved down here, beside the repo count / freshness / `cached` / `offline` badges.

**Window sizing** (`Focus5FloatApp.swift`):
- Default panel `380×560 → 200×560`; min width `360 → 180` so it can sit as a slim floating strip.
- Frame autosave `.v2 → .v3` so the stale wide saved frame resets **once**, then persists again.

**Packaging:** bundle version → `0.49.0`; CHANGELOG entry under `[0.49.0]`.

## Verification
- `swift build` clean; release build packaged via `make-app.sh`, installed to `/Applications`, and relaunched — confirmed the panel opens compact and drags down to ~180px with no tab/status clipping.

## Note
At the 180px floor with the `▶` "start server" button visible (offline state) the tab row is at its tightest — it fits, but a follow-up could move `▶` behind the refresh menu if it ever feels cramped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)