### PR TITLE
feat(GH-172): single-instance + memory-ceiling guard for long-running local jobs

### DIFF
--- a/relay-system/2026-07-19/gh172-job-guard-qa.md
+++ b/relay-system/2026-07-19/gh172-job-guard-qa.md
@@ -4,8 +4,8 @@
   Scaffolded by relay-automation/new-relay.sh on 2026-07-19.
 -->
 
-NEXT: Reviewer
-STATUS: Open
+NEXT: Producer
+STATUS: Approved
 ROUND: 2 / 4
 
 ## ▶ TAKE YOUR TURN — read this first (works for ANY agent: Claude, Codex, agy)
@@ -155,5 +155,16 @@ when evicted. Dead `_terminate()` removed.
 3. `_Evicted` as `BaseException` — correct call, or will it slip past a legitimate cleanup handler?
 
 Your four other `[Pass]` gradings I've left as-is; no changes were made in those areas.
+
+### agy (Reviewer) - 2026-07-19
+**Verdict:** Approved
+
+* **[Pass]** The blocker fix is correct (`utils/job_guard.py:614-634`). Installing a `SIGTERM` handler to raise `_Evicted` ensures the wrapper cleanly catches eviction and executes `_reap_child_tree` (`utils/job_guard.py:623`) before exiting `143`.
+* **[Pass]** Zombie-blind liveness probe is fixed (`utils/job_guard.py:661`). `child.wait(timeout=grace)` properly reaps the direct child, avoiding polling a zombie.
+* **[Pass]** Eviction race is fixed (`utils/job_guard.py:353-359`). Polling `_try_flock()` ensures the lock is genuinely acquired from the OS before returning success.
+* **[Pass]** Answering your round 2 questions:
+  1. The 5s post-SIGKILL window (`utils/job_guard.py:355`) is sound. Because `flock` is atomic in the kernel (`utils/job_guard.py:300`), multiple simultaneous replacers will serialize. One will acquire the lock and return `True`, while the others will fail to acquire, time out, return `False` (`utils/job_guard.py:360`), and correctly raise `InstanceConflict` (`utils/job_guard.py:292`). No livelock.
+  2. Sweeping the group with `killpg` (`utils/job_guard.py:677`) is the standard and correct approach here. Processes that intentionally escape their group via `setsid`/`setpgid` cannot be robustly tracked without cgroups (unavailable on macOS). For typical multiprocessing pools, `killpg` is entirely sufficient.
+  3. `_Evicted` inheriting from `BaseException` (`utils/job_guard.py:99`) is the right call for internal flow control via signals, matching how `KeyboardInterrupt` works and preventing accidental swallowing by overly broad `except Exception:` blocks.
 
 <!-- ↓↓↓ NEXT TURN goes here (append above nothing — this marker stays last) ↓↓↓ -->

--- a/relay-system/2026-07-19/gh172-job-guard-qa.md
+++ b/relay-system/2026-07-19/gh172-job-guard-qa.md
@@ -6,7 +6,7 @@
 
 NEXT: Reviewer
 STATUS: Open
-ROUND: 1 / 4
+ROUND: 2 / 4
 
 ## ▶ TAKE YOUR TURN — read this first (works for ANY agent: Claude, Codex, agy)
 1. **Read this whole file** (header, Setup, Ground rules, every block in the Log).
@@ -89,5 +89,71 @@ defects 2/3/5 in those files.
 6. The relay ends on **Approved** (Reviewer only). End each turn by committing just this file; no push.
 
 ## Log
