### PR TITLE
feat(GH-155): capture direct GitHub push signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 > **not** reintroduce an `[Unreleased]` block — add to (or roll work into) the
 > current dated version instead. See AGENTS.md → "Versioning & Changelog".
 
+## [0.61.0] - 2026-07-18
+
+### Added
+- Direct branch pushes in watched repositories now retain a durable event
+  receipt, per-commit identity, and exact changed-file records. The bounded
+  enrichment path surfaces non-PR commits in activity, HiQS evidence, and the
+  dashboard while preventing duplicate signals when a matching PR is present.
+
 ## [0.60.0] - 2026-07-18
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rebalance-os"
-version = "0.59.1"
+version = "0.61.0"
 description = "Local-first workday operating system with MCP tools and Obsidian ingest"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/dashboard.py
+++ b/scripts/dashboard.py
@@ -383,6 +383,15 @@ def fetch_recent_github(limit: int = 9) -> list[dict[str, Any]]:
                     FROM github_commits
                     WHERE committed_at IS NOT NULL
                     UNION ALL
+                    SELECT 'direct_commit', '', d.repo_full_name, 0, d.message,
+                           d.committed_at, d.author_login, d.html_url
+                    FROM github_direct_commits d
+                    WHERE d.committed_at IS NOT NULL
+                      AND NOT EXISTS (
+                          SELECT 1 FROM github_commits p
+                          WHERE p.repo_full_name = d.repo_full_name AND p.sha = d.sha
+                      )
+                    UNION ALL
                     SELECT 'comment', comment_type, repo_full_name, item_number,
                            body, created_at, author_login, html_url
                     FROM github_comments

--- a/src/rebalance/__init__.py
+++ b/src/rebalance/__init__.py
@@ -28,7 +28,7 @@ import logging
 import os
 
 __all__ = ["__version__"]
-__version__ = "0.58.1"
+__version__ = "0.61.0"
 
 
 def _configure_logging() -> None:

--- a/src/rebalance/ingest/db/github.py
+++ b/src/rebalance/ingest/db/github.py
@@ -247,6 +247,104 @@ def upsert_commit(conn: sqlite3.Connection, values: tuple) -> None:
     )
 
 
