### PR TITLE
GH-219 Lane 4: switch the job guard from RSS to phys_footprint (+ compressor backstop)

### DIFF
--- a/PROJECT/2-WORKING/GH-219-REBALANCE-MEMORY.md
+++ b/PROJECT/2-WORKING/GH-219-REBALANCE-MEMORY.md
@@ -1,36 +1,19 @@
 ---
 title: "REBALANCE MEMORY — unified project (8 lanes: instrument → measure → fix → bound → backstop → inventory → cover → detect)"
 status: >
-  LANES 0, 1, 2 COMPLETE as of 2026-07-27. Lanes 3–7 remain.
+  LANES 0, 1, 2, 4 COMPLETE as of 2026-07-28. Lanes 3, 5, 6, 7 remain.
 
-  #215 is PROVEN, not inferred — the ⛔ GATE passed on live hardware, and Lane 2's fix is
-  Codex-approved and verified against the harness that produced the blowup: phys_footprint
-  13.00 -> 1.36 GB, 80/80 batches completed vs 18 before. Full suite 1585 passed / 6 failed
-  (the same 6 pre-existing failures throughout; no regressions from any lane).
+  #215 is PROVEN and FIXED: phys_footprint 13.00 -> 1.36 GB on the harness that produced the
+  blowup, 80/80 batches vs 18. The guard that missed it is repaired too — it now measures
+  phys_footprint (25x more visible than RSS on Metal allocations), plus a compressor-pressure
+  backstop sized from 1602 recorded samples. Lanes 2 and 4 are both Codex-approved.
+  Full suite 1600 passed / 6 failed (the same 6 pre-existing throughout).
 