+
+### agy (Reviewer) - 2026-07-19
+**Verdict:** Changes requested
+
+* **[Blocker]** In `--on-conflict replace`, `_evict` SIGTERMs the incumbent wrapper PID (`utils/job_guard.py:296`), which dies immediately because `run_guarded` does not install a `SIGTERM` handler. Since the child was started with `start_new_session=True` (`utils/job_guard.py:533`), the entire child process group is stranded and orphaned, reproducing the exact stacked memory failure we want to prevent.
+  * **Fix:** In `run_guarded`, install a `SIGTERM` signal handler (similar to the in-process `guard`) that catches the signal and explicitly calls `_kill_group(child.pid, ...)`, so the wrapper cleanly tears down its tree when evicted.
+* **[Pass]** Single-instance correctness: `flock` correctly provides mutual exclusion and releases on death. The lock directory defaults to `~/.cache/rebalance-os/locks` (`utils/job_guard.py:66-68`), which correctly places it out of the repo to cover worktrees/clones sharing a job name.
+* **[Pass]** Memory ceiling bounds: `tree_rss_bytes` accurately sums the tree using `ps -eo pid=,ppid=,rss=` (`utils/job_guard.py:173`). `available_memory_bytes()` correctly parses `vm_stat` on macOS to sum free + inactive + speculative pages (`utils/job_guard.py:149-153`), preventing false starvation reports on healthy machines with reclaimable pages.
+* **[Pass]** Clean abort: `_kill_group` correctly uses `os.killpg(os.getpgid(pid), signal.SIGTERM)` (`utils/job_guard.py:555`) to signal the whole process group. The in-process `guard` correctly sets a `SIGTERM` handler to raise `MemoryCeilingExceeded` (`utils/job_guard.py:474`) in the main thread so `finally` blocks can execute.
+* **[Pass]** Fails safe on probes: If `sysctl` fails or is blocked by the sandbox, `total_memory_bytes` gracefully returns 0 (`utils/job_guard.py:115`), which causes `MemoryCeiling.start()` to log and cleanly exit (`utils/job_guard.py:393-395`), degrading to "ceiling disabled" rather than falsely aborting.
+* **[Pass]** Defaults: `DEFAULT_MAX_RSS_FRACTION = 0.35` (`utils/job_guard.py:71`) and `DEFAULT_MIN_AVAILABLE_FRACTION = 0.12` with a 4GB floor (`utils/job_guard.py:76-79`) are sensible. A 35% cap gives ~24GB on a 64GB machine (generous enough for large embeddings) and protects against stacking, while the 12% floor provides a reasonable safety margin for the OS.
+
+### claude-a (Producer) — 2026-07-19 — round 2
+
+**Disposition of the [Blocker]: Implemented — and the finding was correct.**
+
+I reproduced it before fixing it rather than taking it on trust. Incumbent wrapper `69659`, marker
+child `69663` in its own pgid; after `--on-conflict replace`, `pgrep -f marker.py` still returned
+`69663`. Orphan confirmed exactly as described. My own pre-relay test that reported "no orphan" was
+simply a bad test (wrong pattern, inconclusive teardown) — the review caught a real defect.
+
+Fixing it surfaced **two further defects the original fix would have papered over**, both found by
+tracing the actual failure rather than assuming the first fix worked:
+
+* **[Blocker-2] Zombie-blind liveness probe.** `_group_alive()` used `killpg(pgid, 0)`, which
+  succeeds against a **zombie**. The wrapper had already SIGTERMed and reaped nothing, so teardown
+  polled a dead-but-unwaited child for the *entire* grace window. Traced live: wrapper stayed
+  `ps_stat='SN'` for 10s+ after SIGTERM with the flock still held every 0.25s sample.
+  *Fix:* `_reap_child_tree()` — the parent now `waitpid()`s the child (`child.wait(timeout=grace)`)
+  instead of polling signal 0, then sweeps grandchildren *after* the child is reaped, when the
+  liveness probe is finally meaningful.
+* **[Blocker-3] Evictor raced the kernel's lock release.** `_terminate()` sent SIGKILL and returned
+  immediately, then `acquire()` retried `flock` exactly once. Observed symptom: replace-mode
+  correctly killed the incumbent and then **refused its own lock** —
+  `job 'orphantest' is already running (pid 78277)`. So replace was broken in both directions.
+  *Fix:* `_evict()` now measures success by **acquiring the flock**, not by the PID vanishing —
+  SIGTERM → poll `_try_flock()` every 100ms up to grace → SIGKILL → poll again. PID liveness was
+  the wrong ground truth; the lock is the only thing that actually answers "who owns this job".
+
+Supporting changes: lockfile is now JSON (`{"pid":…, "child_pgid":…}`, bare-PID tolerated) so an
+evictor can reap a tree whose wrapper it had to SIGKILL and which therefore never ran cleanup;
+`_Evicted(BaseException)` so a broad `except Exception` can't swallow eviction; wrapper exits `143`
+when evicted. Dead `_terminate()` removed.
+
+**Re-test after fix (un-sandboxed, all green):**
+
+| Test | Result |
+|---|---|
+| T1 replace: evicts, acquires, no orphan | PASS — lock taken in 0.168s, marker GONE |
+| T2 refuse while held | PASS — exit 3 |
+| T3 RSS ceiling vs 200MB/0.5s allocator | PASS — exit 4, hog killed, never printed |
+| T4 in-process `guard()` raises in main thread | PASS |
+| T5 child exit-code passthrough | PASS — exit 7 |
+| T6 SIGKILLed holder does not block next run | PASS — exit 0 (flock auto-release) |
+| T7 `--status` | PASS — 64.0 GB total, honest 0.0 GB when sysctl is sandbox-blocked |
+
+**Open for round 2 — please re-review the fix itself, not just the original finding:**
+1. `_evict()`'s escalation loop: SIGTERM+grace then SIGKILL+5s, both polling `_try_flock()`. Is the
+   5s post-SIGKILL window sound, and can two *simultaneous* replacers livelock or both conclude
+   success? That path is untested — I could not construct a reliable race.
+2. `_reap_child_tree()` sweeps the group only `if _group_alive(pgid)` after reaping the direct
+   child. A grandchild that re-parents to init and leaves the group is still unreachable. Real risk
+   for an embedding job, or acceptable?
+3. `_Evicted` as `BaseException` — correct call, or will it slip past a legitimate cleanup handler?
+
+Your four other `[Pass]` gradings I've left as-is; no changes were made in those areas.
 
 <!-- ↓↓↓ NEXT TURN goes here (append above nothing — this marker stays last) ↓↓↓ -->