+def insert_push_event(conn: sqlite3.Connection, values: tuple) -> bool:
+    """Insert one direct-push receipt; return whether it was newly observed."""
+    cursor = conn.execute(
+        """
+        INSERT OR IGNORE INTO github_push_events
+            (event_id, repo_full_name, ref, before_sha, head_sha, observed_at,
+             state, fetched_at)
+        VALUES (?, ?, ?, ?, ?, ?, 'pending', ?)
+        """,
+        values,
+    )
+    return cursor.rowcount == 1
+
+
+def pending_push_events(
+    conn: sqlite3.Connection, limit: int, max_attempts: int
+) -> list[sqlite3.Row]:
+    """Oldest direct-push receipts still requiring bounded enrichment."""
+    return conn.execute(
+        """
+        SELECT event_id, repo_full_name, ref, before_sha, head_sha, observed_at,
+               state, attempt_count
+        FROM github_push_events
+        WHERE state IN ('pending', 'deferred') AND attempt_count < ?
+        ORDER BY observed_at ASC, event_id ASC
+        LIMIT ?
+        """,
+        (max_attempts, limit),
+    ).fetchall()
+
+
+def update_push_event(
+    conn: sqlite3.Connection,
+    event_id: str,
+    *,
+    state: str,
+    now: str,
+    reason: str = "",
+) -> None:
+    """Advance a receipt state without hiding its prior observation."""
+    conn.execute(
+        """
+        UPDATE github_push_events
+        SET state = ?, attempt_count = attempt_count + 1, last_attempt_at = ?,
+            resolved_at = CASE WHEN ? IN ('enriched', 'ignored', 'head_only', 'failed')
+                               THEN ? ELSE resolved_at END,
+            failure_reason = ?
+        WHERE event_id = ?
+        """,
+        (state, now, state, now, reason[:500] or None, event_id),
+    )
+
+
+def upsert_direct_commit(conn: sqlite3.Connection, values: tuple) -> None:
+    """Insert-or-replace a direct commit while retaining its event provenance."""
+    conn.execute(
+        """
+        INSERT INTO github_direct_commits
+            (repo_full_name, sha, event_id, ref, author_login, author_name,
+             message, committed_at, html_url, path_coverage, discovered_at, fetched_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(repo_full_name, sha) DO UPDATE SET
+            event_id=excluded.event_id, ref=excluded.ref,
+            author_login=excluded.author_login, author_name=excluded.author_name,
+            message=excluded.message, committed_at=excluded.committed_at,
+            html_url=excluded.html_url, path_coverage=excluded.path_coverage,
+            fetched_at=excluded.fetched_at
+        """,
+        values,
+    )
+
+
+def replace_direct_commit_files(
+    conn: sqlite3.Connection, repo_full_name: str, sha: str, files: list[dict[str, object]]
+) -> None:
+    """Replace the exact file list for one direct commit atomically."""
+    conn.execute(
+        "DELETE FROM github_direct_commit_files WHERE repo_full_name = ? AND sha = ?",
+        (repo_full_name, sha),
+    )
+    conn.executemany(
+        """
+        INSERT INTO github_direct_commit_files
+            (repo_full_name, sha, path, status, additions, deletions, changes)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            (
+                repo_full_name, sha, str(row.get("filename") or ""),
+                str(row.get("status") or ""), row.get("additions"),
+                row.get("deletions"), row.get("changes"),
+            )
+            for row in files
+            if row.get("filename")
+        ],
+    )
+
+
 def upsert_check_run(conn: sqlite3.Connection, values: tuple) -> None:
     """Insert-or-replace one ``github_check_runs`` row.
 

--- a/src/rebalance/ingest/db/schema.py
+++ b/src/rebalance/ingest/db/schema.py
@@ -587,6 +587,67 @@ def _ensure_github_knowledge_schema(conn: sqlite3.Connection) -> None:
     """)
 
 
+def _ensure_github_direct_commit_schema(conn: sqlite3.Connection) -> None:
+    """Durable receipts and file-level facts for direct branch pushes (GH-155)."""
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS github_push_events (
+            event_id        TEXT PRIMARY KEY,
+            repo_full_name  TEXT NOT NULL,
+            ref             TEXT NOT NULL,
+            before_sha      TEXT,
+            head_sha        TEXT,
+            observed_at     TEXT,
+            state           TEXT NOT NULL,
+            attempt_count   INTEGER NOT NULL DEFAULT 0,
+            last_attempt_at TEXT,
+            resolved_at     TEXT,
+            failure_reason  TEXT,
+            fetched_at      TEXT NOT NULL
+        )
+    """)
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_github_push_events_pending "
+        "ON github_push_events(state, observed_at)"
+    )
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS github_direct_commits (
+            repo_full_name  TEXT NOT NULL,
+            sha             TEXT NOT NULL,
+            event_id        TEXT NOT NULL,
+            ref             TEXT,
+            author_login    TEXT,
+            author_name     TEXT,
+            message         TEXT,
+            committed_at    TEXT,
+            html_url        TEXT,
+            path_coverage   TEXT NOT NULL DEFAULT 'unavailable',
+            discovered_at   TEXT NOT NULL,
+            fetched_at      TEXT NOT NULL,
+            PRIMARY KEY (repo_full_name, sha)
+        )
+    """)
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_github_direct_commits_time "
+        "ON github_direct_commits(committed_at DESC)"
+    )
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS github_direct_commit_files (
+            repo_full_name  TEXT NOT NULL,
+            sha             TEXT NOT NULL,
+            path            TEXT NOT NULL,
+            status          TEXT,
+            additions       INTEGER,
+            deletions       INTEGER,
+            changes         INTEGER,
+            PRIMARY KEY (repo_full_name, sha, path)
+        )
+    """)
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_github_direct_commit_files_path "
+        "ON github_direct_commit_files(repo_full_name, path)"
+    )
+
+
 def ensure_github_schema(conn: sqlite3.Connection) -> None:
     """Create GitHub activity and local knowledge tables if they don't exist.
 
@@ -597,6 +658,7 @@ def ensure_github_schema(conn: sqlite3.Connection) -> None:
     _ensure_github_repo_schema(conn)
     _ensure_github_artifact_schema(conn)
     _ensure_github_knowledge_schema(conn)
+    _ensure_github_direct_commit_schema(conn)
     conn.commit()
 
 

--- a/src/rebalance/ingest/github_direct_commits.py
+++ b/src/rebalance/ingest/github_direct_commits.py
@@ -1,0 +1,271 @@
+"""Bounded, durable capture of direct GitHub branch-push signals (GH-155)."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+from urllib.parse import quote
+
+from rebalance.ingest._http import GITHUB_API, GitHubClient
+from rebalance.ingest.config import normalize_github_repo_name
+from rebalance.ingest.db import db_connection, ensure_github_schema
+from rebalance.ingest.db import github as gh
+
+MAX_PUSH_COMPARES_PER_REFRESH = 5
+MAX_COMMIT_DETAILS_PER_REFRESH = 20
+MAX_COMMITS_PER_PUSH = 250
+MAX_EVENT_ATTEMPTS = 3
+JsonGetter = Callable[[str], tuple[int, Any]]
+
+
+@dataclass
+class DirectCommitCaptureResult:
+    events_seen: int = 0
+    events_new: int = 0
+    events_enriched: int = 0
+    events_deferred: int = 0
+    commits_captured: int = 0
+    head_only: int = 0
+    api_calls_used: int = 0
+
+    def as_dict(self) -> dict[str, int]:
+        return asdict(self)
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _event_id(event: dict[str, Any]) -> str:
+    """Use GitHub's event ID, with a deterministic fixture-safe fallback."""
+    value = str(event.get("id") or "").strip()
+    if value:
+        return value
+    payload = event.get("payload") or {}
+    repo = (event.get("repo") or {}).get("name") or ""
+    return ":".join((str(repo), str(event.get("created_at") or ""), str(payload.get("head") or "")))
+
+
+def _is_deleted(head: str) -> bool:
+    return not head or set(head) == {"0"}
+
+
+def _commit_values(
+    *, repo: str, sha: str, event_id: str, ref: str, row: dict[str, Any], coverage: str, now: str
+) -> tuple:
+    commit = row.get("commit") or {}
+    author = row.get("author") or {}
+    committer = commit.get("committer") or commit.get("author") or {}
+    return (
+        repo,
+        sha,
+        event_id,
+        ref,
+        author.get("login") or "",
+        (commit.get("author") or {}).get("name") or "",
+        (commit.get("message") or "").strip(),
+        committer.get("date"),
+        row.get("html_url") or "",
+        coverage,
+        now,
+        now,
+    )
+
+
+def capture_direct_commits(
+    database_path: Path,
+    *,
+    token: str,
+    events: list[dict[str, Any]],
+    watched_repos: list[str],
+    api_get: JsonGetter | None = None,
+    compare_cap: int = MAX_PUSH_COMPARES_PER_REFRESH,
+    detail_cap: int = MAX_COMMIT_DETAILS_PER_REFRESH,
+) -> DirectCommitCaptureResult:
+    """Persist watched branch PushEvent receipts and enrich them within hard caps.
+
+    The Events payload is only a discovery signal: compare resolves the range and
+    commit-detail resolves exact file paths. A transient failure remains a
+    durable deferred receipt, so no work is silently treated as absent.
+    """
+    result = DirectCommitCaptureResult()
+    watched = {normalize_github_repo_name(repo) for repo in watched_repos}
+    now = _now()
+    with db_connection(database_path, ensure_github_schema) as conn:
+        for event in events:
+            if event.get("type") != "PushEvent":
+                continue
+            repo = str((event.get("repo") or {}).get("name") or "")
+            normalized = normalize_github_repo_name(repo)
+            if normalized not in watched:
+                continue
+            payload = event.get("payload") or {}
+            ref = str(payload.get("ref") or "")
+            if not ref.startswith("refs/heads/"):
+                continue
+            result.events_seen += 1
+            if gh.insert_push_event(
+                conn,
+                (
+                    _event_id(event), repo, ref, payload.get("before"), payload.get("head"),
+                    event.get("created_at"), now,
+                ),
+            ):
+                result.events_new += 1
+        conn.commit()
+
+    fetch = api_get or GitHubClient(token).get
+    compare_used = detail_used = 0
+    with db_connection(database_path, ensure_github_schema) as conn:
+        pending = gh.pending_push_events(
+            conn, max(compare_cap + detail_cap, compare_cap), MAX_EVENT_ATTEMPTS,
+        )
+        for event in pending:
+            event_id = event["event_id"]
+            repo = event["repo_full_name"]
+            ref = event["ref"]
+            before = str(event["before_sha"] or "")
+            head = str(event["head_sha"] or "")
+            attempt_now = _now()
+            if _is_deleted(head):
+                gh.update_push_event(conn, event_id, state="ignored", now=attempt_now, reason="branch deleted")
+                continue
+
+            if not before:
+                if detail_used >= detail_cap:
+                    gh.update_push_event(conn, event_id, state="deferred", now=attempt_now, reason="commit detail cap reached")
+                    result.events_deferred += 1
+                    continue
+                status, detail = fetch(f"{GITHUB_API}/repos/{quote(repo, safe='/')}/commits/{head}")
+                detail_used += 1
+                result.api_calls_used += 1
+                if status == 200 and isinstance(detail, dict):
+                    gh.upsert_direct_commit(conn, _commit_values(
+                        repo=repo, sha=head, event_id=event_id, ref=ref, row=detail,
+                        coverage="complete", now=attempt_now,
+                    ))
+                    gh.replace_direct_commit_files(conn, repo, head, detail.get("files") or [])
+                    gh.update_push_event(conn, event_id, state="head_only", now=attempt_now, reason="missing push base")
+                    result.commits_captured += 1
+                    result.head_only += 1
+                else:
+                    state = "deferred" if status in (429, 500, 502, 503, 504) else "failed"
+                    gh.update_push_event(conn, event_id, state=state, now=attempt_now, reason=f"head fetch HTTP {status}")
+                    result.events_deferred += state == "deferred"
+                continue
+
+            if compare_used >= compare_cap:
+                gh.update_push_event(conn, event_id, state="deferred", now=attempt_now, reason="compare cap reached")
+                result.events_deferred += 1
+                continue
+            compare_url = f"{GITHUB_API}/repos/{quote(repo, safe='/')}/compare/{before}...{head}"
+            status, comparison = fetch(compare_url)
+            compare_used += 1
+            result.api_calls_used += 1
+            if status != 200 or not isinstance(comparison, dict):
+                state = "deferred" if status in (429, 500, 502, 503, 504) else "failed"
+                gh.update_push_event(conn, event_id, state=state, now=attempt_now, reason=f"compare HTTP {status}")
+                result.events_deferred += state == "deferred"
+                continue
+            commits = comparison.get("commits") or []
+            if int(comparison.get("ahead_by") or len(commits)) > MAX_COMMITS_PER_PUSH:
+                gh.update_push_event(conn, event_id, state="failed", now=attempt_now, reason="compare range exceeds direct-commit cap")
+                continue
+
+            complete = True
+            terminal_detail_error = False
+            for summary in commits:
+                sha = str(summary.get("sha") or "")
+                if not sha:
+                    continue
+                existing = conn.execute(
+                    "SELECT path_coverage FROM github_direct_commits WHERE repo_full_name = ? AND sha = ?",
+                    (repo, sha),
+                ).fetchone()
+                if existing and existing["path_coverage"] == "complete":
+                    continue
+                if detail_used >= detail_cap:
+                    gh.upsert_direct_commit(conn, _commit_values(
+                        repo=repo, sha=sha, event_id=event_id, ref=ref, row=summary,
+                        coverage="unavailable", now=attempt_now,
+                    ))
+                    complete = False
+                    continue
+                detail_status, detail = fetch(f"{GITHUB_API}/repos/{quote(repo, safe='/')}/commits/{sha}")
+                detail_used += 1
+                result.api_calls_used += 1
+                if detail_status != 200 or not isinstance(detail, dict):
+                    gh.upsert_direct_commit(conn, _commit_values(
+                        repo=repo, sha=sha, event_id=event_id, ref=ref, row=summary,
+                        coverage="unavailable", now=attempt_now,
+                    ))
+                    complete = False
+                    terminal_detail_error |= detail_status not in (429, 500, 502, 503, 504)
+                    continue
+                gh.upsert_direct_commit(conn, _commit_values(
+                    repo=repo, sha=sha, event_id=event_id, ref=ref, row=detail,
+                    coverage="complete", now=attempt_now,
+                ))
+                gh.replace_direct_commit_files(conn, repo, sha, detail.get("files") or [])
+                result.commits_captured += 1
+            state = "enriched" if complete else ("failed" if terminal_detail_error else "deferred")
+            reason = "" if complete else (
+                "non-retryable commit detail failure" if terminal_detail_error
+                else "commit detail cap or transient fetch failure"
+            )
+            gh.update_push_event(conn, event_id, state=state, now=attempt_now, reason=reason)
+            result.events_enriched += complete
+            result.events_deferred += not complete and not terminal_detail_error
+        conn.commit()
+    return result
+
+
+def sync_direct_commit_documents(database_path: Path) -> int:
+    """Materialize non-PR-overlapping direct commits into the GitHub document corpus."""
+    now = _now()
+    with db_connection(database_path, ensure_github_schema) as conn:
+        conn.execute("DELETE FROM github_documents WHERE doc_type = 'direct_commit'")
+        rows = conn.execute(
+            """
+            SELECT d.repo_full_name, d.sha, d.ref, d.message, d.committed_at, d.html_url,
+                   d.path_coverage
+            FROM github_direct_commits d
+            WHERE NOT EXISTS (
+                SELECT 1 FROM github_commits p
+                WHERE p.repo_full_name = d.repo_full_name AND p.sha = d.sha
+            )
+            ORDER BY d.committed_at DESC
+            """
+        ).fetchall()
+        for row in rows:
+            paths = [
+                file_row["path"] for file_row in conn.execute(
+                    "SELECT path FROM github_direct_commit_files WHERE repo_full_name = ? AND sha = ? "
+                    "ORDER BY path LIMIT 50",
+                    (row["repo_full_name"], row["sha"]),
+                ).fetchall()
+            ]
+            path_text = "\n".join(f"- {path}" for path in paths) or "- (paths unavailable)"
+            body = (
+                f"Direct branch commit {row['sha']}\nRef: {row['ref'] or ''}\n"
+                f"Committed: {row['committed_at'] or ''}\nCoverage: {row['path_coverage']}\n"
+                f"Message: {row['message'] or ''}\nChanged paths:\n{path_text}"
+            )
+            gh.insert_github_document(
+                conn,
+                repo_full_name=row["repo_full_name"],
+                source_type="direct_commit",
+                source_number=0,
+                doc_type="direct_commit",
+                source_key=f"{row['repo_full_name']}:direct_commit:{row['sha']}",
+                title=(row["message"] or "direct commit").splitlines()[0][:200],
+                body=body,
+                content_hash=hashlib.sha256(body.encode("utf-8")).hexdigest(),
+                updated_at=row["committed_at"] or now,
+                fetched_at=now,
+            )
+        conn.commit()
+    return len(rows)

