### PR TITLE
chore(GH-123): VS Code debug + build config for the pulse-tree-view extension

### DIFF
--- a/vscode-extension/pulse-tree-view/.vscode/launch.json
+++ b/vscode-extension/pulse-tree-view/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "outFiles": ["${workspaceFolder}/out/**/*.js"],
+      "preLaunchTask": "${defaultBuildTask}"
+    }
+  ]
+}

--- a/vscode-extension/pulse-tree-view/.vscode/tasks.json
+++ b/vscode-extension/pulse-tree-view/.vscode/tasks.json
@@ -1,0 +1,14 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "compile",
+      "problemMatcher": "$tsc",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Salvage from **#148** before it was closed as superseded.

#148 scaffolded the same extension at `extensions/pulse-tree-view/` (2026-07-09); #134 shipped it to `development` at `vscode-extension/pulse-tree-view/`. Merging #148 would have added a second, stale copy at a parallel path, so it was closed rather than rebased through — but two editor-config files in it had **no equivalent** in the shipped version.

## What this adds

| File | What it does |
|---|---|
| `.vscode/launch.json` | F5 launches an Extension Development Host against this folder (`--extensionDevelopmentPath`), running the default build task first |
| `.vscode/tasks.json` | npm `compile` as the default build task, with the `$tsc` problem matcher |

**Editor config only.** No runtime code, nothing that ships in a `.vsix`.

## Verified against the shipped extension, not assumed

- `compile` exists in the shipped `package.json` ✓
- `tsconfig.json` emits `outDir: "out"`, matching `launch.json`'s `outFiles` glob `${workspaceFolder}/out/**/*.js` ✓
- `main` is `./out/extension.js` ✓
- `.vscode/` is not gitignored here ✓
- Both files parse as valid JSON ✓

## Deliberately not carried over

`media/pulse-icon.svg` from #148. It is not a loose asset — it is load-bearing for a **different UX placement**:

| | Shipped (#134) | #148 |
|---|---|---|
| Placement | view nested in an existing container | own **Activity Bar** container |
| Icon | none (inherits) | `media/pulse-icon.svg` |
| View id | `pulseTreeView` | `pulseTreeView.mainView` |

Adopting the icon means adopting `contributes.viewsContainers.activitybar` plus an id rename — a visible placement change that belongs to GH-123 **Phase 3** (`.vsix` packaging), not to a config cherry-pick. The SVG is a clean 24×24 using `currentColor`, so it would theme correctly if that route is taken later.

Refs #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)