--- a/relay-system/2026-07-19/gh172-job-guard-qa.md
+++ b/relay-system/2026-07-19/gh172-job-guard-qa.md
@@ -1,0 +1,93 @@
+# RELAY · GH-172 QA: job_guard.py single-instance + memory ceiling
+<!--
+  Single source of truth for this two-agent relay. Read the ENTIRE file before acting.
+  Scaffolded by relay-automation/new-relay.sh on 2026-07-19.
+-->
+
+NEXT: Reviewer
+STATUS: Open
+ROUND: 1 / 4
+
+## ▶ TAKE YOUR TURN — read this first (works for ANY agent: Claude, Codex, agy)
+1. **Read this whole file** (header, Setup, Ground rules, every block in the Log).
+2. **Check it's your turn:** `NEXT` (top) names the role to act. Confirm you are bound to it and the
+   last Log block isn't already yours. If not → STOP and reply "wrong window — nudge the <other> window."
+3. **Do your role's work** on the artifact named in Setup:
+   - **Reviewer:** review vs the Definition of Done → graded findings
+     (`[Blocker]`/`[Should]`/`[Nit]`/`[Pass]`), each with a concrete fix → set a **Verdict**
+     (Approved | Changes requested | Blocked). Any `[Pass]` or "verified"/"confirmed" finding MUST
+     carry a quoted span or a `file:line` citation — an uncited one is mechanically downgraded to
+     `[Unverified — no citation]` (GH-173 B3). Do **not** edit the artifact; only append findings here.
+   - **Producer:** log a disposition for every open finding (Implemented / Modified / Declined + why),
+     make the change, then add new work.
+4. **Append ONE block** at the very bottom, directly **above** the marker line. Never edit earlier turns.
+5. **Update the header:** flip `NEXT`; set `STATUS` (`Approved` closes — Reviewer only; else `Open`);
+   the Producer bumps `ROUND` when opening a new cycle. If the max `ROUND` ends without `Approved`,
+   set `STATUS: Escalated`.
+6. **Commit only the relay file** (`relay(gh172-job-guard-qa): <role> r<N>`); no push. **Stop** and report one line.
+
+## Setup
+- Artifact under review: `utils/job_guard.py` (new, additive, NOT yet wired into any job)
+- Reviewer: agy   ·   Producer: claude-a
+- Started: 2026-07-19
+- Tracking issue: GH-172 — CRITICAL: hard kernel panic from unbounded concurrent embedding runs
+  (90 GB resident on a 68.7 GB machine; three stacked Python embedding runs; AppleARMWatchdogTimer
+  fired after watchdogd was starved >90s by VM-compressor thrash).
+
+### What this file is meant to be
+A **standalone, reusable** guard supplying the two primitives GH-172 found missing — it is NOT a fix
+to the embedding stacks themselves. Deliberately stdlib-only (no psutil: must run under system
+python3, launchd, and the rebalance venv with no install step). Two entry points:
+`guard()` (in-process context manager) and `run_guarded()`/`main()` (wrapper CLI around any command).
+
+### Definition of Done — grade against these
+1. **Single-instance correctness.** `flock`-based lock is genuinely mutually exclusive; a killed
+   holder never leaves a lock that blocks the next run; `--on-conflict replace` evicts the incumbent
+   without deadlocking or racing itself; the lock namespace is shared across worktrees/clones of the
+   same repo (two clones running the same job MUST collide).
+2. **Memory ceiling actually bounds.** Both trip conditions are correct and meaningful: the tree-RSS
+   ceiling (catches accumulation — GH-172 defects 2/3) and the system-available floor (catches
+   stacked runs — defect 1). `available_memory_bytes()` must not report false starvation on a
+   healthy machine (macOS: free+inactive+speculative is the intended definition — challenge it).
+3. **Clean abort, no orphans.** On trip the guarded tree dies: SIGTERM then SIGKILL after grace.
+   In wrapper mode the child runs in its own session and the whole **process group** is signalled.
+   In-process mode raises in the MAIN thread so `finally` blocks flush partial work.
+   **Known suspect area — probe this:** in `--on-conflict replace`, `_evict()` SIGTERMs only the
+   incumbent *wrapper* PID recorded in the lockfile. Its child was started with
+   `start_new_session=True`, so the grandchildren may be orphaned rather than reaped. A live test
+   showed no orphan, but that was not conclusive. Determine whether replace-mode can strand a
+   process tree — that would reproduce the exact stacking failure this file exists to prevent.
+4. **Fails safe, never fails closed on ITS own errors.** Every probe (`sysctl`, `vm_stat`, `ps`)
+   returns 0 on failure. Confirm a probe failure degrades to "ceiling disabled + warn" and never to
+   "abort a healthy job" or "silently pretend to be guarding." Note that under a sandboxed shell
+   `sysctl` is blocked and total RAM reads 0 — verify that path is handled honestly.
+5. **Portability.** macOS is primary (Darwin 24.6.0, Apple M1 Max); Linux `/proc` fallback should be
+   correct or explicitly degrade. Python 3.14 is the local interpreter — flag any 3.9-era assumption.
+6. **Defaults are defensible.** 35% of RAM as the per-job RSS ceiling and max(12% of RAM, 4 GB) as
+   the available floor: argue whether these would have actually prevented the GH-172 panic, and
+   whether they are too tight for a legitimate large embedding run (false-abort risk).
+
+### Producer's own test evidence (verify, don't trust)
+Run un-sandboxed. All four passed locally before this relay:
+- `--status` reports 64.0 GiB total on this machine (0.0 GB under the Bash sandbox — sysctl blocked).
+- Second concurrent run exits **3** with the holder PID named.
+- `--max-rss-gb 1.5` against a 200 MB/0.5s allocator: tripped at 1.6 GB, killed the group, exit **4**.
+- In-process `guard(max_rss_gb=1.0)` raised `MemoryCeilingExceeded` in the main thread.
+- `--on-conflict replace` took the lock from a live incumbent and ran.
+
+### Out of scope for this review
+Wiring the guard into `ask_self_ingest.py` / `src/rebalance/ingest/embedder.py` (deliberately not done
+— GH-172's open question of *which* stack held the 45 GB is still unresolved), and fixing GH-172
+defects 2/3/5 in those files.
+
+## Ground rules
+1. This file is the single source of truth. The agents never share memory — read the whole file.
+2. Take a turn only if `NEXT` names your role — otherwise reply "not my turn" and stop.
+3. One turn = one block appended at the very bottom, above the marker. Never edit earlier turns.
+4. Stay tight — findings are bullets, not essays. Grade every finding.
+5. **The Reviewer never edits the artifact.** It proposes graded findings; the Producer implements.
+6. The relay ends on **Approved** (Reviewer only). End each turn by committing just this file; no push.
+
+## Log
+
+<!-- ↓↓↓ NEXT TURN goes here (append above nothing — this marker stays last) ↓↓↓ -->

--- a/utils/job_guard.py
+++ b/utils/job_guard.py
@@ -1,0 +1,634 @@
+#!/usr/bin/env python3
+"""Single-instance + memory-ceiling guard for long-running local jobs (GH-172).
+
+Context — on 2026-07-19 the Mac Studio hard kernel-panicked (AppleARMWatchdogTimer,
+90s watchdogd starvation) because three unbounded Python embedding runs stacked to
+~90 GB resident on a 68.7 GB machine. Nothing in either embedding stack prevented
+concurrent invocation, and nothing aborted before the VM compressor saturated.
+
+This module supplies the two missing primitives, independent of any one job:
+
+  1. SingleInstanceLock — an advisory ``flock`` on a named lockfile. A second run
+     either REFUSES (default) or REPLACES the incumbent. Stale locks left by a
+     killed process are reclaimed automatically.
+  2. MemoryCeiling — a watchdog thread that samples the guarded process tree's
+     RSS *and* system-available memory, and aborts the job CLEANLY (SIGTERM, then
+     SIGKILL after a grace period) before the machine starts thrashing.
+
+Deliberately stdlib-only (no psutil): this has to run under the system python3,
+inside launchd jobs, and inside the rebalance venv without an install step.
+
+Two usage modes.
+
+In-process — wrap the body of a Python job::
+
+    from job_guard import guard
+
+    with guard("ask-self-ingest", max_rss_gb=24):
+        run_the_ingest()
+
+Wrapper — guard any command, including non-Python ones. The ceiling then covers
+the whole child process tree::
+
+    python3 utils/job_guard.py --name ask-self-ingest --max-rss-gb 24 -- \
+        python3 ask_self/ask_self_ingest.py --repo .
+
+Exit codes in wrapper mode:
+    0    child exited 0
+    3    another instance holds the lock (``--on-conflict refuse``)
+    4    memory ceiling tripped; the job was terminated
+    else the child's own exit status
+
+NOT installed into any job by this change — see GH-172. Landing it on the ingest
+stacks is a separate, deliberate step, because the issue's open question (which
+embedding stack actually held the 45 GB) is still unresolved.
+"""
+
+from __future__ import annotations
+
+import argparse
+import errno
+import fcntl
+import os
+import re
+import signal
+import subprocess
+import sys
+import threading
+import time
+from contextlib import contextmanager
+from pathlib import Path
+
+GIB = 1024 ** 3
+
+#: Where lockfiles live. Kept out of the repo so worktrees share one namespace —
+#: two clones of rebalance-OS running the same job must still collide.
+LOCK_DIR = Path(
+    os.environ.get("JOB_GUARD_LOCK_DIR", Path.home() / ".cache" / "rebalance-os" / "locks")
+)
+
+#: Fraction of physical RAM a single guarded job may hold before it is aborted.
+DEFAULT_MAX_RSS_FRACTION = 0.35
+
+#: Abort if system-available memory falls below this fraction of physical RAM,
+#: regardless of how well-behaved *this* job is. This is the defence against
+#: stacked runs: the newcomer notices the machine is already starved and bails.
+DEFAULT_MIN_AVAILABLE_FRACTION = 0.12
+
+#: Never let the available-memory floor drop below this absolute value.
+MIN_AVAILABLE_FLOOR = 4 * GIB
+
+DEFAULT_POLL_SECONDS = 5.0
+DEFAULT_GRACE_SECONDS = 20.0
+
+
+class GuardError(RuntimeError):
+    """Base class for guard failures."""
+
+
+class InstanceConflict(GuardError):
+    """Another instance of this job already holds the lock."""
+
+
+class MemoryCeilingExceeded(GuardError):
+    """The job tripped the RSS ceiling or the system-available floor."""
+
+
+# --------------------------------------------------------------------------- #
+# Memory probing
+# --------------------------------------------------------------------------- #
+
+def _sysctl(name: str) -> str | None:
+    try:
+        out = subprocess.run(
+            ["sysctl", "-n", name], capture_output=True, text=True, timeout=5
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return out.stdout.strip() if out.returncode == 0 else None
+
+
+def total_memory_bytes() -> int:
+    """Physical RAM. Returns 0 when it cannot be determined."""
+    if sys.platform == "darwin":
+        raw = _sysctl("hw.memsize")
+        return int(raw) if raw and raw.isdigit() else 0
+
+    meminfo = Path("/proc/meminfo")
+    if meminfo.exists():
+        for line in meminfo.read_text().splitlines():
+            if line.startswith("MemTotal:"):
+                return int(line.split()[1]) * 1024
+    return 0
+
+
+def available_memory_bytes() -> int:
+    """Memory the OS could hand out without swapping. 0 when undeterminable.
+
+    On macOS this is free + inactive + speculative pages. Inactive pages are
+    reclaimable, so counting only ``free`` would report starvation on a healthy
+    machine and abort every job. Purgeable/compressed pages are excluded because
+    by the time they dominate, the compressor is already the problem.
+    """
+    if sys.platform == "darwin":
+        try:
+            out = subprocess.run(
+                ["vm_stat"], capture_output=True, text=True, timeout=5
+            )
+        except (OSError, subprocess.SubprocessError):
+            return 0
+        if out.returncode != 0:
+            return 0
+
+        page_size = 4096
+        header = re.search(r"page size of (\d+) bytes", out.stdout)
+        if header:
+            page_size = int(header.group(1))
+
+        pages = 0
+        wanted = ("Pages free:", "Pages inactive:", "Pages speculative:")
+        for line in out.stdout.splitlines():
+            for key in wanted:
+                if line.startswith(key):
+                    pages += int(line.split(":")[1].strip().rstrip("."))
+        return pages * page_size
+
+    meminfo = Path("/proc/meminfo")
+    if meminfo.exists():
+        for line in meminfo.read_text().splitlines():
+            if line.startswith("MemAvailable:"):
+                return int(line.split()[1]) * 1024
+    return 0
+
+
+def tree_rss_bytes(pid: int) -> int:
+    """Resident memory of ``pid`` plus every descendant, in bytes.
+
+    Uses ``ps`` rather than /proc so one implementation covers macOS and Linux.
+    A worker pool's memory lives in its children, so summing the tree is the
+    only measurement that would have caught the GH-172 blowup.
+    """
+    try:
+        out = subprocess.run(
+            ["ps", "-eo", "pid=,ppid=,rss="], capture_output=True, text=True, timeout=10
+        )
+    except (OSError, subprocess.SubprocessError):
+        return 0
+    if out.returncode != 0:
+        return 0
+
+    children: dict[int, list[int]] = {}
+    rss: dict[int, int] = {}
+    for line in out.stdout.splitlines():
+        parts = line.split()
+        if len(parts) != 3:
+            continue
+        try:
+            this_pid, ppid, kb = (int(p) for p in parts)
+        except ValueError:
+            continue
+        rss[this_pid] = kb * 1024
+        children.setdefault(ppid, []).append(this_pid)
+
+    total = 0
+    stack = [pid]
+    seen: set[int] = set()
+    while stack:
+        current = stack.pop()
+        if current in seen:
+            continue
+        seen.add(current)
+        total += rss.get(current, 0)
+        stack.extend(children.get(current, ()))
+    return total
+
+
+def _fmt_gb(value: int) -> str:
+    return f"{value / GIB:.1f} GB"
+
+
+# --------------------------------------------------------------------------- #
+# Single-instance lock
+# --------------------------------------------------------------------------- #
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except OSError as exc:
+        return exc.errno == errno.EPERM
+    return True
+
+
+class SingleInstanceLock:
+    """Advisory whole-file ``flock`` keyed by job name.
+
+    ``flock`` is released by the kernel when the holder dies, so a killed job
+    never leaves a lock that blocks the next run — the failure mode a bare PID
+    file has. The PID written into the file is advisory, for diagnostics and for
+    ``on_conflict="replace"``.
+    """
+
+    def __init__(self, name: str, lock_dir: Path | None = None) -> None:
+        safe = re.sub(r"[^A-Za-z0-9._-]", "_", name).strip("_") or "job"
+        self.name = name
+        self.path = (lock_dir or LOCK_DIR) / f"{safe}.lock"
+        self._fh = None
+
+    def holder_pid(self) -> int | None:
+        """PID recorded in the lockfile, if it names a live process."""
+        try:
+            raw = self.path.read_text().strip()
+        except OSError:
+            return None
+        if not raw.isdigit():
+            return None
+        pid = int(raw)
+        return pid if _pid_alive(pid) else None
+
+    def acquire(self, on_conflict: str = "refuse", replace_grace: float = 15.0) -> None:
+        """Take the lock, or raise :class:`InstanceConflict`.
+
+        on_conflict="refuse"  — raise, leaving the incumbent untouched (default;
+                                the safe choice for anything that writes).
+        on_conflict="replace" — SIGTERM the incumbent, wait ``replace_grace``
+                                seconds, SIGKILL it, then take the lock. This is
+                                the "re-running the embeddings" ergonomic the
+                                operator expected and did not get.
+        """
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._fh = open(self.path, "a+")
+
+        if self._try_flock():
+            self._write_pid()
+            return
+
+        if on_conflict == "replace":
+            self._evict(replace_grace)
+            if self._try_flock():
+                self._write_pid()
+                return
+
+        pid = self.holder_pid()
+        self.release()
+        raise InstanceConflict(
+            f"job {self.name!r} is already running"
+            + (f" (pid {pid})" if pid else "")
+            + f"; lock: {self.path}"
+        )
+
+    def _try_flock(self) -> bool:
+        try:
+            fcntl.flock(self._fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            return False
+        return True
+
+    def _write_pid(self) -> None:
+        self._fh.seek(0)
+        self._fh.truncate()
+        self._fh.write(str(os.getpid()))
+        self._fh.flush()
+
+    def _evict(self, grace: float) -> None:
+        pid = self.holder_pid()
+        if pid is None or pid == os.getpid():
+            return
+        _terminate(pid, grace)
+
+    def release(self) -> None:
+        if self._fh is None:
+            return
+        try:
+            fcntl.flock(self._fh.fileno(), fcntl.LOCK_UN)
+        except OSError:
+            pass
+        try:
+            self._fh.close()
+        finally:
+            self._fh = None
+
+    def __enter__(self) -> "SingleInstanceLock":
+        self.acquire()
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.release()
+
+
+def _terminate(pid: int, grace: float) -> None:
+    """SIGTERM a process, escalating to SIGKILL after ``grace`` seconds."""
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except OSError:
+        return
+
+    deadline = time.monotonic() + grace
+    while time.monotonic() < deadline:
+        if not _pid_alive(pid):
+            return
+        time.sleep(0.25)
+
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except OSError:
+        pass
+
+
+# --------------------------------------------------------------------------- #
+# Memory ceiling
+# --------------------------------------------------------------------------- #
+
+class MemoryCeiling:
+    """Background watchdog that aborts a process tree before the machine dies.
+
+    Two independent trip conditions, because they catch different failures:
+
+      * RSS ceiling — this job leaked or accumulated (GH-172 defects 2 and 3,
+        the ``out = [None] * len(texts)`` accumulation).
+      * Available-memory floor — the *machine* is starved, whoever is at fault
+        (GH-172 defect 1, stacked concurrent runs).
+    """
+
+    def __init__(
+        self,
+        pid: int | None = None,
+        max_rss_bytes: int | None = None,
+        min_available_bytes: int | None = None,
+        poll_seconds: float = DEFAULT_POLL_SECONDS,
+        on_trip=None,
+        log=None,
+    ) -> None:
+        total = total_memory_bytes()
+        self.pid = pid or os.getpid()
+        self.total = total
+        self.max_rss = max_rss_bytes or int(total * DEFAULT_MAX_RSS_FRACTION) or None
+        self.min_available = min_available_bytes or max(
+            int(total * DEFAULT_MIN_AVAILABLE_FRACTION), MIN_AVAILABLE_FLOOR if total else 0
+        ) or None
+        self.poll_seconds = poll_seconds
+        self.on_trip = on_trip
+        self.log = log or (lambda msg: print(f"[job-guard] {msg}", file=sys.stderr))
+        self.tripped_reason: str | None = None
+        self.peak_rss = 0
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def preflight(self) -> None:
+        """Refuse to even start when the machine is already starved.
+
+        Cheaper than starting a 40-minute job that will be killed at minute two,
+        and it is the check that turns a stacked run into a clean error instead
+        of a kernel panic.
+        """
+        if not self.min_available:
+            return
+        available = available_memory_bytes()
+        if available and available < self.min_available:
+            raise MemoryCeilingExceeded(
+                f"refusing to start: only {_fmt_gb(available)} available, "
+                f"floor is {_fmt_gb(self.min_available)}"
+            )
+
+    def start(self) -> None:
+        if self.total == 0:
+            self.log("could not determine physical RAM; memory ceiling disabled")
+            return
+        self._thread = threading.Thread(target=self._run, name="job-guard", daemon=True)
+        self._thread.start()
+
+    def _run(self) -> None:
+        while not self._stop.wait(self.poll_seconds):
+            reason = self._check()
+            if reason:
+                self.tripped_reason = reason
+                self.log(f"MEMORY CEILING TRIPPED: {reason}")
+                if self.on_trip:
+                    self.on_trip(reason)
+                return
+
+    def _check(self) -> str | None:
+        rss = tree_rss_bytes(self.pid)
+        self.peak_rss = max(self.peak_rss, rss)
+        if self.max_rss and rss > self.max_rss:
+            return (
+                f"process tree holds {_fmt_gb(rss)}, ceiling is {_fmt_gb(self.max_rss)}"
+            )
+
+        available = available_memory_bytes()
+        if self.min_available and available and available < self.min_available:
+            return (
+                f"system available memory {_fmt_gb(available)} fell below "
+                f"floor {_fmt_gb(self.min_available)} (this job: {_fmt_gb(rss)})"
+            )
+        return None
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=self.poll_seconds + 1)
+            self._thread = None
+
+
+# --------------------------------------------------------------------------- #
+# In-process entry point
+# --------------------------------------------------------------------------- #
+
+@contextmanager
+def guard(
+    name: str,
+    max_rss_gb: float | None = None,
+    min_available_gb: float | None = None,
+    on_conflict: str = "refuse",
+    poll_seconds: float = DEFAULT_POLL_SECONDS,
+    log=None,
+):
+    """Guard the calling process: single-instance lock + memory ceiling.
+
+    On trip the watchdog raises :class:`MemoryCeilingExceeded` in the MAIN
+    thread via ``signal.SIGTERM`` -> handler, so ``finally`` blocks still run and
+    partial work is flushed. If the main thread is wedged inside a C extension
+    and ignores it, the process is SIGKILLed after the grace period.
+    """
+    lock = SingleInstanceLock(name)
+    lock.acquire(on_conflict=on_conflict)
+
+    ceiling = MemoryCeiling(
+        max_rss_bytes=int(max_rss_gb * GIB) if max_rss_gb else None,
+        min_available_bytes=int(min_available_gb * GIB) if min_available_gb else None,
+        poll_seconds=poll_seconds,
+        log=log,
+    )
+
+    def _on_trip(reason: str) -> None:
+        os.kill(os.getpid(), signal.SIGTERM)
+        # Backstop: if SIGTERM is swallowed (native extension mid-allocation),
+        # take the process down rather than let it reach the compressor cliff.
+        time.sleep(DEFAULT_GRACE_SECONDS)
+        os.kill(os.getpid(), signal.SIGKILL)
+
+    ceiling.on_trip = _on_trip
+
+    previous = signal.getsignal(signal.SIGTERM)
+
+    def _handler(signum, frame):
+        raise MemoryCeilingExceeded(ceiling.tripped_reason or "terminated by job guard")
+
+    try:
+        ceiling.preflight()
+        signal.signal(signal.SIGTERM, _handler)
+        ceiling.start()
+        yield ceiling
+    finally:
+        ceiling.stop()
+        try:
+            signal.signal(signal.SIGTERM, previous)
+        except (ValueError, TypeError):
+            pass
+        lock.release()
+
+
+# --------------------------------------------------------------------------- #
+# Wrapper CLI
+# --------------------------------------------------------------------------- #
+
+def run_guarded(
+    name: str,
+    argv: list[str],
+    max_rss_gb: float | None = None,
+    min_available_gb: float | None = None,
+    on_conflict: str = "refuse",
+    poll_seconds: float = DEFAULT_POLL_SECONDS,
+    grace_seconds: float = DEFAULT_GRACE_SECONDS,
+) -> int:
+    """Run ``argv`` as a guarded child process. Returns the exit code."""
+    log = lambda msg: print(f"[job-guard] {msg}", file=sys.stderr)  # noqa: E731
+
+    lock = SingleInstanceLock(name)
+    try:
+        lock.acquire(on_conflict=on_conflict, replace_grace=grace_seconds)
+    except InstanceConflict as exc:
+        log(str(exc))
+        return 3
+
+    try:
+        ceiling = MemoryCeiling(
+            max_rss_bytes=int(max_rss_gb * GIB) if max_rss_gb else None,
+            min_available_bytes=int(min_available_gb * GIB) if min_available_gb else None,
+            poll_seconds=poll_seconds,
+            log=log,
+        )
+        try:
+            ceiling.preflight()
+        except MemoryCeilingExceeded as exc:
+            log(str(exc))
+            return 4
+
+        log(
+            f"starting {name!r}: rss ceiling {_fmt_gb(ceiling.max_rss or 0)}, "
+            f"available floor {_fmt_gb(ceiling.min_available or 0)}"
+        )
+
+        # Own process group, so the whole tree dies together — a pool's workers
+        # outliving their parent is how 90 GB stayed resident in GH-172.
+        child = subprocess.Popen(argv, start_new_session=True)
+        ceiling.pid = child.pid
+        ceiling.on_trip = lambda reason: _kill_group(child.pid, grace_seconds, log)
+        ceiling.start()
+
+        try:
+            code = child.wait()
+        except KeyboardInterrupt:
+            _kill_group(child.pid, grace_seconds, log)
+            return 130
+        finally:
+            ceiling.stop()
+
+        log(f"{name!r} finished with exit {code}; peak tree RSS {_fmt_gb(ceiling.peak_rss)}")
+        return 4 if ceiling.tripped_reason else code
+    finally:
+        lock.release()
+
+
+def _kill_group(pid: int, grace: float, log) -> None:
+    log(f"terminating process group {pid}")
+    try:
+        os.killpg(os.getpgid(pid), signal.SIGTERM)
+    except OSError:
+        return
+
+    deadline = time.monotonic() + grace
+    while time.monotonic() < deadline:
+        if not _pid_alive(pid):
+            return
+        time.sleep(0.25)
+
+    log(f"process group {pid} ignored SIGTERM; sending SIGKILL")
+    try:
+        os.killpg(os.getpgid(pid), signal.SIGKILL)
+    except OSError:
+        pass
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="job_guard",
+        description="Run a long-running local job under a single-instance lock "
+                    "and a memory ceiling (GH-172).",
+    )
+    parser.add_argument("--name", required=True, help="lock identity; same name = same lock")
+    parser.add_argument(
+        "--max-rss-gb", type=float, default=None,
+        help=f"abort above this tree RSS "
+             f"(default: {DEFAULT_MAX_RSS_FRACTION:.0%} of RAM)".replace("%", "%%"),
+    )
+    parser.add_argument(
+        "--min-available-gb", type=float, default=None,
+        help=f"abort below this system-available memory "
+             f"(default: max({DEFAULT_MIN_AVAILABLE_FRACTION:.0%} of RAM, 4 GB))"
+             .replace("%", "%%"),
+    )
+    parser.add_argument(
+        "--on-conflict", choices=("refuse", "replace"), default="refuse",
+        help="what to do when another instance holds the lock (default: refuse)",
+    )
+    parser.add_argument("--poll-seconds", type=float, default=DEFAULT_POLL_SECONDS)
+    parser.add_argument("--grace-seconds", type=float, default=DEFAULT_GRACE_SECONDS)
+    parser.add_argument(
+        "--status", action="store_true",
+        help="report memory and lock state for --name, then exit",
+    )
+    parser.add_argument("command", nargs=argparse.REMAINDER, help="-- command to run")
+    args = parser.parse_args(argv)
+
+    if args.status:
+        total = total_memory_bytes()
+        lock = SingleInstanceLock(args.name)
+        holder = lock.holder_pid()
+        print(f"job:       {args.name}")
+        print(f"lockfile:  {lock.path}")
+        print(f"holder:    {holder if holder else 'none'}")
+        print(f"total RAM: {_fmt_gb(total)}")
+        print(f"available: {_fmt_gb(available_memory_bytes())}")
+        if holder:
+            print(f"tree RSS:  {_fmt_gb(tree_rss_bytes(holder))}")
+        return 0
+
+    command = args.command
+    if command and command[0] == "--":
+        command = command[1:]
+    if not command:
+        parser.error("no command given; pass it after --")
+
+    return run_guarded(
+        args.name,
+        command,
+        max_rss_gb=args.max_rss_gb,
+        min_available_gb=args.min_available_gb,
+        on_conflict=args.on_conflict,
+        poll_seconds=args.poll_seconds,
+        grace_seconds=args.grace_seconds,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/utils/job_guard.py
+++ b/utils/job_guard.py
@@ -37,6 +37,7 @@ Exit codes in wrapper mode:
     0    child exited 0
     3    another instance holds the lock (``--on-conflict refuse``)
     4    memory ceiling tripped; the job was terminated
+    143  evicted by a later ``--on-conflict replace`` run (child tree reaped)
     else the child's own exit status
 
 NOT installed into any job by this change — see GH-172. Landing it on the ingest
@@ -49,6 +50,7 @@ from __future__ import annotations
 import argparse
 import errno
 import fcntl
+import json
 import os
 import re
 import signal
@@ -92,6 +94,14 @@ class InstanceConflict(GuardError):
 
 class MemoryCeilingExceeded(GuardError):
     """The job tripped the RSS ceiling or the system-available floor."""
+
+
+class _Evicted(BaseException):
+    """Raised in the wrapper's main thread when a replacing run SIGTERMs it.
+
+    BaseException, not Exception: it must not be swallowed by a broad
+    ``except Exception`` between the handler and the teardown.
+    """
 
 
 # --------------------------------------------------------------------------- #
@@ -234,15 +244,25 @@ class SingleInstanceLock:
         self.path = (lock_dir or LOCK_DIR) / f"{safe}.lock"
         self._fh = None
 
-    def holder_pid(self) -> int | None:
-        """PID recorded in the lockfile, if it names a live process."""
+    def _read_state(self) -> dict:
+        """Lockfile contents as a dict. Tolerates a bare-PID legacy file."""
         try:
             raw = self.path.read_text().strip()
         except OSError:
+            return {}
+        if not raw:
+            return {}
+        try:
+            state = json.loads(raw)
+        except ValueError:
+            return {"pid": int(raw)} if raw.isdigit() else {}
+        return state if isinstance(state, dict) else {}
+
+    def holder_pid(self) -> int | None:
+        """PID recorded in the lockfile, if it names a live process."""
+        pid = self._read_state().get("pid")
+        if not isinstance(pid, int):
             return None
-        if not raw.isdigit():
-            return None
-        pid = int(raw)
         return pid if _pid_alive(pid) else None
 
     def acquire(self, on_conflict: str = "refuse", replace_grace: float = 15.0) -> None:
@@ -259,13 +279,12 @@ class SingleInstanceLock:
         self._fh = open(self.path, "a+")
 
         if self._try_flock():
-            self._write_pid()
+            self._write_state()
             return
 
         if on_conflict == "replace":
-            self._evict(replace_grace)
-            if self._try_flock():
-                self._write_pid()
+            if self._evict(replace_grace):
+                self._write_state()
                 return
 
         pid = self.holder_pid()
@@ -283,17 +302,62 @@ class SingleInstanceLock:
             return False
         return True
 
-    def _write_pid(self) -> None:
+    def _write_state(self, **extra) -> None:
         self._fh.seek(0)
         self._fh.truncate()
-        self._fh.write(str(os.getpid()))
+        self._fh.write(json.dumps({"pid": os.getpid(), **extra}))
         self._fh.flush()
 
-    def _evict(self, grace: float) -> None:
-        pid = self.holder_pid()
-        if pid is None or pid == os.getpid():
+    def record_child_group(self, pgid: int) -> None:
+        """Record the guarded child's process group in the lockfile.
+
+        Load-bearing for ``--on-conflict replace``: the child runs in its OWN
+        session, so it is unreachable via the wrapper's process group. Without
+        this, an evictor that has to SIGKILL an unresponsive wrapper leaves the
+        grandchildren resident — the exact stacking GH-172 is about.
+        """
+        if self._fh is None:
             return
-        _terminate(pid, grace)
+        self._write_state(child_pgid=pgid)
+
+    def _evict(self, grace: float) -> bool:
+        """Displace the incumbent and take the lock. True if we now hold it.
+
+        Success is measured by ACQUIRING THE FLOCK, not by the incumbent's PID
+        disappearing. PID liveness is the wrong signal: ``kill(pid, 0)`` succeeds
+        against a zombie, so a reaped-but-unwaited incumbent reads as alive
+        forever, and a bare "SIGKILL then retry once" races the kernel's lock
+        release. The flock is the only ground truth about who owns the job.
+        """
+        state = self._read_state()
+        pid = state.get("pid")
+        child_pgid = state.get("child_pgid")
+        if not isinstance(pid, int) or pid == os.getpid():
+            return self._try_flock()
+
+        def _signal_all(sig: int) -> None:
+            try:
+                os.kill(pid, sig)
+            except OSError:
+                pass
+            # The incumbent's child runs in its OWN session, so it is not
+            # reachable via the wrapper's group. A cooperative wrapper reaps it
+            # on SIGTERM; a SIGKILLed one never gets the chance. Signal it
+            # directly so eviction is total either way.
+            if isinstance(child_pgid, int) and child_pgid > 0:
+                try:
+                    os.killpg(child_pgid, sig)
+                except OSError:
+                    pass
+
+        for sig in (signal.SIGTERM, signal.SIGKILL):
+            _signal_all(sig)
+            deadline = time.monotonic() + (grace if sig == signal.SIGTERM else 5.0)
+            while time.monotonic() < deadline:
+                if self._try_flock():
+                    return True
+                time.sleep(0.1)
+        return self._try_flock()
 
     def release(self) -> None:
         if self._fh is None:
@@ -315,21 +379,29 @@ class SingleInstanceLock:
         self.release()
 
 
-def _terminate(pid: int, grace: float) -> None:
-    """SIGTERM a process, escalating to SIGKILL after ``grace`` seconds."""
+def _group_alive(pgid: int) -> bool:
     try:
-        os.kill(pid, signal.SIGTERM)
+        os.killpg(pgid, 0)
+    except OSError as exc:
+        return exc.errno == errno.EPERM
+    return True
+
+
+def _terminate_group(pgid: int, grace: float) -> None:
+    """SIGTERM a process GROUP, escalating to SIGKILL after ``grace`` seconds."""
+    try:
+        os.killpg(pgid, signal.SIGTERM)
     except OSError:
         return
 
     deadline = time.monotonic() + grace
     while time.monotonic() < deadline:
-        if not _pid_alive(pid):
+        if not _group_alive(pgid):
             return
         time.sleep(0.25)
 
     try:
-        os.kill(pid, signal.SIGKILL)
+        os.killpg(pgid, signal.SIGKILL)
     except OSError:
         pass
 
@@ -531,17 +603,34 @@ def run_guarded(
         # Own process group, so the whole tree dies together — a pool's workers
         # outliving their parent is how 90 GB stayed resident in GH-172.
         child = subprocess.Popen(argv, start_new_session=True)
+        lock.record_child_group(child.pid)  # new session => pgid == pid
         ceiling.pid = child.pid
-        ceiling.on_trip = lambda reason: _kill_group(child.pid, grace_seconds, log)
+        ceiling.on_trip = lambda reason: _reap_child_tree(child, grace_seconds, log)
         ceiling.start()
+
+        # A replacing run SIGTERMs THIS wrapper. Without a handler the wrapper
+        # dies instantly and the child — in its own session — is orphaned, so
+        # "replace" would stack processes instead of replacing them.
+        def _on_term(signum, frame):
+            raise _Evicted()
+
+        previous_term = signal.signal(signal.SIGTERM, _on_term)
 
         try:
             code = child.wait()
+        except _Evicted:
+            log("evicted by a replacing run; tearing down child tree")
+            _reap_child_tree(child, grace_seconds, log)
+            return 143
         except KeyboardInterrupt:
-            _kill_group(child.pid, grace_seconds, log)
+            _reap_child_tree(child, grace_seconds, log)
             return 130
         finally:
             ceiling.stop()
+            try:
+                signal.signal(signal.SIGTERM, previous_term)
+            except (ValueError, TypeError):
+                pass
 
         log(f"{name!r} finished with exit {code}; peak tree RSS {_fmt_gb(ceiling.peak_rss)}")
         return 4 if ceiling.tripped_reason else code
@@ -549,24 +638,43 @@ def run_guarded(
         lock.release()
 
 
-def _kill_group(pid: int, grace: float, log) -> None:
-    log(f"terminating process group {pid}")
-    try:
-        os.killpg(os.getpgid(pid), signal.SIGTERM)
-    except OSError:
-        return
+def _reap_child_tree(child: subprocess.Popen, grace: float, log) -> None:
+    """Terminate the guarded child's process group and REAP the child.
 
-    deadline = time.monotonic() + grace
-    while time.monotonic() < deadline:
-        if not _pid_alive(pid):
-            return
-        time.sleep(0.25)
-
-    log(f"process group {pid} ignored SIGTERM; sending SIGKILL")
+    The parent must ``waitpid`` rather than poll ``killpg(pgid, 0)``: a zombie
+    still answers signal 0, so polling alone would block for the entire grace
+    period on a child that has already exited.
+    """
     try:
-        os.killpg(os.getpgid(pid), signal.SIGKILL)
+        pgid = os.getpgid(child.pid)
     except OSError:
-        pass
+        pgid = None
+
+    log(f"terminating child tree {child.pid}")
+    if pgid is not None:
+        try:
+            os.killpg(pgid, signal.SIGTERM)
+        except OSError:
+            pass
+
+    try:
+        child.wait(timeout=grace)
+    except subprocess.TimeoutExpired:
+        log(f"child {child.pid} ignored SIGTERM; sending SIGKILL")
+        if pgid is not None:
+            try:
+                os.killpg(pgid, signal.SIGKILL)
+            except OSError:
+                pass
+        try:
+            child.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            log(f"child {child.pid} survived SIGKILL")
+
+    # Sweep grandchildren that outlived the direct child (the reaped child no
+    # longer confuses the liveness probe, so this poll is now meaningful).
+    if pgid is not None and _group_alive(pgid):
+        _terminate_group(pgid, min(grace, 5.0))
 
 
 def main(argv: list[str] | None = None) -> int:


### PR DESCRIPTION
Adds `utils/job_guard.py` — a standalone, reusable single-instance + memory-ceiling guard for
long-running local jobs. Addresses the primary defect in #172.

**Not wired into anything.** This lands the primitive only. Installing it on the embedding stacks is
deliberately deferred, because #172's open question — *which* stack actually held the 45 GB — is
still unresolved, and guards landed on the wrong stack are worse than no guards.

## What it provides

Two of the fixes #172 calls for, as a job-agnostic utility rather than a patch to either stack:

- **`SingleInstanceLock`** — advisory `flock` keyed by job name, in a shared `~/.cache` namespace so
  two worktrees/clones of the same repo still collide. `refuse` (default) or `replace`.
- **`MemoryCeiling`** — watchdog thread with two independent trip conditions: a tree-RSS ceiling
  (catches the `out = [None] * len(texts)` accumulation, defects 2/3) and a system-available floor
  (catches stacked runs regardless of fault, defect 1), plus a preflight that refuses to start on an
  already-starved machine.

Entry points: `guard()` in-process context manager, and a wrapper CLI that guards a whole child
process tree:

```bash
python3 utils/job_guard.py --name ask-self-ingest --max-rss-gb 24 -- python3 ask_self/ask_self_ingest.py
```

Stdlib-only by design — no psutil, since it must run under system python3, launchd, and the
rebalance venv with no install step.

## Review

QA'd via an automated `/relay-xyz` loop with **agy** as reviewer over two rounds
(`relay-system/2026-07-19/gh172-job-guard-qa.md`). Round 1: **Changes requested**, one Blocker.
Round 2: **Approved**.

agy's Blocker was real, and fixing it exposed two more defects. All three were confirmed by
reproduction, not accepted on argument:

1. **Orphaned tree on replace** (agy) — `_evict()` SIGTERMed only the wrapper; its own-session child
   survived. Reproduced: marker child still alive after replace. This reproduced the exact process
   stacking the guard exists to prevent.
2. **Zombie-blind liveness probe** — `killpg(pgid, 0)` succeeds against a zombie, so teardown polled
   an already-reaped child for the entire grace window. Traced live: wrapper held the flock at
   `ps_stat='SN'` for 10s+ after SIGTERM.
3. **Evictor raced the kernel's lock release** — SIGKILL followed by a single `flock` retry meant
   replace *killed the incumbent and then refused its own lock*. Replace was broken both ways.

Unifying fix: **eviction success is measured by acquiring the flock, not by the PID disappearing.**
PID liveness was the wrong ground truth throughout.

Also fixed pre-review: argparse %-formats help strings, so a literal `%` from a `:.0%` f-string
crashed at import.

## Test evidence

Run un-sandboxed on the affected machine (M1 Max, 68.7 GB). 7/7:

| Test | Result |
|---|---|
| replace: evicts, acquires, no orphan | PASS — lock in 0.168s, child gone |
| refuse while held | PASS — exit 3 |
| RSS ceiling vs 200MB/0.5s allocator | PASS — exit 4, hog killed, never completed |
| in-process `guard()` raises in main thread | PASS |
| child exit-code passthrough | PASS — exit 7 |
| SIGKILLed holder does not block next run | PASS — flock auto-release |
| `--status` | PASS — 64.0 GiB; honest 0.0 when sysctl is sandbox-blocked |

## Known limits

- A grandchild that re-parents to init and leaves its process group is unreachable; agy's read is
  that `killpg` is the correct ceiling on macOS absent cgroups.
- Defaults (35% of RAM RSS ceiling; max(12%, 4 GB) available floor) are argued in the relay thread
  but not empirically tuned against a real embedding run.

Refs #172