--- a/src/rebalance/ingest/github_scan.py
+++ b/src/rebalance/ingest/github_scan.py
@@ -87,6 +87,7 @@ class GitHubScanResult:
     days_fetched: int
     total_events: int
     repo_activity: dict[str, RepoActivity] = field(default_factory=dict)
+    events: list[dict[str, Any]] = field(default_factory=list)
 
 
 class GitHubApiError(Exception):
@@ -477,6 +478,7 @@ def scan_github(token: str, days: int = 30) -> GitHubScanResult:
         days_fetched=days,
         total_events=len(events),
         repo_activity=repo_activity,
+        events=events,
     )
 
 

--- a/src/rebalance/ingest/index_ops.py
+++ b/src/rebalance/ingest/index_ops.py
@@ -873,6 +873,7 @@ def _refresh_github(
     plan_steps = [
         "sync_pushed_repos()",
         f"github_scan(days={since_days})",
+        "capture_direct_commits(events, watched_repos, cap=5/20)",
         f"sync_github_repo() x ~{len(initial_target_repos)} repos (after auto-discovery)",
         f"reconcile_watched_repo() x {external_count} external repos (rollup or purge)",
         "embed_github_documents()",
@@ -893,6 +894,10 @@ def _refresh_github(
     )
     from rebalance.ingest.config import get_github_ignored_repos
     from rebalance.ingest.github_knowledge import sync_github_repo
+    from rebalance.ingest.github_direct_commits import (
+        capture_direct_commits,
+        sync_direct_commit_documents,
+    )
 
     # Auto-discovery: fetch /user/repos?sort=pushed and upsert into
     # github_pushed_repos BEFORE resolving target repos, so newly-pushed
@@ -903,6 +908,12 @@ def _refresh_github(
     scan_result = scan_github(token=token, days=since_days)
     skipped = filter_ignored_repo_activity(scan_result, get_github_ignored_repos())
     upsert_github_activity(database_path, scan_result)
+    direct_commits = capture_direct_commits(
+        database_path,
+        token=token,
+        events=scan_result.events,
+        watched_repos=target_repos,
+    )
 
     repo_results: list[dict[str, Any]] = []
     for repo in target_repos:
@@ -947,6 +958,19 @@ def _refresh_github(
             )
         except Exception as e:  # noqa: BLE001 — one repo must not abort the run
             watched_activity.append({"repo": repo, "error": str(e)})
+
+    direct_documents = sync_direct_commit_documents(database_path)
+    # The GitHub raw source emits github_documents; semantic_index remains the
+    # sole writer of semantic_documents. Re-project each refreshed repo so a
+    # direct commit is queryable in the same run.
+    from rebalance.ingest.db import db_connection, ensure_github_schema
+    from rebalance.ingest.semantic_index import sync_github_documents
+
+    direct_semantic: dict[str, dict[str, int]] = {}
+    with db_connection(database_path, ensure_github_schema) as conn:
+        for repo in target_repos:
+            direct_semantic[repo] = sync_github_documents(conn, repo_full_name=repo)
+        conn.commit()
 
     from rebalance.ingest.github_knowledge import embed_github_documents
 
@@ -1002,6 +1026,11 @@ def _refresh_github(
             "events": scan_result.total_events,
             "repos": len(scan_result.repo_activity),
             "skipped_ignored": len(skipped),
+        },
+        "direct_commit_capture": {
+            **direct_commits.as_dict(),
+            "documents_built": direct_documents,
+            "semantic_projection": direct_semantic,
         },
         "artifact_sync": repo_results,
         "watched_activity": watched_activity,

--- a/src/rebalance/ingest/next_actions.py
+++ b/src/rebalance/ingest/next_actions.py
@@ -575,13 +575,20 @@ def github_candidates(bundle: OperatorBundle) -> list[dict[str, Any]]:
             "why": "open GitHub item you authored/own",
         })
     for c in bundle.gh_commits:
+        direct_push = c.get("source_kind") == "direct_push"
+        paths = [path for path in c.get("paths", []) if path][:5]
+        evidence = [c.get("html_url") or (c.get("sha") or "")]
+        evidence.extend(paths)
         out.append({
             "rank_key": (4, c.get("committed_at") or ""),
             "title": c.get("subject") or "commit",
             "source": "github",
             "project": c.get("repo"),
-            "evidence": [c.get("html_url") or (c.get("sha") or "")],
-            "why": "recent commit (continue / push?)",
+            "evidence": evidence,
+            "why": (
+                "unreviewed direct branch push (inspect or continue?)"
+                if direct_push else "recent commit (continue / push?)"
+            ),
         })
     for cm in bundle.gh_comments:
         out.append({

--- a/src/rebalance/ingest/pulse.py
+++ b/src/rebalance/ingest/pulse.py
@@ -209,6 +209,46 @@ def _query_day_activity(
                 "html_url": r["html_url"] or "",
                 "author_login": r["author_login"] or "",
                 "source_tag": tag,
+                "source_kind": "pull_request",
+            })
+
+    # Direct branch commits are a distinct raw source. The anti-join means a
+    # later-discovered PR commit replaces the visible signal without deleting
+    # the direct-push receipt/provenance.
+    direct_filter = _author_filter_sql("d.author_login")
+    rows = conn.execute(
+        f"""
+        SELECT d.repo_full_name, d.sha, d.message, d.committed_at, d.html_url,
+               d.author_login, d.ref,
+               (SELECT GROUP_CONCAT(path, char(10))
+                  FROM github_direct_commit_files f
+                 WHERE f.repo_full_name = d.repo_full_name AND f.sha = d.sha) AS paths
+        FROM github_direct_commits d
+        WHERE d.committed_at >= ?
+          AND {direct_filter}
+          AND NOT EXISTS (
+              SELECT 1 FROM github_commits p
+              WHERE p.repo_full_name = d.repo_full_name AND p.sha = d.sha
+          )
+        ORDER BY d.committed_at DESC
+        """,
+        (sql_floor, github_login, *CLOUD_AGENT_AUTHORS),
+    ).fetchall()
+    for r in rows:
+        if _in_window(r["committed_at"], start, end):
+            message = r["message"] or ""
+            activity.gh_commits.append({
+                "repo": r["repo_full_name"],
+                "sha": r["sha"][:7] if r["sha"] else "",
+                "subject": message.splitlines()[0][:160] if message else "direct commit",
+                "committed_at": r["committed_at"],
+                "html_url": r["html_url"] or "",
+                "author_login": r["author_login"] or "",
+                "paths": (r["paths"] or "").splitlines(),
+                "source_tag": classify_source(
+                    branch=r["ref"], author_login=r["author_login"], commit_message=message,
+                ),
+                "source_kind": "direct_push",
             })
 
     item_filter = _author_filter_sql("author_login")

--- a/tests/test_github_direct_commits.py
+++ b/tests/test_github_direct_commits.py
@@ -1,0 +1,163 @@
+"""Regression coverage for GH-155 direct branch-push collection."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+from rebalance.ingest.db import db_connection, ensure_github_schema, ensure_schema
+from rebalance.ingest.db import github as gh
+from rebalance.ingest.github_direct_commits import (
+    capture_direct_commits,
+    sync_direct_commit_documents,
+)
+from rebalance.ingest.next_actions import OperatorBundle, github_candidates
+from rebalance.ingest.pulse import _query_day_activity
+
+
+REPO = "Hypercart-Dev-Tools/rebalance-OS"
+SHA = "cfeafe4f564cf8f8fa5b161bad80642ae8752d16"
+BEFORE = "383d61cfb631998d55d7e33856b7fb7cdd55a01a"
+
+
+def _event() -> dict:
+    # Deliberately mirrors production observations: no payload.commits list.
+    return {
+        "id": "push-155",
+        "type": "PushEvent",
+        "repo": {"name": REPO},
+        "created_at": "2026-07-18T03:06:20Z",
+        "payload": {"ref": "refs/heads/main", "before": BEFORE, "head": SHA},
+    }
+
+
+def _commit() -> dict:
+    return {
+        "sha": SHA,
+        "html_url": f"https://github.com/{REPO}/commit/{SHA}",
+        "author": {"login": "noelsaw1"},
+        "commit": {
+            "message": "feat: bring CLIO into rebalance-OS as its canonical home",
+            "author": {"name": "Noel", "date": "2026-07-18T03:06:18Z"},
+            "committer": {"date": "2026-07-18T03:06:18Z"},
+        },
+        "files": [
+            {"filename": "utils/CLIO/INSTALL.md", "status": "added", "additions": 10, "deletions": 0, "changes": 10},
+            {"filename": "utils/CLIO/LICENSE", "status": "added", "additions": 1, "deletions": 0, "changes": 1},
+            {"filename": "utils/CLIO/README.md", "status": "added", "additions": 570, "deletions": 0, "changes": 570},
+        ],
+    }
+
+
+class DirectCommitCaptureTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.db_path = Path(self._tmp.name) / "rebalance.db"
+
+    def test_event_without_payload_commits_resolves_paths_and_is_idempotent(self) -> None:
+        calls: list[str] = []
+        commit = _commit()
+
+        def fetch(url: str):
+            calls.append(url)
+            if "/compare/" in url:
+                return 200, {"ahead_by": 1, "commits": [dict(commit, files=[])]}
+            if f"/commits/{SHA}" in url:
+                return 200, commit
+            return 404, {}
+
+        result = capture_direct_commits(
+            self.db_path, token="unused", events=[_event()], watched_repos=[REPO], api_get=fetch,
+        )
+        self.assertEqual(result.events_new, 1)
+        self.assertEqual(result.commits_captured, 1)
+        self.assertEqual(result.api_calls_used, 2)
+        with db_connection(self.db_path, ensure_github_schema) as conn:
+            row = conn.execute(
+                "SELECT message, path_coverage FROM github_direct_commits WHERE sha = ?", (SHA,)
+            ).fetchone()
+            paths = [r["path"] for r in conn.execute(
+                "SELECT path FROM github_direct_commit_files WHERE sha = ? ORDER BY path", (SHA,)
+            ).fetchall()]
+            event = conn.execute("SELECT state FROM github_push_events WHERE event_id = 'push-155'").fetchone()
+        self.assertEqual(row["path_coverage"], "complete")
+        self.assertIn("CLIO", row["message"])
+        self.assertEqual(paths, ["utils/CLIO/INSTALL.md", "utils/CLIO/LICENSE", "utils/CLIO/README.md"])
+        self.assertEqual(event["state"], "enriched")
+
+        calls.clear()
+        again = capture_direct_commits(
+            self.db_path, token="unused", events=[_event()], watched_repos=[REPO], api_get=fetch,
+        )
+        self.assertEqual(again.events_new, 0)
+        self.assertEqual(again.api_calls_used, 0)
+        self.assertEqual(calls, [])
+
+    def test_compare_cap_leaves_durable_deferred_receipt(self) -> None:
+        result = capture_direct_commits(
+            self.db_path, token="unused", events=[_event()], watched_repos=[REPO],
+            api_get=lambda _url: self.fail("cap must prevent API calls"), compare_cap=0,
+        )
+        self.assertEqual(result.events_deferred, 1)
+        with db_connection(self.db_path, ensure_github_schema) as conn:
+            row = conn.execute(
+                "SELECT state, failure_reason FROM github_push_events WHERE event_id = 'push-155'"
+            ).fetchone()
+        self.assertEqual(row["state"], "deferred")
+        self.assertIn("cap", row["failure_reason"])
+
+    def test_pr_overlap_removes_direct_document_but_keeps_raw_provenance(self) -> None:
+        commit = _commit()
+
+        def fetch(url: str):
+            if "/compare/" in url:
+                return 200, {"ahead_by": 1, "commits": [dict(commit, files=[])]}
+            return 200, commit
+
+        capture_direct_commits(
+            self.db_path, token="unused", events=[_event()], watched_repos=[REPO], api_get=fetch,
+        )
+        self.assertEqual(sync_direct_commit_documents(self.db_path), 1)
+        with db_connection(self.db_path, ensure_github_schema) as conn:
+            gh.upsert_commit(conn, (REPO, "pull_request", 155, SHA, "noelsaw1", "PR version", "2026-07-18T03:06:18Z", "", "now"))
+            conn.commit()
+        self.assertEqual(sync_direct_commit_documents(self.db_path), 0)
+        with db_connection(self.db_path, ensure_github_schema) as conn:
+            self.assertEqual(conn.execute("SELECT COUNT(*) FROM github_direct_commits").fetchone()[0], 1)
+            self.assertEqual(
+                conn.execute("SELECT COUNT(*) FROM github_documents WHERE doc_type = 'direct_commit'").fetchone()[0],
+                0,
+            )
+
+    def test_direct_commit_reaches_activity_and_hiqs_with_path_evidence(self) -> None:
+        commit = _commit()
+
+        def fetch(url: str):
+            if "/compare/" in url:
+                return 200, {"ahead_by": 1, "commits": [dict(commit, files=[])]}
+            return 200, commit
+
+        capture_direct_commits(
+            self.db_path, token="unused", events=[_event()], watched_repos=[REPO], api_get=fetch,
+        )
+        with db_connection(self.db_path, ensure_github_schema) as conn:
+            ensure_schema(conn)
+            activity = _query_day_activity(
+                conn,
+                label="incident",
+                start=datetime(2026, 7, 18, tzinfo=timezone.utc),
+                end=datetime(2026, 7, 19, tzinfo=timezone.utc),
+                github_login="noelsaw1",
+                slack_user_id=None,
+            )
+        self.assertEqual(len(activity.gh_commits), 1)
+        direct = activity.gh_commits[0]
+        self.assertEqual(direct["source_kind"], "direct_push")
+        self.assertIn("utils/CLIO/README.md", direct["paths"])
+        candidates = github_candidates(OperatorBundle(local_day="incident", gh_commits=[direct]))
+        self.assertEqual(len(candidates), 1)
+        self.assertIn("utils/CLIO/README.md", candidates[0]["evidence"])
+        self.assertIn("direct branch push", candidates[0]["why"])


### PR DESCRIPTION
## Summary

Implements GH-155's bounded direct-commit collection path for watched repositories.

- Persists PushEvent receipts plus direct commit and file-level records.
- Resolves before/head ranges through compare, then fetches exact commit files under hard per-refresh caps (5 compares, 20 commit details).
- Preserves explicit deferred/failed/head-only states and makes unchanged reruns API-free.
- Anti-joins PR commits so direct provenance remains raw evidence without duplicate dashboard, activity, document, or HiQS signals.
- Adds GitHub documents, semantic re-projection, pulse/HiQS path evidence, and dashboard activity rows.
- Bumps the package to 0.61.0.

## Validation

- 104 passed, 16 subtests passed
- compileall and git diff --check passed

Closes #155