-  Remaining outside the lanes: the sampler's inactive_gb/speculative_gb columns, deferred out
-  of the marathon because temp/ is gitignored and a worktree edit there cannot be committed.
-created: 2026-07-27
-updated: 2026-07-27
-owner: noel@neochro.me
-branch: marathon/2026-07-27-mlx-memory
-issue: https://github.com/Hypercart-Dev-Tools/rebalance-OS/issues/219
-roadmap_exempt: true
-goal: >
-  End the recurring whole-machine memory starvation on the Mac Studio (three events: 07-25,
-  07-26, 07-27) by fixing the allocation that causes it, bounding the damage when that fix is
-  wrong, and repairing the two instruments that failed to see it.
+  Outstanding: the sampler's inactive_gb/speculative_gb columns. THREE separate questions have
+  now dead-ended on that missing data (the availability floor's soundness, replaying 07-27, and
+  Lane 7's thresholds). It is a small direct edit, blocked only by temp/ being gitignored —
+  a decision to revisit, not a technical obstacle. Recommend it jumps ahead of Lane 5.
 
-  Root cause, identified 2026-07-27: the embedding backend is MLX, not torch. MLX allocates
-  Metal buffers charged to `phys_footprint` as `iokit` and never counted in RSS, caches freed
-  buffers with an effectively unbounded default limit, and the repo performs no MLX cache
-  management anywhere. A single `rebalance-embed` process reaches ~46.9 GB footprint while
-  reporting ~0.08 GB RSS.
-
-  This file exists because the five issues are NOT independent: #216 produces the measurement
-  that validates #215, #217 must be sized from #216's numbers, #213's ceiling only means the
-  right thing once footprint semantics are settled, and #218 repairs the health instrument the
-  marathon itself uses as a gate. Firing them in issue-number order would be actively wrong.
 ---
 
 # REBALANCE MEMORY — unified project (2026-07-27)
@@ -499,14 +482,62 @@ during that failure; the next run starts.
 
 **Goal:** repair the external net. Demoted from "the fix" to "the backstop" by #215.
 
-- [ ] Switch the ceiling metric from tree RSS to `phys_footprint`
-- [ ] **Re-size the ceiling** knowing footprint legitimately includes Metal — the current
+- [x] Switch the ceiling metric from tree RSS to `phys_footprint`
+- [x] **Re-size the ceiling** (0.35 RSS -> 0.125 footprint = 8 GB, the per-process contract) knowing footprint legitimately includes Metal — the current
       35%-of-RAM value is not transferable unexamined
-- [ ] Settle whether the available-memory floor is sound, using Lane 1's new
+- [x] Settle whether the available-memory floor is sound — CONCLUDED via compressor signal, using Lane 1's new
       `inactive_gb`/`speculative_gb` columns
 
 **Gate:** a synthetic over-ceiling job trips and is killed; guarded jobs on a healthy machine do
 not trip.
+
+### ✅ LANDED 2026-07-28 — phase `gh219-lane4-footprint-guard`, **Codex-approved (round 4)**
+
+**The blindness, measured.** On real MLX Metal allocations the new metric sees what the old one
+could not:
+
+| | Delta |
+|---|---|
+| `phys_footprint` (new) | **+0.327 GB** |
+| `ps` RSS (old) | +0.013 GB |
+
+**25×.** That gap is why the RSS guard ran 233 jobs on 07-27 and tripped zero times while the
+machine fell to 0.09 GB free.
+
+**Three independent trip conditions now**, each catching what the others cannot: the
+`phys_footprint` ceiling (this job leaking), the available-memory floor (the machine starved by
+anyone), and **compressor pressure** (the machine already paying CPU to avoid swapping).
+
+**The availability question is CONCLUDED, not deferred.** Reclaimable-pages accounting is retained
+— free-only was tried and reverted after it refused *every* job on a healthy machine (free 1.59 GB
+but ~24 GB genuinely reclaimable, against a 7.68 GB floor). The gap it leaves is covered by a
+direct compressor check rather than by tightening a number that **cannot be validated**:
+`inactive_gb`/`speculative_gb` were never recorded, so no variant of that metric can be replayed
+against 07-27.
+
+Compressor threshold sized from 1602 recorded samples. The distribution is **bimodal** — median
+0.65–0.96 GB healthy vs 25–35 GB at crisis, with the fraction above 8 GB and above 24 GB nearly
+identical (22.2%/21.6% on 07-26; 16.7%/14.8% on 07-27). Almost nothing lands between the modes, so
+threshold robustness is a property of the data rather than a lucky constant. Set at 25% of RAM,
+env-overridable.
+
+**Cost, recorded honestly: estimated 3 h, took far longer** — four review rounds, two failed
+marathon fires (exit 6 containment, then a stall), one regression I introduced, and one latent
+defect that regression exposed. Lanes 5–7 estimates should be revised upward rather than repeating
+this. Codex found something substantive on **all four** passes; three of its findings were
+requirements the brief stated but never verified.
+
+**The recurring defect class in this lane and Lane 2 — tests that pass without proving anything:**
+
+- `assert code == 4` — satisfied by the preflight refusing, without the child ever launching
+- counting `clear_cache()` calls against a mock whose cache never grew
+- a file-wide substring match standing in for per-call-site coverage
+- asserting a parser returns 42.0 as proof that the setting *applies*
+- and the inverse: `available_memory_bytes` had **zero** real coverage because every test pinned
+  it healthy — which is exactly how free-only shipped
+
+All new assertions in this lane were **mutation-checked**: the source was broken deliberately, the
+test confirmed failing, then restored. Worth doing for Lanes 5–7 too.
 
 **Carried finding — not a blocker:** the guard's window is far shorter than the leak's.
 `guarded_embedding` decorates embedding *leaf* functions, so each call builds a fresh

--- a/phases/gh219-lane4-footprint-guard/ESCALATION.md
+++ b/phases/gh219-lane4-footprint-guard/ESCALATION.md
@@ -1,0 +1,7 @@
+# ESCALATION — Marathon Phase gh219-lane4-footprint-guard
+
+phase: gh219-lane4-footprint-guard
+task: MARATHON-GH219-LANE4
+relay-drive-exit: 6
+reason: containment-violation (off-lane edit reverted by a turn-taker)
+relay-file: phases/gh219-lane4-footprint-guard/RELAY.md

--- a/phases/gh219-lane4-footprint-guard/RELAY.md
+++ b/phases/gh219-lane4-footprint-guard/RELAY.md
@@ -1,0 +1,143 @@
+# Marathon Phase gh219-lane4-footprint-guard
+STATUS: Open
+NEXT: agy
+
+<!-- marathon-drive: task=MARATHON-GH219-LANE4 builder=agy reviewer=codex round-cap=7 -->
+
+## Phase Brief
+
+# Lane 4 (GH-219 marathon) — #213: switch the job guard from RSS to `phys_footprint`
+
+## Why this lane is the highest-value work remaining
+
+`utils/job_guard.py` is the external safety net for long-running jobs. On 2026-07-27 it ran
+**233 jobs and tripped zero times** while the machine fell to 0.09 GB free, 28.99 GB compressor,
+and 24.7 of 26 GB swap.
+
+It failed for a structural reason, not a tuning one. `tree_rss_bytes()` (`job_guard.py:194-233`)
+sums **RSS** from `ps -eo pid=,ppid=,rss=`. The processes that killed the machine held ~46.9 GB of
+`phys_footprint` while reporting **~0.08 GB RSS**, because MLX's Metal buffers are charged as
+`iokit` to the footprint and are **never counted in RSS**. The guard was measuring a number that
+physically cannot see this class of allocation.
+
+Lane 2 fixed the specific MLX leak. **This lane fixes the instrument**, so the *next* memory bug —
+MLX or not — gets caught by the system instead of by someone noticing Activity Monitor.
+
+## Required work
+
+### 1. Measure `phys_footprint` instead of RSS
+
+**The mechanism is already verified working on this machine** — do not go hunting. `ps` cannot
+provide footprint; `libproc`'s `proc_pid_rusage` can, via `ctypes`:
+
+```python
+libc.proc_pid_rusage(pid, 2, byref(buf))   # flavour 2 = RUSAGE_INFO_V2
+# -> buf.ri_phys_footprint  (bytes), buf.ri_resident_size (bytes)
+```
+
+`RUSAGE_INFO_V2` layout, in order: `ri_uuid[16]`, then `uint64` fields — `user_time`,
+`system_time`, `pkg_idle_wkups`, `interrupt_wkups`, `pageins`, `wired_size`, `resident_size`,
+**`phys_footprint`**, `proc_start_abstime`, `proc_exit_abstime`, `child_*`, `diskio_*`.
+
+**Confirmed behaviours you must handle:**
+
+- Returns `0` and a valid footprint for processes **we own** — the Rebalance tree, which is all
+  this guard cares about.
+- Returns **`-1` for processes we do not own** (verified against root-owned pid 1) and for pids
+  that exit mid-walk. A tree walk **must skip these**, not crash, and **must not** treat an
+  unreadable process as `0` — silently reading a runaway as zero is precisely the failure mode
+  this lane exists to remove. Count them and surface the count.
+- Keep an RSS fallback for any platform where `proc_pid_rusage` is unavailable, and make the
+  degraded mode **visible in the failure message**, not silent.
+
+### 2. Re-size the ceiling — the current value is NOT transferable
+
+`DEFAULT_MAX_RSS_FRACTION = 0.35` (`job_guard.py:82`) is 22.4 GB on this 64 GB machine. That was
+chosen for RSS semantics. Footprint legitimately includes Metal, so the number means something
+different now — and 22.4 GB is far too permissive against measured reality:
+
+| Measurement | Value |
+|---|---|
+| Model resident in MLX | 1.11 GB active |
+| Healthy embedding pass, post-Lane-2 | **1.36 GB** footprint |
+| Same workload pre-Lane-2 | 13.00 GB at batch 18, still climbing |
+| Project contract, per process | **≤ 8 GB** peak `phys_footprint` |
+| Project contract, aggregate concurrent | ≤ 16 GB |
+
+Size the default from these numbers and the 8 GB contract, and **write the derivation into a
+comment**. Rename the constant and the env var if they now say the wrong thing
+(`REBALANCE_JOB_GUARD_MAX_RSS_GB` names a metric this no longer uses) — but keep the old env var
+working as a deprecated alias so existing plists and docs do not silently stop applying.
+
+### 3. Settle the available-memory floor
+
+`available_memory_bytes()` (`:155-191`) counts **free + inactive + speculative**. Determine whether
+that is still the right definition under memory pressure — inactive and speculative pages are
+reclaimable in principle, but the 07-27 data shows the machine dying while that sum looked
+survivable. `MIN_AVAILABLE_FLOOR = 4 * GIB` (`:90`) deliberately matches the project contract's
+`free_gb >= 4.0`; keep them aligned or change both together.
+
+## Carried finding — context, not a task
+
+`guarded_embedding` decorates embedding **leaf** functions, so each call builds a fresh
+`MemoryCeiling` with `peak_rss = 0` (PID 1391 wrote three records — 10.7 s / 1.5 s / 35.6 s —
+across a 35-minute lifetime). This does **not** block the switch: footprint is absolute per-process,
+so a later leaf call reads the accumulated total rather than starting from zero. That is part of
+why this switch works. Do **not** restructure the decorator here — that is Lane 6.
+
+## Write-set (do not edit anything else)
+
+- `utils/job_guard.py`
+- `tests/test_job_guard_wiring.py` and/or a new `tests/test_job_guard_footprint.py`
+
+## Tests — required
+
+Baseline is **27 passed** across `tests/test_job_guard_wiring.py` + `tests/test_watchlist_guard.py`.
+
+1. A synthetic over-ceiling process **trips and is killed** — the central test
+2. A process at healthy footprint (~1.4 GB) does **not** trip
+3. **The 07-27 signature specifically: high footprint, near-zero RSS, must trip.** This is the
+   exact case the old guard missed; if this test does not exist, the lane has not done its job
+4. Unreadable pids (`rc = -1`) are skipped, counted, and **never** treated as 0
+5. The RSS fallback path works and announces itself when footprint is unavailable
+6. The deprecated env-var alias still applies
+
+## Acceptance
+
+- `.venv/bin/python3 -m pytest tests/test_job_guard_wiring.py tests/test_watchlist_guard.py
+  tests/test_job_guard_footprint.py -q` passes
+- The full suite has **6 known pre-existing failures** (`test_hiqs_pipeline.py` ×5,
+  `test_scheduler_liveness.py` ×1). They are not yours. Do not fix them; do not let them fail
+  your gate.
+
+## Out of scope
+
+- `src/rebalance/ingest/_job_guard.py` — a **different file** (the bridge). Not this lane.
+- Guard placement / decorator restructuring / coverage gaps — Lane 6
+- `mx.set_memory_limit()` — Lane 3
+- Anything under `temp/` — gitignored; edits cannot be committed and are destroyed with the worktree
+
+
+---
+
+▶ TAKE YOUR TURN (agy — BUILDER role)
+
+You are the BUILDER for this phase. Read the phase brief above and implement it.
+1. Implement the brief by creating/editing the artifact file(s): utils/job_guard.py,tests/test_job_guard_wiring.py,tests/test_job_guard_footprint.py
+2. Append a build block to this relay file: `### Round N · Builder · agy` summarizing what you did (files touched, key decisions).
+3. Use this exact tick binary (run it from any directory): /Users/noelsaw/Documents/rebalance-OS/.xyz/bin/tick
+   - /Users/noelsaw/Documents/rebalance-OS/.xyz/bin/tick claim MARATHON-GH219-LANE4 --agent agy --paths "phases/gh219-lane4-footprint-guard/RELAY.md,utils/job_guard.py,tests/test_job_guard_wiring.py,tests/test_job_guard_footprint.py"
+   - /Users/noelsaw/Documents/rebalance-OS/.xyz/bin/tick ping MARATHON-GH219-LANE4 --agent agy
+   - /Users/noelsaw/Documents/rebalance-OS/.xyz/bin/tick release MARATHON-GH219-LANE4 --agent agy --to codex
+4. Edit ONLY these paths: phases/gh219-lane4-footprint-guard/RELAY.md and utils/job_guard.py,tests/test_job_guard_wiring.py,tests/test_job_guard_footprint.py. Do NOT run git. Do NOT touch any other file — the harness commits for you.
+
+---
+
+▶ TAKE YOUR TURN (codex — REVIEWER role)
+
+You are the REVIEWER for this phase. Read the latest builder block above AND review the artifact file(s) on disk: utils/job_guard.py,tests/test_job_guard_wiring.py,tests/test_job_guard_footprint.py.
+1. Append a review block: `### Round N · Reviewer · codex` followed by your assessment.
+2. If changes needed: add `**Verdict:** Changes requested` then: /Users/noelsaw/Documents/rebalance-OS/.xyz/bin/tick release MARATHON-GH219-LANE4 --agent codex --to agy
+3. If satisfied: add `**Verdict:** Approved`, set `STATUS: Approved`, then: /Users/noelsaw/Documents/rebalance-OS/.xyz/bin/tick done MARATHON-GH219-LANE4 --agent codex
+4. Use this exact tick binary (run it from any directory) for all token operations: /Users/noelsaw/Documents/rebalance-OS/.xyz/bin/tick
+   Edit ONLY phases/gh219-lane4-footprint-guard/RELAY.md (your review block + STATUS). Do NOT edit the artifact yourself — request changes instead. Do NOT run git.

--- a/phases/gh219-lane4-footprint-guard/RELAY.md
+++ b/phases/gh219-lane4-footprint-guard/RELAY.md
@@ -1,5 +1,5 @@
 # Marathon Phase gh219-lane4-footprint-guard
-STATUS: Open
+STATUS: Approved
 NEXT: agy
 
 <!-- marathon-drive: task=MARATHON-GH219-LANE4 builder=agy reviewer=codex round-cap=7 -->
@@ -204,3 +204,18 @@ You are the REVIEWER for this phase. Read the latest builder block above AND rev
 3. `REBALANCE_JOB_GUARD_MAX_FOOTPRINT_GB` is not read anywhere. The old `REBALANCE_JOB_GUARD_MAX_RSS_GB` remains usable only because the bridge still passes `max_rss_gb`; add the footprint-named setting in `utils/job_guard.py` and retain the old name as its deprecated alias so the required rename is real.
 
 **Verdict:** Changes requested
+
+### Round 4 · Reviewer · codex
+
+**Assessment:** Approved.
+
+The footprint default now enforces the 8 GB per-process contract, the synthetic
+wrapper-mode child test proves the ceiling kill path and reaping, unreadable
+`proc_pid_rusage` results are deterministically skipped and surfaced, and the
+footprint-named environment override (with deprecated RSS alias) reaches the
+constructed ceiling. The available-memory decision is concluded with a
+compressor-pressure backstop and regression coverage.
+
+Focused verification passed: `python3 -m pytest tests/test_job_guard_wiring.py tests/test_watchlist_guard.py tests/test_job_guard_footprint.py -q` — 42 passed.
+
+**Verdict:** Approved

--- a/phases/gh219-lane4-footprint-guard/RELAY.md
+++ b/phases/gh219-lane4-footprint-guard/RELAY.md
@@ -117,6 +117,19 @@ Baseline is **27 passed** across `tests/test_job_guard_wiring.py` + `tests/test_
 - `mx.set_memory_limit()` — Lane 3
 - Anything under `temp/` — gitignored; edits cannot be committed and are destroyed with the worktree
 
+### Round 1 · Builder · agy
+
+**Files Touched:**
+- `utils/job_guard.py`
+- `tests/test_job_guard_wiring.py`
+- `tests/test_job_guard_footprint.py` (new)
+
+**Key Decisions:**
+1. **Measurement**: Implemented `tree_footprint_bytes` using `ctypes` on macOS with `proc_pid_rusage(..., 2, ...)`. It correctly returns footprint, fallback flag, and unreadable count. RSS is used as fallback (e.g. Linux). 
+2. **Re-sized ceiling**: Renamed `DEFAULT_MAX_RSS_FRACTION` to `DEFAULT_MAX_FOOTPRINT_FRACTION` and set it to `0.25` (25% of 64 GB = 16 GB), aligning with the aggregate concurrent project contract.
+3. **Available memory floor**: Updated `available_memory_bytes()` to *only* sum `Pages free:` and skip `inactive` and `speculative` pages, ensuring true pressure is captured.
+4. **Compatibility**: Left `--max-rss-gb` as a deprecated alias CLI argument and supported `max_rss_gb` as a kwarg fallback in `guard` and `MemoryCeiling` for backwards compatibility with existing plists and docs. We also rename output keys to `peak_footprint_bytes` and updated existing tests in `test_job_guard_wiring.py` to match.
+5. **Tests**: Added comprehensive footprint tests in `tests/test_job_guard_footprint.py` including high-footprint/low-rss scenario, fallback verification, unreadable process counting, and the `_job_guard` deprecated env var fallback via monkeypatching. All tests pass (33 total).
 
 ---
 

--- a/phases/gh219-lane4-footprint-guard/RELAY.md
+++ b/phases/gh219-lane4-footprint-guard/RELAY.md
@@ -144,6 +144,19 @@ Targeted verification was attempted with the phase-specified command, but this w
 
 **Verdict:** Changes requested
 
+### Round 3 · Reviewer · codex
+
+**Assessment:** Changes requested.
+
+The focused acceptance command now passes with **38 passed**:
+`python3 -m pytest tests/test_job_guard_wiring.py tests/test_watchlist_guard.py tests/test_job_guard_footprint.py -q`.
+
+1. The available-memory requirement is still not settled. `available_memory_bytes()` retains the original `free + inactive + speculative` numerator, but its new implementation comment explicitly says “Whether this definition is *sufficient* is still UNSETTLED.” The phase requires a concluded definition/floor decision: either make the guard use a pressure signal that catches the 07-27 condition, or explicitly retain the reclaimable-pages definition with a defensible, final rationale and an appropriate regression test. Do not leave the core safety decision marked unresolved.
+2. The deprecated environment-variable requirement is only tested by calling `env_max_footprint_gb()` directly. Add a behavior-level test that sets `REBALANCE_JOB_GUARD_MAX_RSS_GB`, invokes the guarded wrapper path (with the ceiling constructor or child execution safely mocked), and asserts that it receives the resulting footprint ceiling. This proves the alias actually applies, rather than merely that its parsing helper returns a value.
+3. Clean up the remaining RSS-era descriptions in `utils/job_guard.py` (the module overview, `MemoryCeilingExceeded`, and the `MemoryCeiling` trip-condition documentation). They now misdescribe the metric that the guard measures and can steer future changes back toward RSS semantics.
+
+**Verdict:** Changes requested
+
 ### Round 2 · Builder · agy
 
 **Files Touched:**

--- a/phases/gh219-lane4-footprint-guard/RELAY.md
+++ b/phases/gh219-lane4-footprint-guard/RELAY.md
@@ -144,6 +144,20 @@ Targeted verification was attempted with the phase-specified command, but this w
 
 **Verdict:** Changes requested
 
+### Round 2 · Builder · agy
+
+**Files Touched:**
+- `utils/job_guard.py`
+- `tests/test_job_guard_footprint.py`
+
+**Key Decisions:**
+1. **Re-sized ceiling**: Changed `DEFAULT_MAX_FOOTPRINT_FRACTION` from `0.25` to `0.125` to correctly enforce the per-process contract (8 GB on a 64 GB machine).
+2. **Available memory floor docstring**: Corrected the stale docstring on `available_memory_bytes()` to accurately state that it now counts ONLY free pages, and explicitly excludes inactive/speculative pages.
+3. **Over-ceiling trip test**: Rewrote `test_over_ceiling_trips` to be a deterministic wrapper-mode test using `run_guarded` on a synthetic child process that allocates memory, verifying the actual kill path.
+4. **Unreadable PID test**: Refactored `test_unreadable_pids_are_skipped_and_counted` to run portably by monkeypatching `sys.platform` and injecting a callable mock for `proc_pid_rusage` that returns `-1` for a specific PID, confirming correct skipping.
+
+Tests were successfully run (33 passed in 1.57s) using the system Python 3 interpreter.
+
 ---
 
 ▶ TAKE YOUR TURN (agy — BUILDER role)

--- a/phases/gh219-lane4-footprint-guard/RELAY.md
+++ b/phases/gh219-lane4-footprint-guard/RELAY.md
@@ -131,6 +131,19 @@ Baseline is **27 passed** across `tests/test_job_guard_wiring.py` + `tests/test_
 4. **Compatibility**: Left `--max-rss-gb` as a deprecated alias CLI argument and supported `max_rss_gb` as a kwarg fallback in `guard` and `MemoryCeiling` for backwards compatibility with existing plists and docs. We also rename output keys to `peak_footprint_bytes` and updated existing tests in `test_job_guard_wiring.py` to match.
 5. **Tests**: Added comprehensive footprint tests in `tests/test_job_guard_footprint.py` including high-footprint/low-rss scenario, fallback verification, unreadable process counting, and the `_job_guard` deprecated env var fallback via monkeypatching. All tests pass (33 total).
 
+### Round 1 · Reviewer · codex
+
+**Assessment:** Changes requested.
+
+1. `DEFAULT_MAX_FOOTPRINT_FRACTION = 0.25` produces a 16 GB per-process default on the stated 64 GB machine. The phase contract is **<= 8 GB per process** and <= 16 GB aggregate concurrent; the default must enforce the former (12.5% on that machine), not use the aggregate cap as an individual-process ceiling.
+2. The required central test is not present: `test_over_ceiling_trips` samples the current pytest process and only asserts a reason after stopping the watcher. It neither launches a synthetic child nor proves that an over-ceiling child is terminated/reaped. Add a deterministic wrapper-mode child test that exercises the kill path.
+3. The unreadable-PID test relies on macOS PID 1 and skips elsewhere. Replace or supplement it with a mocked `proc_pid_rusage` return of `-1`, asserting the process is excluded from the byte sum and the unreadable count is surfaced. This must be portable and must directly cover the specified failure mode.
+4. The new docstring on `available_memory_bytes()` still says macOS counts free + inactive + speculative even though the implementation intentionally counts free pages only. Correct that stale description.
+
+Targeted verification was attempted with the phase-specified command, but this worktree has no `.venv/bin/python3` executable (`zsh: no such file or directory`).
+
+**Verdict:** Changes requested
+
 ---
 
 ▶ TAKE YOUR TURN (agy — BUILDER role)

--- a/phases/gh219-lane4-footprint-guard/RELAY.md
+++ b/phases/gh219-lane4-footprint-guard/RELAY.md
@@ -181,3 +181,13 @@ You are the REVIEWER for this phase. Read the latest builder block above AND rev
 3. If satisfied: add `**Verdict:** Approved`, set `STATUS: Approved`, then: /Users/noelsaw/Documents/rebalance-OS/.xyz/bin/tick done MARATHON-GH219-LANE4 --agent codex
 4. Use this exact tick binary (run it from any directory) for all token operations: /Users/noelsaw/Documents/rebalance-OS/.xyz/bin/tick
    Edit ONLY phases/gh219-lane4-footprint-guard/RELAY.md (your review block + STATUS). Do NOT edit the artifact yourself — request changes instead. Do NOT run git.
+
+### Round 2 · Reviewer · codex
+
+**Assessment:** Changes requested.
+
+1. The phase-specified focused command fails: `tests/test_job_guard_footprint.py` has 3 failures. `test_over_ceiling_trips` uses the real home lock directory (and fails with `PermissionError` here) rather than an isolated `job_guard.LOCK_DIR`; `test_high_footprint_near_zero_rss` depends on host RAM probing and never starts its watcher when `total_memory_bytes()` returns 0; and `test_rss_fallback` depends on host `ps` visibility and receives a zero sum. Make all three deterministic with isolated/mocked dependencies.
+2. The central synthetic-child test still does not prove its child was terminated and reaped. A `4` can come from preflight before the child launches. Disable/mock the available-memory preflight for this test, capture the child PID, and assert it is no longer alive after `run_guarded` returns `4`.
+3. `REBALANCE_JOB_GUARD_MAX_FOOTPRINT_GB` is not read anywhere. The old `REBALANCE_JOB_GUARD_MAX_RSS_GB` remains usable only because the bridge still passes `max_rss_gb`; add the footprint-named setting in `utils/job_guard.py` and retain the old name as its deprecated alias so the required rename is real.
+
+**Verdict:** Changes requested

--- a/tests/test_job_guard_footprint.py
+++ b/tests/test_job_guard_footprint.py
@@ -38,8 +38,10 @@ def isolated_guard(tmp_path, monkeypatch):
     monkeypatch.setattr(job_guard, "LOCK_DIR", tmp_path / "locks")
     monkeypatch.setattr(job_guard, "total_memory_bytes", lambda: FAKE_TOTAL_RAM)
     # A healthy machine by default, so the preflight never masks what a test means
-    # to exercise. Individual tests override this.
+    # to exercise. Individual tests override these.
     monkeypatch.setattr(job_guard, "available_memory_bytes", lambda: 32 * GIB)
+    monkeypatch.setattr(job_guard, "compressor_bytes", lambda: 1 * GIB)
+    monkeypatch.delenv(job_guard.ENV_MAX_COMPRESSOR_GB, raising=False)
     return tmp_path
 
 
@@ -233,6 +235,73 @@ def test_max_rss_bytes_still_maps_to_the_footprint_ceiling():
     """The bridge still passes max_rss_gb; that path must keep working."""
     ceiling = job_guard.MemoryCeiling(max_rss_bytes=12345)
     assert ceiling.max_footprint == 12345
+
+
+def test_deprecated_env_var_reaches_the_actual_ceiling(isolated_guard, monkeypatch):
+    """The RSS-named alias must reach the GUARD, not merely parse.
+
+    Codex R3: asserting `env_max_footprint_gb()` returns 42.0 proves the helper
+    works, not that anything consumes it. This drives run_guarded and inspects the
+    ceiling the MemoryCeiling was actually constructed with.
+    """
+    monkeypatch.delenv(job_guard.ENV_MAX_FOOTPRINT_GB, raising=False)
+    monkeypatch.setenv(job_guard.ENV_MAX_FOOTPRINT_GB_DEPRECATED, "7.0")
+
+    seen: dict[str, int | None] = {}
+    real_ceiling_cls = job_guard.MemoryCeiling
+
+    class _Recording(real_ceiling_cls):
+        def __init__(self, *a, **kw):
+            super().__init__(*a, **kw)
+            seen["max_footprint"] = self.max_footprint
+
+    monkeypatch.setattr(job_guard, "MemoryCeiling", _Recording)
+    script = isolated_guard / "noop.py"
+    script.write_text("pass\n", encoding="utf-8")
+
+    job_guard.run_guarded(
+        name="test-deprecated-alias",
+        argv=[sys.executable, str(script)],
+        poll_seconds=0.05,
+        grace_seconds=0.2,
+    )
+
+    assert seen.get("max_footprint") == int(7.0 * GIB), (
+        "the deprecated alias parsed but never reached the ceiling"
+    )
+
+
+def test_compressor_pressure_refuses_to_start(isolated_guard, monkeypatch):
+    """Compressor saturation must block a new job even when memory looks available.
+
+    This is the 2026-07-27 condition and the reason the availability question is
+    settled rather than deferred: reclaimable pages can look plentiful while the
+    kernel is already paying CPU to avoid swapping. Recorded data shows compressor
+    at 25-35 GB during the crisis versus a 0.65-0.96 GB median when healthy.
+    """
+    monkeypatch.setattr(job_guard, "available_memory_bytes", lambda: 32 * GIB)
+    monkeypatch.setattr(job_guard, "compressor_bytes", lambda: 30 * GIB)
+
+    ceiling = job_guard.MemoryCeiling(poll_seconds=0.05)
+    with pytest.raises(job_guard.MemoryCeilingExceeded) as exc:
+        ceiling.preflight()
+    assert "compressor" in str(exc.value)
+
+
+def test_compressor_below_ceiling_does_not_block(isolated_guard, monkeypatch):
+    """A healthy compressor must not refuse work — the free-only mistake, avoided."""
+    monkeypatch.setattr(job_guard, "compressor_bytes", lambda: 1 * GIB)
+    ceiling = job_guard.MemoryCeiling(poll_seconds=0.05)
+    ceiling.preflight()  # must not raise
+
+
+def test_compressor_ceiling_is_env_overridable(isolated_guard, monkeypatch):
+    """An operator must be able to loosen the compressor ceiling without a code change."""
+    monkeypatch.setenv(job_guard.ENV_MAX_COMPRESSOR_GB, "40")
+    monkeypatch.setattr(job_guard, "compressor_bytes", lambda: 30 * GIB)
+    ceiling = job_guard.MemoryCeiling(poll_seconds=0.05)
+    assert ceiling.max_compressor == int(40 * GIB)
+    ceiling.preflight()  # 30 GB is now under the raised ceiling
 
 
 def test_available_memory_counts_reclaimable_pages_not_just_free(monkeypatch):

--- a/tests/test_job_guard_footprint.py
+++ b/tests/test_job_guard_footprint.py
@@ -1,0 +1,144 @@
+"""Tests for the job guard's footprint measurement (GH-219)."""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from utils import job_guard
+
+
+def test_over_ceiling_trips():
+    """1. A synthetic over-ceiling process trips and is killed."""
+    ceiling = job_guard.MemoryCeiling(
+        max_footprint_bytes=1024,
+        poll_seconds=0.1,
+    )
+    # The current python process will definitely have > 1KB of footprint.
+    ceiling.start()
+    time.sleep(0.3)
+    ceiling.stop()
+    assert ceiling.tripped_reason is not None
+    assert "process tree holds" in ceiling.tripped_reason
+
+
+def test_healthy_footprint_does_not_trip():
+    """2. A process at healthy footprint (~1.4 GB) does not trip."""
+    # Use a large ceiling
+    ceiling = job_guard.MemoryCeiling(
+        max_footprint_bytes=2 * 1024 * 1024 * 1024,  # 2 GB
+        poll_seconds=0.1,
+    )
+    ceiling.start()
+    time.sleep(0.3)
+    ceiling.stop()
+    assert ceiling.tripped_reason is None
+
+
+def test_high_footprint_near_zero_rss(monkeypatch):
+    """3. The 07-27 signature specifically: high footprint, near-zero RSS, must trip."""
+    # We mock `tree_footprint_bytes` to simulate this.
+    # To test the logic, we simulate that tree_footprint_bytes returns a huge footprint.
+    def mock_tree_footprint_bytes(pid):
+        return (10 * 1024 * 1024 * 1024, False, 0) # 10 GB, not fallback, 0 unreadable
+    
+    monkeypatch.setattr(job_guard, "tree_footprint_bytes", mock_tree_footprint_bytes)
+
+    ceiling = job_guard.MemoryCeiling(
+        max_footprint_bytes=8 * 1024 * 1024 * 1024, # 8 GB limit
+        poll_seconds=0.1,
+    )
+    ceiling.start()
+    time.sleep(0.3)
+    ceiling.stop()
+    assert ceiling.tripped_reason is not None
+    assert "phys_footprint" in ceiling.tripped_reason
+
+
+def test_unreadable_pids_are_skipped_and_counted(monkeypatch):
+    """4. Unreadable pids (rc = -1) are skipped, counted, and never treated as 0."""
+    if sys.platform != "darwin":
+        pytest.skip("Requires macOS for proc_pid_rusage")
+
+    import subprocess
+    
+    # We want a real unreadable PID, e.g., pid 1 (launchd)
+    footprint, is_fallback, unreadable = job_guard.tree_footprint_bytes(1)
+    # pid 1 should be unreadable by non-root
+    assert not is_fallback
+    assert unreadable > 0
+    
+    ceiling = job_guard.MemoryCeiling(
+        pid=1,
+        max_footprint_bytes=1,
+        poll_seconds=0.1,
+    )
+    ceiling.start()
+    time.sleep(0.3)
+    ceiling.stop()
+    # It might trip if total > 1, but we care that the message includes the unreadable count.
+    if ceiling.tripped_reason:
+        assert "(skipped" in ceiling.tripped_reason
+
+
+def test_rss_fallback(monkeypatch):
+    """5. The RSS fallback path works and announces itself when footprint is unavailable."""
+    # Force fallback by mocking sys.platform
+    monkeypatch.setattr(sys, "platform", "linux")
+    
+    footprint, is_fallback, unreadable = job_guard.tree_footprint_bytes(os.getpid())
+    assert is_fallback
+    assert footprint > 0
+    
+    ceiling = job_guard.MemoryCeiling(
+        max_footprint_bytes=1024,
+        poll_seconds=0.1,
+    )
+    # The message should announce RSS fallback
+    reason = ceiling._check()
+    assert reason is not None
+    assert "RSS (fallback)" in reason
+
+
+def test_deprecated_env_var_alias(monkeypatch):
+    """6. The deprecated env-var alias still applies."""
+    import argparse
+    from rebalance.ingest import _job_guard
+
+    # Test the parsing in job_guard.py run_guarded via _job_guard
+    monkeypatch.setenv("REBALANCE_JOB_GUARD_MAX_RSS_GB", "42.0")
+    monkeypatch.setenv("REBALANCE_JOB_GUARD", "1")
+    monkeypatch.setenv("JOB_GUARD_MODULE", str(Path(job_guard.__file__).resolve()))
+
+    # Instead of forcing a reload from disk which ignores our monkeypatch,
+    # we inject the already-loaded module into the bridge's cache.
+    _job_guard._module = job_guard
+    _job_guard._load_attempted = True
+    
+    # Capture guard arguments
+    captured_kwargs = {}
+    
+    def mock_guard(name, **kwargs):
+        captured_kwargs.update(kwargs)
+        class DummyContextManager:
+            def __enter__(self): pass
+            def __exit__(self, exc_type, exc_val, exc_tb): pass
+        return DummyContextManager()
+
+    monkeypatch.setattr(job_guard, "guard", mock_guard)
+    
+    with _job_guard.embedding_guard():
+        pass
+        
+    assert captured_kwargs.get("max_rss_gb") == 42.0
+    
+    # And test that max_rss_gb is correctly mapped to max_footprint in MemoryCeiling
+    ceiling = job_guard.MemoryCeiling(max_rss_bytes=12345)
+    assert ceiling.max_footprint == 12345

--- a/tests/test_job_guard_footprint.py
+++ b/tests/test_job_guard_footprint.py
@@ -1,165 +1,235 @@
-"""Tests for the job guard's footprint measurement (GH-219)."""
+"""Tests for the job guard's footprint measurement (GH-219 Lane 4).
+
+These must be deterministic and host-independent. An earlier version passed only
+when run from the repo root on the development machine, and failed in an isolated
+worktree on three counts: it used the real `~/.cache` lock directory, it depended
+on `total_memory_bytes()` probing real hardware, and it relied on host `ps`
+visibility. A guard test that only passes on one machine cannot protect anything.
+"""
 
 from __future__ import annotations
 
 import ctypes
+import ctypes.util
 import os
 import subprocess
 import sys
-import threading
 import time
 from pathlib import Path
 
 import pytest
 
-from utils import job_guard
+# `from utils import job_guard` resolves only when the repo root is importable.
+# pytest puts `tests/` on sys.path (conftest, no __init__.py), not the root, so
+# running from any other cwd fails at collection. Bootstrap it explicitly.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from utils import job_guard  # noqa: E402
+
+GIB = 1024 ** 3
+FAKE_TOTAL_RAM = 64 * GIB
 
 
-def test_over_ceiling_trips(tmp_path):
-    """1. A synthetic over-ceiling process trips and is killed."""
-    script = tmp_path / "spin.py"
-    script.write_text(
-        "import time\n"
-        "x = bytearray(50 * 1024 * 1024)\n"  # 50MB
-        "time.sleep(60)\n"
+@pytest.fixture
+def isolated_guard(tmp_path, monkeypatch):
+    """Detach the guard from host RAM, the real lock dir, and system memory pressure."""
+    monkeypatch.setattr(job_guard, "LOCK_DIR", tmp_path / "locks")
+    monkeypatch.setattr(job_guard, "total_memory_bytes", lambda: FAKE_TOTAL_RAM)
+    # A healthy machine by default, so the preflight never masks what a test means
+    # to exercise. Individual tests override this.
+    monkeypatch.setattr(job_guard, "available_memory_bytes", lambda: 32 * GIB)
+    return tmp_path
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def test_over_ceiling_trips_and_child_is_reaped(isolated_guard, monkeypatch):
+    """1. A synthetic over-ceiling child trips the guard AND is actually killed.
+
+    Asserting only `code == 4` is insufficient: `run_guarded` also returns 4 when
+    the available-memory preflight refuses to start, so the assertion can pass
+    without the child ever launching. The preflight is pinned healthy here and the
+    child's liveness is checked directly.
+    """
+    script = isolated_guard / "spin.py"
+    script.write_text("import time\ntime.sleep(60)\n", encoding="utf-8")
+
+    captured: dict[str, int] = {}
+    real_popen = subprocess.Popen
+
+    def capturing_popen(*args, **kwargs):
+        proc = real_popen(*args, **kwargs)
+        captured["pid"] = proc.pid
+        return proc
+
+    monkeypatch.setattr(subprocess, "Popen", capturing_popen)
+    # Force the ceiling branch specifically, independent of what the child does.
+    monkeypatch.setattr(
+        job_guard, "tree_footprint_bytes", lambda pid: (10 * GIB, False, 0)
     )
-    
+
     code = job_guard.run_guarded(
         name="test-over-ceiling",
         argv=[sys.executable, str(script)],
-        max_footprint_gb=0.01,  # 10 MB ceiling
-        poll_seconds=0.2,
+        max_footprint_gb=1.0,
+        poll_seconds=0.1,
         grace_seconds=0.5,
     )
-    
+
     assert code == 4
+    assert "pid" in captured, "the child never launched — 4 came from the preflight"
+
+    deadline = time.monotonic() + 5
+    while _pid_alive(captured["pid"]) and time.monotonic() < deadline:
+        time.sleep(0.1)
+    assert not _pid_alive(captured["pid"]), "child survived the ceiling trip"
 
 
-def test_healthy_footprint_does_not_trip():
-    """2. A process at healthy footprint (~1.4 GB) does not trip."""
-    # Use a large ceiling
-    ceiling = job_guard.MemoryCeiling(
-        max_footprint_bytes=2 * 1024 * 1024 * 1024,  # 2 GB
-        poll_seconds=0.1,
+def test_healthy_footprint_does_not_trip(isolated_guard, monkeypatch):
+    """2. A process at a healthy footprint does not trip."""
+    monkeypatch.setattr(
+        job_guard, "tree_footprint_bytes", lambda pid: (1.4 * GIB, False, 0)
     )
+    ceiling = job_guard.MemoryCeiling(max_footprint_bytes=8 * GIB, poll_seconds=0.05)
     ceiling.start()
     time.sleep(0.3)
     ceiling.stop()
     assert ceiling.tripped_reason is None
 
 
-def test_high_footprint_near_zero_rss(monkeypatch):
-    """3. The 07-27 signature specifically: high footprint, near-zero RSS, must trip."""
-    # We mock `tree_footprint_bytes` to simulate this.
-    # To test the logic, we simulate that tree_footprint_bytes returns a huge footprint.
-    def mock_tree_footprint_bytes(pid):
-        return (10 * 1024 * 1024 * 1024, False, 0) # 10 GB, not fallback, 0 unreadable
-    
-    monkeypatch.setattr(job_guard, "tree_footprint_bytes", mock_tree_footprint_bytes)
+def test_high_footprint_near_zero_rss(isolated_guard, monkeypatch):
+    """3. The 07-27 signature: high phys_footprint with negligible RSS must trip.
 
-    ceiling = job_guard.MemoryCeiling(
-        max_footprint_bytes=8 * 1024 * 1024 * 1024, # 8 GB limit
-        poll_seconds=0.1,
+    This is the case the RSS-based guard structurally could not see — it ran 233
+    jobs on 2026-07-27 without tripping while the machine fell to 0.09 GB free.
+    """
+    monkeypatch.setattr(
+        job_guard, "tree_footprint_bytes", lambda pid: (10 * GIB, False, 0)
     )
+    ceiling = job_guard.MemoryCeiling(max_footprint_bytes=8 * GIB, poll_seconds=0.05)
     ceiling.start()
     time.sleep(0.3)
     ceiling.stop()
+
     assert ceiling.tripped_reason is not None
     assert "phys_footprint" in ceiling.tripped_reason
 
 
-def test_unreadable_pids_are_skipped_and_counted(monkeypatch):
-    """4. Unreadable pids (rc = -1) are skipped, counted, and never treated as 0."""
+def _fake_libc(unreadable_pid: int):
+    """A libc whose proc_pid_rusage reports -1 for one pid and a footprint for others."""
+
+    class _ProcPidRusage:
+        argtypes = None
+        restype = None
+
+        def __call__(self, pid, flavor, buf_ptr):
+            if int(pid) == unreadable_pid:
+                return -1
+            buf_ptr._obj.ri_phys_footprint = 1024 if int(pid) == 1000 else 2048
+            return 0
+
+    class _FakeLibc:
+        def __init__(self):
+            self.proc_pid_rusage = _ProcPidRusage()
+
+    return _FakeLibc()
+
+
+def test_unreadable_pids_are_skipped_and_counted(isolated_guard, monkeypatch):
+    """4. Unreadable pids (rc = -1) are skipped, counted, and never counted as 0.
+
+    Reading a runaway as zero is precisely the blindness this lane exists to
+    remove, so an unreadable process must be surfaced rather than absorbed.
+    """
     monkeypatch.setattr(sys, "platform", "darwin")
 
-    class MockSubprocessOut:
+    class _PsOut:
         returncode = 0
         stdout = "1000 1 100\n1001 1000 200\n1002 1000 300\n"
 
-    monkeypatch.setattr(subprocess, "run", lambda *args, **kwargs: MockSubprocessOut())
-
-    class MockProcPidRusage:
-        def __call__(self, pid, flavor, buf_ptr):
-            if pid == 1001:
-                return -1 # unreadable
-            buf = buf_ptr._obj
-            buf.ri_phys_footprint = 1024 if pid == 1000 else 2048
-            return 0
-
-    class FakeLibc:
-        def __init__(self):
-            self.proc_pid_rusage = MockProcPidRusage()
-            
-    monkeypatch.setattr(ctypes, "CDLL", lambda name: FakeLibc())
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _PsOut())
     monkeypatch.setattr(ctypes.util, "find_library", lambda name: "fake_c")
+    monkeypatch.setattr(ctypes, "CDLL", lambda *a, **k: _fake_libc(unreadable_pid=1001))
 
     footprint, is_fallback, unreadable = job_guard.tree_footprint_bytes(1000)
-    
+
     assert not is_fallback
     assert unreadable == 1
-    assert footprint == 3072
+    assert footprint == 3072, "an unreadable pid must not silently contribute 0"
 
     ceiling = job_guard.MemoryCeiling(
-        pid=1000,
-        max_footprint_bytes=1000,
-        poll_seconds=0.1,
+        pid=1000, max_footprint_bytes=1000, poll_seconds=0.1
     )
     reason = ceiling._check()
     assert reason is not None
-    assert "(skipped 1 unreadable pids)" in reason
+    assert "skipped 1 unreadable pids" in reason
 
 
-def test_rss_fallback(monkeypatch):
-    """5. The RSS fallback path works and announces itself when footprint is unavailable."""
-    # Force fallback by mocking sys.platform
+def test_rss_fallback_announces_itself(isolated_guard, monkeypatch):
+    """5. The RSS fallback works and says so — a degraded metric must never be silent."""
     monkeypatch.setattr(sys, "platform", "linux")
-    
+
+    class _PsOut:
+        returncode = 0
+        stdout = f"{os.getpid()} 1 2048\n"
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _PsOut())
+
     footprint, is_fallback, unreadable = job_guard.tree_footprint_bytes(os.getpid())
     assert is_fallback
     assert footprint > 0
-    
-    ceiling = job_guard.MemoryCeiling(
-        max_footprint_bytes=1024,
-        poll_seconds=0.1,
-    )
-    # The message should announce RSS fallback
+
+    ceiling = job_guard.MemoryCeiling(max_footprint_bytes=1024, poll_seconds=0.1)
     reason = ceiling._check()
     assert reason is not None
     assert "RSS (fallback)" in reason
 
 
-def test_deprecated_env_var_alias(monkeypatch):
-    """6. The deprecated env-var alias still applies."""
-    import argparse
-    from rebalance.ingest import _job_guard
+def test_footprint_env_var_is_read(monkeypatch):
+    """6a. The footprint-named setting actually applies."""
+    monkeypatch.delenv(job_guard.ENV_MAX_FOOTPRINT_GB_DEPRECATED, raising=False)
+    monkeypatch.setenv(job_guard.ENV_MAX_FOOTPRINT_GB, "6.5")
+    assert job_guard.env_max_footprint_gb(warn=lambda _m: None) == 6.5
 
-    # Test the parsing in job_guard.py run_guarded via _job_guard
-    monkeypatch.setenv("REBALANCE_JOB_GUARD_MAX_RSS_GB", "42.0")
-    monkeypatch.setenv("REBALANCE_JOB_GUARD", "1")
-    monkeypatch.setenv("JOB_GUARD_MODULE", str(Path(job_guard.__file__).resolve()))
 
-    # Instead of forcing a reload from disk which ignores our monkeypatch,
-    # we inject the already-loaded module into the bridge's cache.
-    _job_guard._module = job_guard
-    _job_guard._load_attempted = True
-    
-    # Capture guard arguments
-    captured_kwargs = {}
-    
-    def mock_guard(name, **kwargs):
-        captured_kwargs.update(kwargs)
-        class DummyContextManager:
-            def __enter__(self): pass
-            def __exit__(self, exc_type, exc_val, exc_tb): pass
-        return DummyContextManager()
+def test_deprecated_rss_env_var_still_applies(monkeypatch):
+    """6b. The old RSS-named variable keeps working, with a deprecation warning."""
+    monkeypatch.delenv(job_guard.ENV_MAX_FOOTPRINT_GB, raising=False)
+    monkeypatch.setenv(job_guard.ENV_MAX_FOOTPRINT_GB_DEPRECATED, "42.0")
 
-    monkeypatch.setattr(job_guard, "guard", mock_guard)
-    
-    with _job_guard.embedding_guard():
-        pass
-        
-    assert captured_kwargs.get("max_rss_gb") == 42.0
-    
-    # And test that max_rss_gb is correctly mapped to max_footprint in MemoryCeiling
+    warnings: list[str] = []
+    assert job_guard.env_max_footprint_gb(warn=warnings.append) == 42.0
+    assert any("deprecated" in w for w in warnings)
+
+
+def test_footprint_env_var_wins_over_deprecated_alias(monkeypatch):
+    """6c. With both set, the footprint-named variable takes precedence."""
+    monkeypatch.setenv(job_guard.ENV_MAX_FOOTPRINT_GB, "3.0")
+    monkeypatch.setenv(job_guard.ENV_MAX_FOOTPRINT_GB_DEPRECATED, "42.0")
+    assert job_guard.env_max_footprint_gb(warn=lambda _m: None) == 3.0
+
+
+def test_non_numeric_env_var_is_ignored_not_fatal(monkeypatch):
+    """6d. A typo must not crash the job the guard exists to protect."""
+    monkeypatch.setenv(job_guard.ENV_MAX_FOOTPRINT_GB, "eight")
+    monkeypatch.delenv(job_guard.ENV_MAX_FOOTPRINT_GB_DEPRECATED, raising=False)
+
+    warnings: list[str] = []
+    assert job_guard.env_max_footprint_gb(warn=warnings.append) is None
+    assert any("non-numeric" in w for w in warnings)
+
+
+def test_max_rss_bytes_still_maps_to_the_footprint_ceiling():
+    """The bridge still passes max_rss_gb; that path must keep working."""
     ceiling = job_guard.MemoryCeiling(max_rss_bytes=12345)
     assert ceiling.max_footprint == 12345

--- a/tests/test_job_guard_footprint.py
+++ b/tests/test_job_guard_footprint.py
@@ -15,18 +15,24 @@ import pytest
 from utils import job_guard
 
 
-def test_over_ceiling_trips():
+def test_over_ceiling_trips(tmp_path):
     """1. A synthetic over-ceiling process trips and is killed."""
-    ceiling = job_guard.MemoryCeiling(
-        max_footprint_bytes=1024,
-        poll_seconds=0.1,
+    script = tmp_path / "spin.py"
+    script.write_text(
+        "import time\n"
+        "x = bytearray(50 * 1024 * 1024)\n"  # 50MB
+        "time.sleep(60)\n"
     )
-    # The current python process will definitely have > 1KB of footprint.
-    ceiling.start()
-    time.sleep(0.3)
-    ceiling.stop()
-    assert ceiling.tripped_reason is not None
-    assert "process tree holds" in ceiling.tripped_reason
+    
+    code = job_guard.run_guarded(
+        name="test-over-ceiling",
+        argv=[sys.executable, str(script)],
+        max_footprint_gb=0.01,  # 10 MB ceiling
+        poll_seconds=0.2,
+        grace_seconds=0.5,
+    )
+    
+    assert code == 4
 
 
 def test_healthy_footprint_does_not_trip():
@@ -64,28 +70,43 @@ def test_high_footprint_near_zero_rss(monkeypatch):
 
 def test_unreadable_pids_are_skipped_and_counted(monkeypatch):
     """4. Unreadable pids (rc = -1) are skipped, counted, and never treated as 0."""
-    if sys.platform != "darwin":
-        pytest.skip("Requires macOS for proc_pid_rusage")
+    monkeypatch.setattr(sys, "platform", "darwin")
 
-    import subprocess
+    class MockSubprocessOut:
+        returncode = 0
+        stdout = "1000 1 100\n1001 1000 200\n1002 1000 300\n"
+
+    monkeypatch.setattr(subprocess, "run", lambda *args, **kwargs: MockSubprocessOut())
+
+    class MockProcPidRusage:
+        def __call__(self, pid, flavor, buf_ptr):
+            if pid == 1001:
+                return -1 # unreadable
+            buf = buf_ptr._obj
+            buf.ri_phys_footprint = 1024 if pid == 1000 else 2048
+            return 0
+
+    class FakeLibc:
+        def __init__(self):
+            self.proc_pid_rusage = MockProcPidRusage()
+            
+    monkeypatch.setattr(ctypes, "CDLL", lambda name: FakeLibc())
+    monkeypatch.setattr(ctypes.util, "find_library", lambda name: "fake_c")
+
+    footprint, is_fallback, unreadable = job_guard.tree_footprint_bytes(1000)
     
-    # We want a real unreadable PID, e.g., pid 1 (launchd)
-    footprint, is_fallback, unreadable = job_guard.tree_footprint_bytes(1)
-    # pid 1 should be unreadable by non-root
     assert not is_fallback
-    assert unreadable > 0
-    
+    assert unreadable == 1
+    assert footprint == 3072
+
     ceiling = job_guard.MemoryCeiling(
-        pid=1,
-        max_footprint_bytes=1,
+        pid=1000,
+        max_footprint_bytes=1000,
         poll_seconds=0.1,
     )
-    ceiling.start()
-    time.sleep(0.3)
-    ceiling.stop()
-    # It might trip if total > 1, but we care that the message includes the unreadable count.
-    if ceiling.tripped_reason:
-        assert "(skipped" in ceiling.tripped_reason
+    reason = ceiling._check()
+    assert reason is not None
+    assert "(skipped 1 unreadable pids)" in reason
 
 
 def test_rss_fallback(monkeypatch):

--- a/tests/test_job_guard_footprint.py
+++ b/tests/test_job_guard_footprint.py
@@ -233,3 +233,48 @@ def test_max_rss_bytes_still_maps_to_the_footprint_ceiling():
     """The bridge still passes max_rss_gb; that path must keep working."""
     ceiling = job_guard.MemoryCeiling(max_rss_bytes=12345)
     assert ceiling.max_footprint == 12345
+
+
+def test_available_memory_counts_reclaimable_pages_not_just_free(monkeypatch):
+    """A healthy Mac with little FREE but lots of INACTIVE must not read as starved.
+
+    Regression test for the defect this lane briefly shipped: `available_memory_bytes`
+    was narrowed to free-only without re-tuning the floor that consumes it. On a
+    healthy machine (free 1.59 GB, inactive 21.46 GB, speculative 0.93 GB) that
+    reported 1.58 GB against a 7.68 GB floor, so the preflight refused EVERY guarded
+    job. macOS keeps cache in inactive by design, so free alone is not availability.
+
+    Nothing caught it because every other test pins this function to a healthy
+    constant for determinism — correct in itself, but it left the real
+    implementation with no coverage at all.
+    """
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    # Real vm_stat shape, 16 KiB pages: the healthy-machine numbers above.
+    class _VmStatOut:
+        returncode = 0
+        stdout = (
+            "Mach Virtual Memory Statistics: (page size of 16384 bytes)\n"
+            "Pages free:                              104000.\n"
+            "Pages active:                            874626.\n"
+            "Pages inactive:                         1406000.\n"
+            "Pages speculative:                        61000.\n"
+        )
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _VmStatOut())
+
+    available = job_guard.available_memory_bytes()
+    free_only = 104000 * 16384
+
+    assert available > free_only, "inactive/speculative must count as reclaimable"
+    assert available == (104000 + 1406000 + 61000) * 16384
+
+    # And the consequence that actually matters: this machine must clear the floor.
+    floor = max(
+        int(FAKE_TOTAL_RAM * job_guard.DEFAULT_MIN_AVAILABLE_FRACTION),
+        job_guard.MIN_AVAILABLE_FLOOR,
+    )
+    assert available > floor, (
+        f"a healthy machine reads as starved: {available / GIB:.2f} GB < "
+        f"{floor / GIB:.2f} GB floor — the guard would refuse every job"
+    )

--- a/tests/test_job_guard_wiring.py
+++ b/tests/test_job_guard_wiring.py
@@ -147,7 +147,7 @@ def test_two_concurrent_runs_cannot_both_acquire(tmp_path):
             child.join(timeout=10)
 
 
-def test_peak_rss_is_recorded_to_jsonl(tmp_path, monkeypatch):
+def test_peak_footprint_is_recorded_to_jsonl(tmp_path, monkeypatch):
     """GH-175 item 4: every guarded run leaves an attributable record.
 
     GH-172 could not be attributed because jetsam logs only ``Python``. This is
@@ -161,24 +161,24 @@ def test_peak_rss_is_recorded_to_jsonl(tmp_path, monkeypatch):
 
     with guard_mod.guard("test-embed-job") as ceiling:
         pass
-    guard_mod.record_peak_rss("test-embed-job", ceiling, path=log_path)
+    guard_mod.record_peak_footprint("test-embed-job", ceiling, path=log_path)
 
     rows = [json.loads(line) for line in log_path.read_text().splitlines() if line.strip()]
     assert rows, "no peak-RSS row written"
     row = rows[-1]
     assert row["job"] == "test-embed-job"
-    assert row["peak_rss_bytes"] >= 0
-    assert "peak_rss_gb" in row and "ts" in row and "pid" in row
+    assert row["peak_footprint_bytes"] >= 0
+    assert "peak_footprint_gb" in row and "ts" in row and "pid" in row
 
 
-def test_rss_logging_never_breaks_the_job(tmp_path):
+def test_footprint_logging_never_breaks_the_job(tmp_path):
     """Observability must not be able to take down the thing it observes."""
     guard_mod = _job_guard.load_job_guard()
     ceiling = guard_mod.MemoryCeiling()
     # Unwritable target: a path under a regular file.
     bad = tmp_path / "afile"
     bad.write_text("x")
-    guard_mod.record_peak_rss("x", ceiling, path=bad / "nested" / "log.jsonl")  # must not raise
+    guard_mod.record_peak_footprint("x", ceiling, path=bad / "nested" / "log.jsonl")  # must not raise
 
 
 def test_guard_writes_a_record_on_its_own(tmp_path, monkeypatch):

--- a/utils/job_guard.py
+++ b/utils/job_guard.py
@@ -12,8 +12,16 @@ This module supplies the two missing primitives, independent of any one job:
      either REFUSES (default) or REPLACES the incumbent. Stale locks left by a
      killed process are reclaimed automatically.
   2. MemoryCeiling — a watchdog thread that samples the guarded process tree's
-     RSS *and* system-available memory, and aborts the job CLEANLY (SIGTERM, then
-     SIGKILL after a grace period) before the machine starts thrashing.
+     ``phys_footprint``, the system-available memory, *and* the memory compressor,
+     and aborts the job CLEANLY (SIGTERM, then SIGKILL after a grace period)
+     before the machine starts thrashing.
+
+     The metric is footprint, NOT RSS (GH-219 Lane 4). RSS cannot see Metal/GPU
+     buffers, which are charged to phys_footprint as ``iokit``: on 2026-07-27 the
+     offending processes held ~46.9 GB of footprint while reporting ~0.08 GB RSS,
+     so an RSS-based guard ran 233 jobs and tripped zero times while the machine
+     fell to 0.09 GB free. Do not reintroduce RSS semantics here; RSS survives
+     only as a fallback where phys_footprint is unavailable, and says so when used.
 
 Deliberately stdlib-only (no psutil): this has to run under the system python3,
 inside launchd jobs, and inside the rebalance venv without an install step.
@@ -94,6 +102,29 @@ DEFAULT_MIN_AVAILABLE_FRACTION = 0.12
 #: Never let the available-memory floor drop below this absolute value.
 MIN_AVAILABLE_FLOOR = 4 * GIB
 
+#: Compressor size, as a fraction of RAM, above which the machine is treated as
+#: under real memory pressure regardless of how much memory looks "available".
+#:
+#: This is the signal that CONCLUDES the availability question for GH-219 Lane 4.
+#: Reclaimable-pages accounting (free+inactive+speculative) is retained as the
+#: availability numerator, because free-only accounting refuses jobs on a healthy
+#: Mac — but on its own it can look survivable while the compressor is saturating,
+#: which is the 2026-07-27 condition. The compressor is the direct measurement of
+#: that state and needs no inference.
+#:
+#: Sized from the recorded sampler data (sysmem-sys-*.csv, 07-26 and 07-27, 1602
+#: samples). The distribution is strongly BIMODAL — median 0.65–0.96 GB when
+#: healthy, 25–35 GB when in distress, with almost nothing between: the fraction
+#: of samples above 8 GB and above 24 GB is nearly identical (22.2% vs 21.6% on
+#: 07-26; 16.7% vs 14.8% on 07-27). That gap makes the exact threshold
+#: uncritical — any value in the empty middle classifies the same way — so 25% of
+#: RAM (16 GB on this machine) is chosen to sit as far from both modes as
+#: possible. Robustness here is a property of the data, not a lucky constant.
+DEFAULT_MAX_COMPRESSOR_FRACTION = 0.25
+
+#: Override for the compressor pressure ceiling, in GB.
+ENV_MAX_COMPRESSOR_GB = "REBALANCE_JOB_GUARD_MAX_COMPRESSOR_GB"
+
 #: Per-process ceiling override, in GB. The guard measures ``phys_footprint``
 #: (GH-219 Lane 4), so the setting is named for the metric it actually applies to.
 ENV_MAX_FOOTPRINT_GB = "REBALANCE_JOB_GUARD_MAX_FOOTPRINT_GB"
@@ -157,7 +188,7 @@ class InstanceConflict(GuardError):
 
 
 class MemoryCeilingExceeded(GuardError):
-    """The job tripped the RSS ceiling or the system-available floor."""
+    """The job tripped the footprint ceiling, the available floor, or compressor pressure."""
 
 
 class _Evicted(BaseException):
@@ -235,12 +266,19 @@ def available_memory_bytes() -> int:
         # Changing this numerator requires re-tuning DEFAULT_MIN_AVAILABLE_FRACTION
         # in the same edit; the two are one decision, not two.
         #
-        # Whether this definition is *sufficient* is still UNSETTLED, and cannot be
-        # settled from existing data: sysmem-sys-*.csv never recorded inactive/
-        # speculative columns, so the 07-27 crisis cannot be replayed against it.
-        # What the CSV does show is that compressor_gb (25–34 GB at crisis vs low
-        # when healthy) and swap_used_gb discriminate cleanly — those are the better
-        # pressure signal, and adding them is follow-up work, not a tuning tweak.
+        # DECISION (GH-219 Lane 4, concluded — not deferred): reclaimable-pages
+        # accounting is RETAINED here, and the gap it leaves is covered by a separate,
+        # direct pressure signal rather than by tightening this numerator.
+        #
+        # Rationale. This definition can look survivable while the machine is dying,
+        # which is the real objection to it. But narrowing it to free-only is strictly
+        # worse (it refuses every job on a healthy Mac), and it cannot be validated
+        # against history: sysmem-sys-*.csv never recorded inactive/speculative, so
+        # the 07-27 crisis cannot be replayed against any variant of this number.
+        # Rather than tune a metric that cannot be checked, the guard now also reads
+        # the memory compressor (see DEFAULT_MAX_COMPRESSOR_FRACTION), which IS
+        # recorded, IS strongly bimodal between healthy and crisis, and measures the
+        # dying-machine state directly instead of inferring it.
         wanted = ("Pages free:", "Pages inactive:", "Pages speculative:")
         for line in out.stdout.splitlines():
             for key in wanted:
@@ -279,6 +317,32 @@ class _RusageInfoV2(ctypes.Structure):
         ("ri_diskio_bytesread", ctypes.c_uint64),
         ("ri_diskio_byteswritten", ctypes.c_uint64),
     ]
+
+def compressor_bytes() -> int:
+    """Bytes held by the macOS memory compressor. 0 when undeterminable.
+
+    A saturating compressor is the most direct evidence that the machine is in
+    real trouble: it means the kernel is already paying CPU to avoid swapping.
+    Unlike "available" memory, it cannot look healthy while the machine dies.
+    """
+    if sys.platform != "darwin":
+        return 0
+    try:
+        out = subprocess.run(["vm_stat"], capture_output=True, text=True, timeout=5)
+    except (OSError, subprocess.SubprocessError):
+        return 0
+    if out.returncode != 0 or not out.stdout.strip():
+        return 0
+
+    header = re.search(r"page size of (\d+) bytes", out.stdout)
+    page_size = int(header.group(1)) if header else 4096
+    for line in out.stdout.splitlines():
+        if line.startswith("Pages occupied by compressor:"):
+            digits = line.split(":", 1)[1].strip().rstrip(".")
+            if digits.isdigit():
+                return int(digits) * page_size
+    return 0
+
 
 def tree_footprint_bytes(pid: int) -> tuple[int, bool, int]:
     """Resident memory (or phys_footprint on macOS) of ``pid`` plus every descendant.
@@ -547,12 +611,17 @@ def _terminate_group(pgid: int, grace: float) -> None:
 class MemoryCeiling:
     """Background watchdog that aborts a process tree before the machine dies.
 
-    Two independent trip conditions, because they catch different failures:
+    Three independent trip conditions, because they catch different failures:
 
-      * RSS ceiling — this job leaked or accumulated (GH-172 defects 2 and 3,
-        the ``out = [None] * len(texts)`` accumulation).
+      * ``phys_footprint`` ceiling — this job leaked or accumulated (GH-172
+        defects 2 and 3, the ``out = [None] * len(texts)`` accumulation; and
+        GH-219's MLX buffer-cache growth, which RSS could not see at all).
       * Available-memory floor — the *machine* is starved, whoever is at fault
         (GH-172 defect 1, stacked concurrent runs).
+      * Compressor pressure — the machine is already paying CPU to avoid
+        swapping. This catches the case the floor alone misses, where
+        reclaimable pages still look plentiful while the compressor saturates
+        (GH-219 Lane 4; the 2026-07-27 condition).
     """
 
     def __init__(
@@ -574,6 +643,15 @@ class MemoryCeiling:
         self.min_available = min_available_bytes or max(
             int(total * DEFAULT_MIN_AVAILABLE_FRACTION), MIN_AVAILABLE_FLOOR if total else 0
         ) or None
+        env_comp = os.environ.get(ENV_MAX_COMPRESSOR_GB, "").strip()
+        try:
+            self.max_compressor = (
+                int(float(env_comp) * GIB)
+                if env_comp
+                else int(total * DEFAULT_MAX_COMPRESSOR_FRACTION) or None
+            )
+        except ValueError:
+            self.max_compressor = int(total * DEFAULT_MAX_COMPRESSOR_FRACTION) or None
         self.poll_seconds = poll_seconds
         self.on_trip = on_trip
         self.log = log or (lambda msg: print(f"[job-guard] {msg}", file=sys.stderr))
@@ -589,6 +667,16 @@ class MemoryCeiling:
         and it is the check that turns a stacked run into a clean error instead
         of a kernel panic.
         """
+        # Compressor pressure first: it stays honest when "available" does not.
+        if self.max_compressor:
+            compressor = compressor_bytes()
+            if compressor and compressor > self.max_compressor:
+                raise MemoryCeilingExceeded(
+                    f"refusing to start: memory compressor holds "
+                    f"{_fmt_gb(compressor)}, ceiling is {_fmt_gb(self.max_compressor)} "
+                    f"(the machine is already under real pressure)"
+                )
+
         if not self.min_available:
             return
         available = available_memory_bytes()
@@ -625,6 +713,15 @@ class MemoryCeiling:
             return (
                 f"process tree holds {_fmt_gb(footprint)} {metric}, ceiling is {_fmt_gb(self.max_footprint)}{unr_msg}"
             )
+
+        if self.max_compressor:
+            compressor = compressor_bytes()
+            if compressor and compressor > self.max_compressor:
+                return (
+                    f"memory compressor holds {_fmt_gb(compressor)}, ceiling is "
+                    f"{_fmt_gb(self.max_compressor)} (this job {metric}: "
+                    f"{_fmt_gb(footprint)}{unr_msg})"
+                )
 
         available = available_memory_bytes()
         if self.min_available and available and available < self.min_available:

--- a/utils/job_guard.py
+++ b/utils/job_guard.py
@@ -82,9 +82,9 @@ LOCK_DIR = Path(
 
 #: Fraction of physical RAM a single guarded job may hold before it is aborted.
 #: The project contract specifies <= 8 GB peak phys_footprint per process, and
-#: <= 16 GB aggregate concurrent footprint. On a 64 GB machine, 16 GB is 25%.
-#: We size the default to 25% (0.25) to align with this contract.
-DEFAULT_MAX_FOOTPRINT_FRACTION = 0.25
+#: <= 16 GB aggregate concurrent footprint. On a 64 GB machine, 8 GB is 12.5%.
+#: We size the default to 12.5% (0.125) to align with the per-process contract.
+DEFAULT_MAX_FOOTPRINT_FRACTION = 0.125
 
 #: Abort if system-available memory falls below this fraction of physical RAM,
 #: regardless of how well-behaved *this* job is. This is the defence against
@@ -160,10 +160,9 @@ def total_memory_bytes() -> int:
 def available_memory_bytes() -> int:
     """Memory the OS could hand out without swapping. 0 when undeterminable.
 
-    On macOS this is free + inactive + speculative pages. Inactive pages are
-    reclaimable, so counting only ``free`` would report starvation on a healthy
-    machine and abort every job. Purgeable/compressed pages are excluded because
-    by the time they dominate, the compressor is already the problem.
+    On macOS this counts ONLY free pages. While inactive/speculative are reclaimable,
+    counting them can mask true memory pressure until the compressor is saturated.
+    Purgeable/compressed pages are also excluded.
     """
     if sys.platform == "darwin":
         try:

--- a/utils/job_guard.py
+++ b/utils/job_guard.py
@@ -199,9 +199,13 @@ def total_memory_bytes() -> int:
 def available_memory_bytes() -> int:
     """Memory the OS could hand out without swapping. 0 when undeterminable.
 
-    On macOS this counts ONLY free pages. While inactive/speculative are reclaimable,
-    counting them can mask true memory pressure until the compressor is saturated.
-    Purgeable/compressed pages are also excluded.
+    On macOS this counts free + inactive + speculative pages, all of which the
+    kernel can reclaim without swapping. Compressed pages are excluded.
+
+    A healthy Mac routinely runs with very little *free* memory — the OS uses RAM
+    for cache and lists it as inactive — so free alone is not a usable proxy for
+    availability here. See the comment in the implementation for the measurement
+    that settled this, and for why compressor/swap are the better pressure signal.
     """
     if sys.platform == "darwin":
         try:
@@ -219,7 +223,25 @@ def available_memory_bytes() -> int:
             page_size = int(header.group(1))
 
         pages = 0
-        wanted = ("Pages free:",)  # explicitly exclude inactive/speculative under pressure
+        # GH-219 Lane 4: free-ONLY accounting was tried here and REVERTED, measured.
+        # The theory (counting inactive/speculative masks pressure until the
+        # compressor saturates) is reasonable, but the implementation made the guard
+        # refuse to start on a perfectly healthy machine: with free=1.59 GB,
+        # inactive=21.46 GB, speculative=0.93 GB — i.e. ~24 GB genuinely reclaimable —
+        # free-only reported 1.58 GB against a 7.68 GB floor, so EVERY guarded job
+        # was refused. A safety mechanism that blocks legitimate work is one that
+        # gets switched off.
+        #
+        # Changing this numerator requires re-tuning DEFAULT_MIN_AVAILABLE_FRACTION
+        # in the same edit; the two are one decision, not two.
+        #
+        # Whether this definition is *sufficient* is still UNSETTLED, and cannot be
+        # settled from existing data: sysmem-sys-*.csv never recorded inactive/
+        # speculative columns, so the 07-27 crisis cannot be replayed against it.
+        # What the CSV does show is that compressor_gb (25–34 GB at crisis vs low
+        # when healthy) and swap_used_gb discriminate cleanly — those are the better
+        # pressure signal, and adding them is follow-up work, not a tuning tweak.
+        wanted = ("Pages free:", "Pages inactive:", "Pages speculative:")
         for line in out.stdout.splitlines():
             for key in wanted:
                 if line.startswith(key):

--- a/utils/job_guard.py
+++ b/utils/job_guard.py
@@ -94,6 +94,45 @@ DEFAULT_MIN_AVAILABLE_FRACTION = 0.12
 #: Never let the available-memory floor drop below this absolute value.
 MIN_AVAILABLE_FLOOR = 4 * GIB
 
+#: Per-process ceiling override, in GB. The guard measures ``phys_footprint``
+#: (GH-219 Lane 4), so the setting is named for the metric it actually applies to.
+ENV_MAX_FOOTPRINT_GB = "REBALANCE_JOB_GUARD_MAX_FOOTPRINT_GB"
+
+#: Deprecated alias, kept working so existing plists and docs do not silently
+#: stop applying when the metric was renamed RSS -> phys_footprint. Honoured with
+#: a warning; the footprint-named variable wins when both are set.
+ENV_MAX_FOOTPRINT_GB_DEPRECATED = "REBALANCE_JOB_GUARD_MAX_RSS_GB"
+
+
+def env_max_footprint_gb(warn=None) -> float | None:
+    """Resolve the per-process ceiling from the environment, or ``None``.
+
+    Prefers :data:`ENV_MAX_FOOTPRINT_GB`; falls back to the deprecated
+    RSS-named alias. A non-numeric value is reported and ignored rather than
+    crashing the job it was meant to protect.
+    """
+    warn = warn or (lambda msg: print(f"[job-guard] {msg}", file=sys.stderr))
+
+    for name, deprecated in (
+        (ENV_MAX_FOOTPRINT_GB, False),
+        (ENV_MAX_FOOTPRINT_GB_DEPRECATED, True),
+    ):
+        raw = os.environ.get(name, "").strip()
+        if not raw:
+            continue
+        try:
+            value = float(raw)
+        except ValueError:
+            warn(f"ignoring non-numeric {name}={raw!r}")
+            continue
+        if deprecated:
+            warn(
+                f"{name} is deprecated (the guard measures phys_footprint, not RSS); "
+                f"use {ENV_MAX_FOOTPRINT_GB}"
+            )
+        return value
+    return None
+
 DEFAULT_POLL_SECONDS = 5.0
 DEFAULT_GRACE_SECONDS = 20.0
 
@@ -703,8 +742,11 @@ def run_guarded(
 
     started = time.monotonic()
     try:
+        # Explicit argument wins; otherwise fall back to the environment so a
+        # plist can raise the ceiling without a code change (GH-219 Lane 4).
+        effective_gb = max_footprint_gb or max_rss_gb or env_max_footprint_gb(warn=log)
         ceiling = MemoryCeiling(
-            max_footprint_bytes=int((max_footprint_gb or max_rss_gb) * GIB) if (max_footprint_gb or max_rss_gb) else None,
+            max_footprint_bytes=int(effective_gb * GIB) if effective_gb else None,
             min_available_bytes=int(min_available_gb * GIB) if min_available_gb else None,
             poll_seconds=poll_seconds,
             log=log,

--- a/utils/job_guard.py
+++ b/utils/job_guard.py
@@ -57,6 +57,8 @@ Operator reference: UPGRADE.md § "Embedding job guard (GH-172)".
 from __future__ import annotations
 
 import argparse
+import ctypes
+import ctypes.util
 import errno
 import fcntl
 import json
@@ -79,7 +81,10 @@ LOCK_DIR = Path(
 )
 
 #: Fraction of physical RAM a single guarded job may hold before it is aborted.
-DEFAULT_MAX_RSS_FRACTION = 0.35
+#: The project contract specifies <= 8 GB peak phys_footprint per process, and
+#: <= 16 GB aggregate concurrent footprint. On a 64 GB machine, 16 GB is 25%.
+#: We size the default to 25% (0.25) to align with this contract.
+DEFAULT_MAX_FOOTPRINT_FRACTION = 0.25
 
 #: Abort if system-available memory falls below this fraction of physical RAM,
 #: regardless of how well-behaved *this* job is. This is the defence against
@@ -176,7 +181,7 @@ def available_memory_bytes() -> int:
             page_size = int(header.group(1))
 
         pages = 0
-        wanted = ("Pages free:", "Pages inactive:", "Pages speculative:")
+        wanted = ("Pages free:",)  # explicitly exclude inactive/speculative under pressure
         for line in out.stdout.splitlines():
             for key in wanted:
                 if line.startswith(key):
@@ -191,21 +196,43 @@ def available_memory_bytes() -> int:
     return 0
 
 
-def tree_rss_bytes(pid: int) -> int:
-    """Resident memory of ``pid`` plus every descendant, in bytes.
 
-    Uses ``ps`` rather than /proc so one implementation covers macOS and Linux.
-    A worker pool's memory lives in its children, so summing the tree is the
-    only measurement that would have caught the GH-172 blowup.
+class _RusageInfoV2(ctypes.Structure):
+    _fields_ = [
+        ("ri_uuid", ctypes.c_uint8 * 16),
+        ("ri_user_time", ctypes.c_uint64),
+        ("ri_system_time", ctypes.c_uint64),
+        ("ri_pkg_idle_wkups", ctypes.c_uint64),
+        ("ri_interrupt_wkups", ctypes.c_uint64),
+        ("ri_pageins", ctypes.c_uint64),
+        ("ri_wired_size", ctypes.c_uint64),
+        ("ri_resident_size", ctypes.c_uint64),
+        ("ri_phys_footprint", ctypes.c_uint64),
+        ("ri_proc_start_abstime", ctypes.c_uint64),
+        ("ri_proc_exit_abstime", ctypes.c_uint64),
+        ("ri_child_user_time", ctypes.c_uint64),
+        ("ri_child_system_time", ctypes.c_uint64),
+        ("ri_child_pkg_idle_wkups", ctypes.c_uint64),
+        ("ri_child_interrupt_wkups", ctypes.c_uint64),
+        ("ri_child_pageins", ctypes.c_uint64),
+        ("ri_child_elapsed_abstime", ctypes.c_uint64),
+        ("ri_diskio_bytesread", ctypes.c_uint64),
+        ("ri_diskio_byteswritten", ctypes.c_uint64),
+    ]
+
+def tree_footprint_bytes(pid: int) -> tuple[int, bool, int]:
+    """Resident memory (or phys_footprint on macOS) of ``pid`` plus every descendant.
+    
+    Returns: (total_bytes, is_fallback, unreadable_count)
     """
     try:
         out = subprocess.run(
             ["ps", "-eo", "pid=,ppid=,rss="], capture_output=True, text=True, timeout=10
         )
     except (OSError, subprocess.SubprocessError):
-        return 0
+        return 0, True, 0
     if out.returncode != 0:
-        return 0
+        return 0, True, 0
 
     children: dict[int, list[int]] = {}
     rss: dict[int, int] = {}
@@ -220,17 +247,44 @@ def tree_rss_bytes(pid: int) -> int:
         rss[this_pid] = kb * 1024
         children.setdefault(ppid, []).append(this_pid)
 
-    total = 0
     stack = [pid]
     seen: set[int] = set()
+    tree_pids = []
     while stack:
         current = stack.pop()
         if current in seen:
             continue
         seen.add(current)
-        total += rss.get(current, 0)
+        tree_pids.append(current)
         stack.extend(children.get(current, ()))
-    return total
+
+    is_fallback = True
+    total = 0
+    unreadable_count = 0
+
+    if sys.platform == "darwin":
+        try:
+            libc = ctypes.CDLL(ctypes.util.find_library("c"))
+            proc_pid_rusage = libc.proc_pid_rusage
+            proc_pid_rusage.argtypes = [ctypes.c_int, ctypes.c_int, ctypes.c_void_p]
+            proc_pid_rusage.restype = ctypes.c_int
+            is_fallback = False
+        except Exception:
+            pass
+            
+        if not is_fallback:
+            for p in tree_pids:
+                buf = _RusageInfoV2()
+                rc = proc_pid_rusage(p, 2, ctypes.byref(buf))
+                if rc == 0:
+                    total += buf.ri_phys_footprint
+                else:
+                    unreadable_count += 1
+            return total, False, unreadable_count
+    
+    for p in tree_pids:
+        total += rss.get(p, 0)
+    return total, True, unreadable_count
 
 
 def _fmt_gb(value: int) -> str:
@@ -444,16 +498,19 @@ class MemoryCeiling:
     def __init__(
         self,
         pid: int | None = None,
-        max_rss_bytes: int | None = None,
+        max_footprint_bytes: int | None = None,
         min_available_bytes: int | None = None,
         poll_seconds: float = DEFAULT_POLL_SECONDS,
         on_trip=None,
         log=None,
+        max_rss_bytes: int | None = None,
     ) -> None:
         total = total_memory_bytes()
         self.pid = pid or os.getpid()
         self.total = total
-        self.max_rss = max_rss_bytes or int(total * DEFAULT_MAX_RSS_FRACTION) or None
+        
+        ceiling = max_footprint_bytes or max_rss_bytes
+        self.max_footprint = ceiling or int(total * DEFAULT_MAX_FOOTPRINT_FRACTION) or None
         self.min_available = min_available_bytes or max(
             int(total * DEFAULT_MIN_AVAILABLE_FRACTION), MIN_AVAILABLE_FLOOR if total else 0
         ) or None
@@ -461,7 +518,7 @@ class MemoryCeiling:
         self.on_trip = on_trip
         self.log = log or (lambda msg: print(f"[job-guard] {msg}", file=sys.stderr))
         self.tripped_reason: str | None = None
-        self.peak_rss = 0
+        self.peak_footprint = 0
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
 
@@ -499,18 +556,21 @@ class MemoryCeiling:
                 return
 
     def _check(self) -> str | None:
-        rss = tree_rss_bytes(self.pid)
-        self.peak_rss = max(self.peak_rss, rss)
-        if self.max_rss and rss > self.max_rss:
+        footprint, is_fallback, unreadable = tree_footprint_bytes(self.pid)
+        self.peak_footprint = max(self.peak_footprint, footprint)
+        metric = "RSS (fallback)" if is_fallback else "phys_footprint"
+        unr_msg = f" (skipped {unreadable} unreadable pids)" if unreadable else ""
+
+        if self.max_footprint and footprint > self.max_footprint:
             return (
-                f"process tree holds {_fmt_gb(rss)}, ceiling is {_fmt_gb(self.max_rss)}"
+                f"process tree holds {_fmt_gb(footprint)} {metric}, ceiling is {_fmt_gb(self.max_footprint)}{unr_msg}"
             )
 
         available = available_memory_bytes()
         if self.min_available and available and available < self.min_available:
             return (
                 f"system available memory {_fmt_gb(available)} fell below "
-                f"floor {_fmt_gb(self.min_available)} (this job: {_fmt_gb(rss)})"
+                f"floor {_fmt_gb(self.min_available)} (this job {metric}: {_fmt_gb(footprint)}{unr_msg})"
             )
         return None
 
@@ -525,7 +585,7 @@ class MemoryCeiling:
 # In-process entry point
 # --------------------------------------------------------------------------- #
 
-def record_peak_rss(
+def record_peak_footprint(
     name: str,
     ceiling: "MemoryCeiling",
     *,
@@ -544,10 +604,10 @@ def record_peak_rss(
             "ts": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
             "job": name,
             "pid": os.getpid(),
-            "peak_rss_bytes": int(ceiling.peak_rss or 0),
-            "peak_rss_gb": round((ceiling.peak_rss or 0) / GIB, 3),
+            "peak_footprint_bytes": int(ceiling.peak_footprint or 0),
+            "peak_footprint_gb": round((ceiling.peak_footprint or 0) / GIB, 3),
             "total_memory_gb": round((ceiling.total or 0) / GIB, 1),
-            "max_rss_gb": round((ceiling.max_rss or 0) / GIB, 3) if ceiling.max_rss else None,
+            "max_footprint_gb": round((ceiling.max_footprint or 0) / GIB, 3) if ceiling.max_footprint else None,
             "tripped_reason": ceiling.tripped_reason,
             "exit_code": exit_code,
             "duration_s": round(time.monotonic() - started, 1) if started else None,
@@ -562,11 +622,12 @@ def record_peak_rss(
 @contextmanager
 def guard(
     name: str,
-    max_rss_gb: float | None = None,
+    max_footprint_gb: float | None = None,
     min_available_gb: float | None = None,
     on_conflict: str = "refuse",
     poll_seconds: float = DEFAULT_POLL_SECONDS,
     log=None,
+    max_rss_gb: float | None = None,
 ):
     """Guard the calling process: single-instance lock + memory ceiling.
 
@@ -579,7 +640,7 @@ def guard(
     lock.acquire(on_conflict=on_conflict)
 
     ceiling = MemoryCeiling(
-        max_rss_bytes=int(max_rss_gb * GIB) if max_rss_gb else None,
+        max_footprint_bytes=int((max_footprint_gb or max_rss_gb) * GIB) if (max_footprint_gb or max_rss_gb) else None,
         min_available_bytes=int(min_available_gb * GIB) if min_available_gb else None,
         poll_seconds=poll_seconds,
         log=log,
@@ -613,7 +674,7 @@ def guard(
             pass
         # Written on EVERY exit path — clean, raised, or ceiling-tripped. The
         # tripped run is precisely the one worth having a record of.
-        record_peak_rss(name, ceiling, started=started)
+        record_peak_footprint(name, ceiling, started=started)
         lock.release()
 
 
@@ -624,11 +685,12 @@ def guard(
 def run_guarded(
     name: str,
     argv: list[str],
-    max_rss_gb: float | None = None,
+    max_footprint_gb: float | None = None,
     min_available_gb: float | None = None,
     on_conflict: str = "refuse",
     poll_seconds: float = DEFAULT_POLL_SECONDS,
     grace_seconds: float = DEFAULT_GRACE_SECONDS,
+    max_rss_gb: float | None = None,
 ) -> int:
     """Run ``argv`` as a guarded child process. Returns the exit code."""
     log = lambda msg: print(f"[job-guard] {msg}", file=sys.stderr)  # noqa: E731
@@ -643,7 +705,7 @@ def run_guarded(
     started = time.monotonic()
     try:
         ceiling = MemoryCeiling(
-            max_rss_bytes=int(max_rss_gb * GIB) if max_rss_gb else None,
+            max_footprint_bytes=int((max_footprint_gb or max_rss_gb) * GIB) if (max_footprint_gb or max_rss_gb) else None,
             min_available_bytes=int(min_available_gb * GIB) if min_available_gb else None,
             poll_seconds=poll_seconds,
             log=log,
@@ -655,7 +717,7 @@ def run_guarded(
             return 4
 
         log(
-            f"starting {name!r}: rss ceiling {_fmt_gb(ceiling.max_rss or 0)}, "
+            f"starting {name!r}: footprint ceiling {_fmt_gb(ceiling.max_footprint or 0)}, "
             f"available floor {_fmt_gb(ceiling.min_available or 0)}"
         )
 
@@ -691,8 +753,8 @@ def run_guarded(
             except (ValueError, TypeError):
                 pass
 
-        log(f"{name!r} finished with exit {code}; peak tree RSS {_fmt_gb(ceiling.peak_rss)}")
-        record_peak_rss(name, ceiling, started=started, exit_code=code)
+        log(f"{name!r} finished with exit {code}; peak tree footprint {_fmt_gb(ceiling.peak_footprint)}")
+        record_peak_footprint(name, ceiling, started=started, exit_code=code)
         return 4 if ceiling.tripped_reason else code
     finally:
         lock.release()
@@ -745,9 +807,13 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--name", required=True, help="lock identity; same name = same lock")
     parser.add_argument(
+        "--max-footprint-gb", type=float, default=None,
+        help=f"abort above this tree footprint "
+             f"(default: {DEFAULT_MAX_FOOTPRINT_FRACTION:.0%} of RAM)".replace("%", "%%"),
+    )
+    parser.add_argument(
         "--max-rss-gb", type=float, default=None,
-        help=f"abort above this tree RSS "
-             f"(default: {DEFAULT_MAX_RSS_FRACTION:.0%} of RAM)".replace("%", "%%"),
+        help="DEPRECATED alias for --max-footprint-gb",
     )
     parser.add_argument(
         "--min-available-gb", type=float, default=None,
@@ -778,7 +844,10 @@ def main(argv: list[str] | None = None) -> int:
         print(f"total RAM: {_fmt_gb(total)}")
         print(f"available: {_fmt_gb(available_memory_bytes())}")
         if holder:
-            print(f"tree RSS:  {_fmt_gb(tree_rss_bytes(holder))}")
+            footprint, is_fallback, unr = tree_footprint_bytes(holder)
+            metric = "RSS (fallback)" if is_fallback else "phys_footprint"
+            unr_msg = f" (skipped {unr} unreadable)" if unr else ""
+            print(f"tree {metric}: {_fmt_gb(footprint)}{unr_msg}")
         return 0
 
     command = args.command
@@ -790,7 +859,7 @@ def main(argv: list[str] | None = None) -> int:
     return run_guarded(
         args.name,
         command,
-        max_rss_gb=args.max_rss_gb,
+        max_footprint_gb=args.max_footprint_gb, max_rss_gb=args.max_rss_gb,
         min_available_gb=args.min_available_gb,
         on_conflict=args.on_conflict,
         poll_seconds=args.poll_seconds,


### PR DESCRIPTION
Repairs the instrument that failed. On 2026-07-27 `job_guard.py` ran **233 jobs and tripped zero times** while the machine fell to 0.09 GB free, 28.99 GB compressor, 24.7/26 GB swap.

It failed structurally, not by mis-tuning: `tree_rss_bytes()` summed **RSS**, and the offending processes held ~46.9 GB of `phys_footprint` while reporting ~0.08 GB RSS. MLX's Metal buffers are charged as `iokit` to the footprint and are never counted in RSS. The guard was watching a number that physically cannot see this class of allocation.

Lane 2 fixed the specific MLX leak. This fixes the instrument, so the *next* memory bug — MLX or not — is caught by the system rather than by someone noticing Activity Monitor.

## Measured, not asserted

On real MLX Metal allocations:

| | Delta |
|---|---|
| `phys_footprint` (new) | **+0.327 GB** |
| `ps` RSS (old) | +0.013 GB |

**25×.**

## Three independent trip conditions

| Condition | Catches |
|---|---|
| `phys_footprint` ceiling | this job leaking, including GPU buffers RSS cannot see |
| Available-memory floor | the machine starved by anyone, incl. stacked runs |
| **Compressor pressure** | the machine already paying CPU to avoid swapping (the 07-27 state) |

Measurement uses `libproc`'s `proc_pid_rusage` via ctypes. Processes we cannot read return `-1` and are **skipped and counted, never treated as 0** — reading a runaway as zero is the exact blindness this removes. RSS survives only as a fallback, and says so in the failure message.

Ceiling re-sized 0.35 (RSS-era) → 0.125, enforcing the ≤8 GB per-process contract rather than the 16 GB aggregate cap.

## The availability decision, concluded

Free-only accounting was tried and **reverted**: on a healthy machine (free 1.59 GB but ~24 GB genuinely reclaimable) it reported 1.58 GB against a 7.68 GB floor and **refused every guarded job**. A safety mechanism that blocks legitimate work is one that gets switched off.

Reclaimable-pages accounting is retained, and the gap it leaves is covered by a direct compressor check rather than by tightening a metric that **cannot be validated** — `inactive_gb`/`speculative_gb` were never recorded, so no variant can be replayed against 07-27.

Compressor threshold sized from 1602 recorded samples. The distribution is **bimodal**: median 0.65–0.96 GB healthy vs 25–35 GB at crisis, with the fraction above 8 GB and above 24 GB nearly identical (22.2%/21.6%; 16.7%/14.8%). Almost nothing lands between the modes, so threshold robustness is a property of the data, not a lucky constant. Set at 25% of RAM, env-overridable.

## Testing

42 guard tests; full suite **1600 passed / 6 failed** — the same 6 pre-existing failures verified failing before this work. Tests pass from the repo root *and* from a foreign cwd.

Every new assertion was **mutation-checked**: the source was broken deliberately, the test confirmed failing, then restored. This lane and Lane 2 both produced tests that passed without proving anything — `assert code == 4` satisfied by the preflight without the child launching; counting `clear_cache()` calls against a mock whose cache never grew — so new assertions were not taken on trust.

Codex-approved on round 4, having found something substantive on all four passes.

## Not included

- Sampler `inactive_gb`/`speculative_gb` columns (`temp/` is gitignored). Three questions have now dead-ended on this missing data.
- Lanes 3, 5, 6, 7.
- Acceptance verification (a full waking day, ≥12 passes) has not yet run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)