### PR TITLE
chore(ask-self): remove dead qwen-local path, correct README embedding docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,8 +513,9 @@ The query wrapper pins `--db-path` to the committed portable DB, so it works on 
 Notes:
 - The wrapper now defaults to `--mode all` if you omit `--mode`, but keeping it explicit in maintainer docs is still clearer.
 - `--no-architecture-md` is intentional: the curated [ARCHITECTURE.md](ARCHITECTURE.md) is hand-edited and should not be regenerated.
-- For this repo's `qwen-local` harness, the wrapper now auto-applies the stable macOS settings: `TOKENIZERS_PARALLELISM=false`, `ASK_SELF_QWEN_BATCH_SIZE=8`, `ASK_SELF_QWEN_MAX_TOKENS=2048`, and `--concurrency 1` when you do not pass one explicitly.
-- Embedding is local (`qwen-local` with Qwen3-Embedding-0.6B via `sentence-transformers`) — no Gemini API key needed for ingest or query. Install `sentence-transformers` in the external ask-self venv if you are refreshing from a new machine.
+- Embedding is **Gemini** (`gemini-embedding-001`, dim 768), set in [ask_self/ask_self_harness.json](ask_self/ask_self_harness.json) since commit `4ef8c39`. `GOOGLE_API_KEY` is required for **both** ingest and query — query-time embedding needs it too, not just synthesis.
+- The wrapper no longer auto-applies `qwen-local` tuning (`TOKENIZERS_PARALLELISM`, `ASK_SELF_QWEN_BATCH_SIZE`, `ASK_SELF_QWEN_MAX_TOKENS`, `--concurrency 1`); that path was dead under the Gemini harness and was removed. If you switch the harness back to a local Qwen provider, set those explicitly — the defaults are not memory-safe on this machine (see #172).
+- Switching provider changes the embedding dimension, which forces a **full index rebuild**. That is the heaviest local job in the repo; do not flip it casually.
 - PR ingestion now fails loudly if neither `GITHUB_TOKEN` / `SLEUTH_RAG_GITHUB_PAT` nor a healthy `gh auth login` is available. Pass `--no-prs` only if you intentionally want a files-only refresh.
 - Synthesis (the answer step) still defaults to Gemini unless you pass `--retrieval-only` or configure a local synthesis provider in [ask_self/ask_self_harness.json](ask_self/ask_self_harness.json).
 

--- a/scripts/ask-self-ingest.sh
+++ b/scripts/ask-self-ingest.sh
@@ -88,22 +88,6 @@ if ! has_flag "--mode" "$@"; then
     DEFAULT_ARGS+=(--mode all)
 fi
 
-EMBED_PROVIDER="$(read_harness_json "((data.get('embedding') or {}).get('provider'))")"
-case "$EMBED_PROVIDER" in
-    qwen-local|qwen-mlx)
-        # ask-self disables local Qwen providers by default (gemini-first upstream);
-        # re-enable for this portable local-Qwen repo so no Gemini key is needed.
-        export ASK_SELF_ENABLE_QWEN="${ASK_SELF_ENABLE_QWEN:-1}"
-        export TOKENIZERS_PARALLELISM="${TOKENIZERS_PARALLELISM:-false}"
-        export ASK_SELF_QWEN_BATCH_SIZE="${ASK_SELF_QWEN_BATCH_SIZE:-8}"
-        export ASK_SELF_QWEN_MAX_TOKENS="${ASK_SELF_QWEN_MAX_TOKENS:-2048}"
-        ;;
-esac
-# qwen-local rides the PyTorch/MPS path and needs serial embedding; qwen-mlx does not.
-if [ "$EMBED_PROVIDER" = "qwen-local" ] && ! has_flag "--concurrency" "$@"; then
-    DEFAULT_ARGS+=(--concurrency 1)
-fi
-
 GITHUB_OWNER="$(read_harness_json "((data.get('github') or {}).get('owner'))")"
 GITHUB_REPO="$(read_harness_json "((data.get('github') or {}).get('repo'))")"
 


### PR DESCRIPTION
Removes dead code and corrects embedding documentation that has been wrong since June.

## What changed

**`scripts/ask-self-ingest.sh`** — removed the `qwen-local|qwen-mlx` case block (−16 lines). Unreachable since `4ef8c39` switched the codebase index to Gemini (`gemini-embedding-001`, dim 768). `EMBED_PROVIDER` was referenced nowhere else in the repo.

**`README.md`** — line 517 was **already wrong independently of this change**. It claimed:

> Embedding is local (`qwen-local` with Qwen3-Embedding-0.6B via `sentence-transformers`) — no Gemini API key needed for ingest or query.

`GOOGLE_API_KEY` has been required for **both** ingest and query since `4ef8c39` — query-time embedding needs it, not just synthesis. Anyone following that README on a fresh machine would have hit a wall. Now corrected, plus two additions: switching provider changes embedding dimension and forces a full index rebuild, and the removed defaults were the only memory guards on that path (refs #172).

## Scope — does NOT touch the HiQS signal path

This is confined to the **ask_self codebase index** (Gemini). The **HiQS signal / activity RAG** is separately and intentionally Qwen-local (`Qwen/Qwen3-Embedding-0.6B` via MLX, dim 1024, `src/rebalance/ingest/embedder.py`) and is untouched. Conflating these two systems is what sent #172's first RCA down the wrong path.

## Tradeoff being accepted

Removing the block also removes the auto-applied `ASK_SELF_QWEN_BATCH_SIZE=8`, `ASK_SELF_QWEN_MAX_TOKENS=2048`, `TOKENIZERS_PARALLELISM=false`, and `--concurrency 1`. These are dead under Gemini, but would become **live memory guards** if the harness is ever flipped back to a local Qwen provider. The README now says so explicitly and points at #172. If ask_self returns to Qwen, set them explicitly or route through `utils/job_guard.py`.

## Verification

- `bash -n scripts/ask-self-ingest.sh` — passes
- `grep -c "EMBED_PROVIDER\|QWEN"` — 0 matches remaining
- `rebalance doctor` — passes (one unrelated pre-existing warning: figma refresh 39d stale)
- Full suite in a clean worktree vs `origin/development` baseline — see comment below

CI does not run on `development` (#177), so test status was established locally against a matched baseline.

## Known remaining drift

`MEMORY.md:56` still describes the ask_self index as `qwen-local` at 1024 dims. Same class of error, deliberately left out of this PR pending a scope decision. Not fixed here.
