### PR TITLE
10-day sweep: 10 bug fixes (GH-139,160,166,167,170,171,186,189,201,202)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,34 @@
+"""Root conftest.py — make pytest import THIS checkout's own ``src/`` tree.
+
+GH-170: the package is installed editable from wherever it was last
+``pip install -e``'d (see ``pyproject.toml``'s ``package-dir = {"" = "src"}``).
+Editable installs resolve via an absolute path baked into a ``.pth`` file in
+site-packages at install time. That means running ``pytest`` inside a linked
+git worktree would otherwise still import the ORIGINAL checkout's copy of
+``rebalance`` (whatever path was active when ``pip install -e .`` ran),
+even though a fully independent copy of ``rebalance`` sits right next to
+this very file. A green suite in a worktree would then prove nothing about
+that worktree's own changes.
+
+Fix: prepend this repo's own ``src/`` directory to ``sys.path`` before any
+test module gets a chance to ``import rebalance``. Python resolves imports by
+walking ``sys.path`` in order and using the first match, so this local
+``src/`` always wins over whatever is installed editable in site-packages —
+regardless of which checkout that editable install happens to point at.
+
+This is a path-resolution shim only. It does not change ``pyproject.toml``'s
+package layout and has no effect outside of test collection.
+"""
+
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parent / "src"
+
+if _SRC.is_dir():
+    _src_str = str(_SRC)
+    # De-dupe first so this ends up at index 0 even if something upstream
+    # (e.g. an editable install of THIS SAME checkout) already added it.
+    if _src_str in sys.path:
+        sys.path.remove(_src_str)
+    sys.path.insert(0, _src_str)

--- a/scripts/github_sync.sh
+++ b/scripts/github_sync.sh
@@ -23,7 +23,7 @@ log "=== rebalance hourly github sync starting ==="
 # unattended. It does NOT need the GitHub token — a github error won't skip it
 # (refresh_index runs each scope independently), and the non-blocking page from
 # PR #72 is untouched (this is the background writer the page reads from).
-if "$PYTHON" - <<'PY' >> "$LOG_FILE" 2>&1
+if rb_run_python_stdin <<'PY' >> "$LOG_FILE" 2>&1
 import json
 import sys
 from rebalance.ingest.index_ops import refresh_index

--- a/scripts/health_issue_reporter.py
+++ b/scripts/health_issue_reporter.py
@@ -12,8 +12,14 @@ the full check results, every LLM call + response, and every GitHub action taken
 
 De-duplication
 --------------
-Issues are matched by stable title (``health: <check-name>``).
-- Already **open**: skip silently.
+Issues are matched by a stable check id (``Check.name`` from the doctor
+registry — see ``run_doctor_checks()``), not by the GitHub issue *title*.
+The id is embedded as a hidden ``<!-- health-check-id: ... -->`` marker in
+the issue body at file time, so a human retitling the issue on GitHub (or a
+future change to ``ISSUE_TITLE_PREFIX``) can no longer orphan it. Issues
+filed before this marker existed are still matched by parsing the check name
+out of their title (GH-139 legacy fallback) — see ``dedup_key_for_issue()``.
+- Already **open**: refresh the Detail block and bump the occurrence counter.
 - Recently **closed** (within --dedup-days, default 30): add a comment noting
   the recurrence instead of opening a new issue.
 - Older closed / never filed: file a new issue.
@@ -233,7 +239,7 @@ def list_health_issues(token: str, repo: str, state: str = "open",
         if not isinstance(results, list) or not results:
             break
         for issue in results:
-            issues[issue["title"]] = issue
+            issues[dedup_key_for_issue(issue)] = issue
         page += 1
     return issues
 
@@ -292,6 +298,78 @@ def set_occurrence_count(body: str, count: int, last_seen: str,
     return new_line + (body or "")
 
 
+# ---------------------------------------------------------------------------
+# Issue body — Detail block refresh
+#
+# _issue_body() writes the finding's Detail as a fenced code block:
+#   **Detail:**
+#   ```
+#   <detail text>
+#   ```
+#
+# Previously only set_occurrence_count() ran on a repeat sighting, so a
+# changed root-cause message on re-fire never reached the issue (GH-139).
+# set_detail() rewrites that block in place; everything else in the body
+# (title, status line, hint, footer, occurrence counter, check-id marker)
+# is left untouched.
+# ---------------------------------------------------------------------------
+
+_DETAIL_RE = re.compile(r"\*\*Detail:\*\*\n```\n.*?\n```", re.DOTALL)
+
+
+def set_detail(body: str, detail: str) -> str:
+    if not _DETAIL_RE.search(body or ""):
+        return body
+    replacement = f"**Detail:**\n```\n{detail}\n```"
+    return _DETAIL_RE.sub(lambda _m: replacement, body, count=1)
+
+
+# ---------------------------------------------------------------------------
+# Issue body — stable check-id marker (GH-139)
+#
+# Dedup used to key off the rendered GitHub issue *title*
+# (``f"{ISSUE_TITLE_PREFIX} {check['name']}"``), matched via exact string
+# equality against ``issue["title"]``. That title is mutable — a human can
+# retitle the issue on GitHub, or a future edit to ISSUE_TITLE_PREFIX (or to
+# a check's own registry name) changes the computed string — and either one
+# silently orphans the existing issue and files a duplicate under the new
+# title.
+#
+# Instead, every issue this script files carries a hidden marker line
+# embedding the check's stable registry id (``Check.name`` — see
+# ``run_doctor_checks()``, already the identifier used throughout the doctor
+# check registry, independent of any GitHub-side display text):
+#   <!-- health-check-id: <check-name> -->
+#
+# dedup_key_for_issue() reads that marker first. Issues filed before this
+# marker existed (e.g. the pre-GH-139 pulse-collector duplicates, #46-48 and
+# #83-85) have no marker, so it falls back to parsing the check name out of
+# the title — preserving today's matching behavior for those legacy issues
+# rather than re-duplicating or auto-touching them.
+# ---------------------------------------------------------------------------
+
+_CHECK_ID_RE = re.compile(r"^<!-- health-check-id: (.+?) -->\n?", re.MULTILINE)
+
+
+def check_id_marker(check_id: str) -> str:
+    return f"<!-- health-check-id: {check_id} -->\n"
+
+
+def parse_check_id(body: str) -> str | None:
+    m = _CHECK_ID_RE.search(body or "")
+    return m.group(1).strip() if m else None
+
+
+def dedup_key_for_issue(issue: dict) -> str:
+    """Stable dedup key for an existing GitHub issue — see module docstring."""
+    check_id = parse_check_id(issue.get("body") or "")
+    if check_id:
+        return check_id
+    title = issue.get("title") or ""
+    prefix = f"{ISSUE_TITLE_PREFIX} "
+    return title[len(prefix):] if title.startswith(prefix) else title
+
+
 def update_issue_body(
     token: str, repo: str, number: int, new_body: str, dry_run: bool
 ) -> None:
@@ -309,6 +387,7 @@ def _issue_body(check_name: str, status: str, detail: str, hint: str, source: st
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     parts = [
         f"> **Seen:** 1× · Last: {now} · Device: {DEVICE_NAME}\n",
+        check_id_marker(check_name),
         f"## Rebalance health: `{check_name}`\n",
         f"**Status:** `{status.upper()}`  ",
         f"**Detected:** {now}  ",
@@ -609,16 +688,20 @@ def main() -> int:
     llm_calls_this_run = 0
 
     for check in checks:
-        title = f"{ISSUE_TITLE_PREFIX} {check['name']}"
-        already_open = open_issues.get(title)
-        recently_was_closed = recently_closed.get(title)
+        check_id = check["name"]  # stable, registry-level id — see run_doctor_checks()
+        title = f"{ISSUE_TITLE_PREFIX} {check_id}"
+        already_open = open_issues.get(check_id)
+        recently_was_closed = recently_closed.get(check_id)
 
         if check["status"] in min_level:
             if already_open:
-                # Increment the occurrence counter in the issue body.
+                # Refresh the Detail block, then increment the occurrence
+                # counter in the issue body (GH-139: Detail used to go stale
+                # forever after the first sighting).
                 current_body = already_open.get("body") or ""
-                new_count = parse_occurrence_count(current_body) + 1
-                new_body = set_occurrence_count(current_body, new_count, now_str,
+                refreshed_body = set_detail(current_body, check["detail"])
+                new_count = parse_occurrence_count(refreshed_body) + 1
+                new_body = set_occurrence_count(refreshed_body, new_count, now_str,
                                                 device=DEVICE_NAME)
                 update_issue_body(token, args.repo, already_open["number"], new_body, args.dry_run)
                 print(f"  SEEN×{new_count:<3} {check['status'].upper():4}  {check['name']}  "

--- a/scripts/lib/scheduler_common.sh
+++ b/scripts/lib/scheduler_common.sh
@@ -71,3 +71,60 @@ rb_job_init() {
 rb_trim_logs() {
     find "$LOG_DIR" -name "${RB_LOG_PREFIX}_*.log" -mtime "+$RB_LOG_RETENTION_DAYS" -delete 2>/dev/null || true
 }
+
+# --- GH-186: transient interpreter-bootstrap EINTR retry -------------------
+#
+# A rare macOS/CPython bug: during interpreter bootstrap (inside frozen
+# modules like <frozen getpath>, before any application code has run) a
+# signal interrupts a syscall and raises an uncaught
+# `InterruptedError: [Errno 4] Interrupted system call`, killing the process
+# before main() starts. This is a transient startup race, not an application
+# failure, and it has been observed across multiple scheduled jobs
+# (github-sync, pulse-warning-watch, pulse_server, vault_sync) that all
+# invoke `$PYTHON` via this shared runtime — so the retry lives here once,
+# not per-wrapper.
+#
+# Detection is intentionally narrow (both substrings must be present) so a
+# real application-level InterruptedError, or any other non-zero exit, is
+# never retried/masked — only this specific bootstrap crash signature is.
+RB_PY_EINTR_MAX_RETRIES="${RB_PY_EINTR_MAX_RETRIES:-2}"
+
+_rb_is_bootstrap_eintr() {
+    grep -q '<frozen getpath>' "$1" 2>/dev/null \
+        && grep -q 'InterruptedError: \[Errno 4\] Interrupted system call' "$1" 2>/dev/null
+}
+
+# rb_run_python_stdin
+# Drop-in replacement for `"$PYTHON" - <<'PY' ... PY`: reads a python script
+# from stdin (the heredoc) and runs it via $PYTHON, retrying up to
+# RB_PY_EINTR_MAX_RETRIES times ONLY when the failure matches the transient
+# interpreter-bootstrap EINTR signature above. Any other non-zero exit
+# (real application errors/exceptions) is returned immediately, unretried,
+# so a genuine failure is never silently masked as a "success after retry".
+# Output from every attempt (including a failed retry) is emitted on stdout
+# so it still lands wherever the caller redirected, e.g. `>> "$LOG_FILE"`.
+rb_run_python_stdin() {
+    local script capture attempt=0 code
+    script="$(mktemp "${TMPDIR:-/tmp}/rb_py_src.XXXXXX")"
+    capture="$(mktemp "${TMPDIR:-/tmp}/rb_py_out.XXXXXX")"
+    cat > "$script"
+    while :; do
+        if "$PYTHON" "$script" > "$capture" 2>&1; then
+            code=0
+        else
+            code=$?
+        fi
+        cat "$capture"
+        if [ "$code" -eq 0 ]; then
+            rm -f "$script" "$capture"
+            return 0
+        fi
+        if [ "$attempt" -lt "$RB_PY_EINTR_MAX_RETRIES" ] && _rb_is_bootstrap_eintr "$capture"; then
+            attempt=$((attempt + 1))
+            echo "[$(date '+%Y-%m-%d %H:%M:%S')] transient interpreter-bootstrap EINTR on python startup, retrying (attempt $attempt/$RB_PY_EINTR_MAX_RETRIES)..." >&2
+            continue
+        fi
+        rm -f "$script" "$capture"
+        return "$code"
+    done
+}

--- a/scripts/pulse_web.py
+++ b/scripts/pulse_web.py
@@ -1035,7 +1035,7 @@ def render_repo_pie(
     </section>
     """
 
-    labels = [r.get("repo_full_name") or "" for r in rows]
+    labels = [(r.get("repo_full_name") or "").split("/")[-1] for r in rows]
     values = [int(r.get("events") or 0) for r in rows]
     colors = [PIE_PALETTE[i % len(PIE_PALETTE)] for i in range(len(rows))]
     total = sum(values)

--- a/src/rebalance/doctor.py
+++ b/src/rebalance/doctor.py
@@ -19,7 +19,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, Literal
 
-from rebalance.tz_utils import local_tz
+from rebalance.tz_utils import format_timestamp, local_tz
 
 OK = "ok"
 WARN = "warn"
@@ -1188,10 +1188,8 @@ def _check_pulse_collectors(*, current_device_id: str | None = None) -> list[Che
 
         if health.age_hours is None:
             age = "never pushed"
-        elif health.age_hours >= 24:
-            age = f"last scan {health.age_hours / 24:.1f}d ago"
         else:
-            age = f"last scan {health.age_hours:.1f}h ago"
+            age = f"last scan {format_timestamp(health.last_scan_utc, relative=True)}"
         healthy = health.healthy
         state = health.state
         # A laptop's upstream classifier intentionally uses the fleet's 3h

--- a/src/rebalance/doctor.py
+++ b/src/rebalance/doctor.py
@@ -11,6 +11,7 @@ projects, GitHub data freshness, the credentials for each external integration
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import subprocess
@@ -732,6 +733,37 @@ def _daily_sync_launchd_check(
     )
 
 
+# A single `launchctl list` snapshot only ever shows the *current* PID and the
+# *last* exit status — it cannot tell a one-off crash from a KeepAlive job that
+# launchd is repeatedly respawning (GH-160). Detecting a loop needs memory
+# across polls, so recent crash-relaunch events are persisted to disk here and
+# consulted on the next `doctor` run.
+_LAUNCHD_CRASH_LOOP_LOOKBACK_S = 15 * 60  # 15 minutes
+_LAUNCHD_CRASH_LOOP_THRESHOLD = 2  # >=2 crash-relaunches in the window == looping
+
+
+def _launchd_crash_state_path(log_dir: Path) -> Path:
+    return log_dir / "launchd_crash_state.json"
+
+
+def _load_launchd_crash_state(path: Path) -> dict:
+    """Load persisted per-label crash-relaunch history; missing/corrupt -> empty."""
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    return raw if isinstance(raw, dict) else {}
+
+
+def _save_launchd_crash_state(path: Path, state: dict) -> None:
+    """Best-effort persist; a write failure must never break `doctor`."""
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(state), encoding="utf-8")
+    except OSError:
+        pass
+
+
 def _check_launchd(
     launchctl_output: str | None = None,
     *,
@@ -742,7 +774,10 @@ def _check_launchd(
 
     ``daily-sync`` has a richer, recent JSON outcome which supersedes its sticky
     launchctl exit status. Other jobs have no comparable result contract and keep
-    the historical launchctl-only assessment.
+    the historical launchctl-only assessment, with one addition (GH-160): a job
+    whose live PID keeps changing identity across polls while each exit is a
+    genuine crash (positive, non-signal) is a KeepAlive crash loop and WARNs
+    even though its current PID is live.
     """
     if launchctl_output is None:
         launchctl_output = _launchctl_list()
@@ -757,6 +792,10 @@ def _check_launchd(
         except RuntimeError:
             log_dir = Path("temp/logs")
     now = now or datetime.now(timezone.utc)
+
+    crash_state_path = _launchd_crash_state_path(log_dir)
+    crash_state = _load_launchd_crash_state(crash_state_path)
+    state_dirty = False
 
     checks: list[Check] = []
     for line in launchctl_output.splitlines():
@@ -787,8 +826,45 @@ def _check_launchd(
             pass
 
         is_ok_status = status_val in ("0", "-") or is_negative_signal
+        # A genuine crash exit: live now, but the exit that produced this
+        # snapshot was neither clean (0) nor a signal (GH-146 Root cause B).
+        is_crash_exit = has_live_pid and not is_ok_status
 
-        if has_live_pid or is_ok_status:
+        label_key = label.strip()
+        entry = crash_state.get(label_key, {})
+        prior_pid = entry.get("last_pid")
+        crash_events = [
+            t
+            for t in entry.get("crash_events", ())
+            if isinstance(t, (int, float))
+            and now.timestamp() - t <= _LAUNCHD_CRASH_LOOP_LOOKBACK_S
+        ]
+
+        # A crash-relaunch happened between the last poll and this one when the
+        # live PID's identity changed (launchd respawned it) and this exit was
+        # a genuine crash. The very first observation of a label has no prior
+        # PID to compare against, so a single positive exit next to a live PID
+        # never counts on its own (GH-146: not every non-zero exit is a crash
+        # loop) — only a *repeated* crash-relaunch pattern does (GH-160).
+        if is_crash_exit and prior_pid is not None and prior_pid != pid_val:
+            crash_events.append(now.timestamp())
+
+        crash_state[label_key] = {"last_pid": pid_val, "crash_events": crash_events}
+        state_dirty = True
+
+        is_crash_looping = len(crash_events) >= _LAUNCHD_CRASH_LOOP_THRESHOLD
+
+        if is_crash_looping:
+            checks.append(
+                Check(
+                    f"launchd:{short}", WARN,
+                    f"crash-looping: {len(crash_events)} crash-relaunches in the "
+                    f"last {_LAUNCHD_CRASH_LOOP_LOOKBACK_S // 60}m despite a live PID",
+                    "inspect temp/logs/ for this job's error output — it is being "
+                    "relaunched immediately after each crash",
+                )
+            )
+        elif has_live_pid or is_ok_status:
             running = "running" if has_live_pid else "idle, last run ok"
             checks.append(
                 Check(f"launchd:{short}", OK, running, severity=NOTICE)
@@ -801,6 +877,10 @@ def _check_launchd(
                     "inspect temp/logs/ for this job's error output",
                 )
             )
+
+    if state_dirty:
+        _save_launchd_crash_state(crash_state_path, crash_state)
+
     return checks
 
 

--- a/src/rebalance/ingest/github_knowledge.py
+++ b/src/rebalance/ingest/github_knowledge.py
@@ -35,6 +35,11 @@ from rebalance.ingest.embedder import (
 from rebalance.ingest.semantic_index import sync_github_documents
 DEFAULT_SYNC_DAYS = 90
 MIN_EMBED_CHARS = 40
+# GH-171: release the single SQLite writer periodically during a long persist
+# loop instead of holding one write transaction for the whole sync. Mirrors
+# the batch size GH-169's commit-history backfill already established
+# (see github_commit_backfill.py's _COMMIT_BATCH).
+_COMMIT_BATCH = 100
 _CLOSES_RE = re.compile(r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b", re.IGNORECASE)
 _ISSUE_REF_RE = re.compile(r"(?<![/\w])#(\d+)\b")
 
@@ -392,11 +397,63 @@ def sync_github_repo(
         direction="desc",
     )
 
+    # --- Fetch phase (GH-171) ---
+    # Pull every per-issue and per-PR payload (comments, reviews, review
+    # comments, commits, check-runs) from the GitHub API here, before any
+    # write transaction opens. Previously all of this fetching happened
+    # *inside* the `with db_connection(...)` block below, so the write
+    # transaction spanned the full network walk — worst case ~49 minutes per
+    # GH-146 — holding the single SQLite writer for the entire run and giving
+    # every other writer a bare "database is locked". What is fetched and how
+    # is unchanged; only the transaction boundary moves.
+    issue_payloads: list[tuple[dict[str, Any], list[dict[str, Any]]]] = []
+    for issue in issues:
+        item_number = int(issue["number"])
+        issue_comments = _paginate_list(f"{repo_base}/issues/{item_number}/comments", api_get)
+        issue_payloads.append((issue, issue_comments))
+
+    pr_payloads: list[
+        tuple[
+            dict[str, Any],
+            list[dict[str, Any]],
+            list[dict[str, Any]],
+            list[dict[str, Any]],
+            list[dict[str, Any]],
+            list[dict[str, Any]],
+        ]
+    ] = []
+    for pull_summary in pull_summaries:
+        item_number = int(pull_summary["number"])
+        pr = api_get(f"{repo_base}/pulls/{item_number}")
+        if not isinstance(pr, dict):
+            continue
+
+        pr_issue_comments = _paginate_list(f"{repo_base}/issues/{item_number}/comments", api_get)
+        pr_reviews = _paginate_list(f"{repo_base}/pulls/{item_number}/reviews", api_get)
+        pr_review_comments = _paginate_list(f"{repo_base}/pulls/{item_number}/comments", api_get)
+        pr_commits = _paginate_list(f"{repo_base}/pulls/{item_number}/commits", api_get)
+        check_runs_resp = api_get(_build_url(f"{repo_base}/commits/{pr.get('head', {}).get('sha', '')}/check-runs", per_page=100))
+        pr_check_runs = (
+            check_runs_resp.get("check_runs", [])
+            if isinstance(check_runs_resp, dict)
+            else []
+        )
+        pr_payloads.append(
+            (pr, pr_issue_comments, pr_reviews, pr_review_comments, pr_commits, pr_check_runs)
+        )
+
     comments_synced = 0
     commits_synced = 0
     checks_synced = 0
     docs_built = 0
+    persisted_records = 0
 
+    # --- Persist phase (GH-171) ---
+    # Everything below is a local DB write against already-fetched data. The
+    # write transaction is batch-committed every _COMMIT_BATCH records
+    # (mirrors GH-169's commit-history backfill pattern in
+    # github_commit_backfill.py) so a long sync releases the SQLite writer
+    # periodically instead of holding it for the whole run.
     with db_connection(database_path, ensure_github_schema) as conn:
         gh.delete_repo_table(conn, "github_branches", repo_full_name)
         gh.delete_repo_table(conn, "github_labels", repo_full_name)
@@ -480,7 +537,7 @@ def sync_github_repo(
                 ),
             )
 
-        for issue in issues:
+        for issue, issue_comments in issue_payloads:
             item_type = "issue"
             item_number = int(issue["number"])
             milestone = issue.get("milestone") or {}
@@ -526,7 +583,6 @@ def sync_github_repo(
 
             gh.upsert_item(conn, item_record)
 
-            issue_comments = _paginate_list(f"{repo_base}/issues/{item_number}/comments", api_get)
             for comment in issue_comments:
                 body = comment.get("body", "") or ""
                 gh.upsert_comment(
@@ -579,23 +635,15 @@ def sync_github_repo(
                 )
                 docs_built += 1
 
-        for pull_summary in pull_summaries:
-            item_type = "pull_request"
-            item_number = int(pull_summary["number"])
-            pr = api_get(f"{repo_base}/pulls/{item_number}")
-            if not isinstance(pr, dict):
-                continue
+            # GH-171: release the writer periodically instead of holding one
+            # transaction across the entire issue+PR persist loop.
+            persisted_records += 1
+            if persisted_records % _COMMIT_BATCH == 0:
+                conn.commit()
 
-            issue_comments = _paginate_list(f"{repo_base}/issues/{item_number}/comments", api_get)
-            reviews = _paginate_list(f"{repo_base}/pulls/{item_number}/reviews", api_get)
-            review_comments = _paginate_list(f"{repo_base}/pulls/{item_number}/comments", api_get)
-            commits = _paginate_list(f"{repo_base}/pulls/{item_number}/commits", api_get)
-            check_runs_resp = api_get(_build_url(f"{repo_base}/commits/{pr.get('head', {}).get('sha', '')}/check-runs", per_page=100))
-            check_runs = (
-                check_runs_resp.get("check_runs", [])
-                if isinstance(check_runs_resp, dict)
-                else []
-            )
+        for pr, issue_comments, reviews, review_comments, commits, check_runs in pr_payloads:
+            item_type = "pull_request"
+            item_number = int(pr["number"])
             milestone = pr.get("milestone") or {}
             gh.delete_item_children(conn, repo_full_name, item_type, item_number)
 
@@ -829,6 +877,11 @@ def sync_github_repo(
                     fetched_at=fetched_at,
                 )
                 docs_built += 1
+
+            # GH-171: same periodic-release batching as the issue loop above.
+            persisted_records += 1
+            if persisted_records % _COMMIT_BATCH == 0:
+                conn.commit()
 
         ensure_semantic_schema(conn)
         sync_github_documents(conn, repo_full_name=repo_full_name)

--- a/src/rebalance/ingest/index_ops.py
+++ b/src/rebalance/ingest/index_ops.py
@@ -710,14 +710,35 @@ def get_index_status(database_path: Path) -> dict[str, Any]:
             drift["vault_chunks_missing_from_semantic"] = None
 
         try:
-            gh_drift = conn.execute(
-                """
-                SELECT COUNT(*) FROM github_documents gd
-                LEFT JOIN semantic_documents sd
-                  ON sd.source_type = 'github' AND sd.source_pk = gd.source_key
-                WHERE sd.id IS NULL
-                """
-            ).fetchone()[0]
+            # GH-167: mirror the ignored-repo exclusion that
+            # ``github_documents_for_semantic()`` applies to the projection
+            # itself. Without this, a doc in an ignored repo is correctly never
+            # projected but still counts as "missing" here forever — a
+            # permanent false-positive drift reading, not a real gap.
+            from rebalance.ingest.config import get_github_ignored_repos
+
+            ignored_repos = sorted(get_github_ignored_repos())
+            if ignored_repos:
+                placeholders = ", ".join("?" for _ in ignored_repos)
+                gh_drift = conn.execute(
+                    f"""
+                    SELECT COUNT(*) FROM github_documents gd
+                    LEFT JOIN semantic_documents sd
+                      ON sd.source_type = 'github' AND sd.source_pk = gd.source_key
+                    WHERE sd.id IS NULL
+                      AND LOWER(gd.repo_full_name) NOT IN ({placeholders})
+                    """,
+                    ignored_repos,
+                ).fetchone()[0]
+            else:
+                gh_drift = conn.execute(
+                    """
+                    SELECT COUNT(*) FROM github_documents gd
+                    LEFT JOIN semantic_documents sd
+                      ON sd.source_type = 'github' AND sd.source_pk = gd.source_key
+                    WHERE sd.id IS NULL
+                    """
+                ).fetchone()[0]
             drift["github_documents_missing_from_semantic"] = int(gh_drift)
         except Exception:
             drift["github_documents_missing_from_semantic"] = None

--- a/src/rebalance/ingest/index_ops.py
+++ b/src/rebalance/ingest/index_ops.py
@@ -191,8 +191,36 @@ def _safe_count_where(conn: Any, table: str, where: str) -> int | None:
         return None
 
 
+# GH-166: how far behind the vault writer the ingester is allowed to drift
+# before signal_health.vault trips, in minutes. com.rebalance-os.vault-sync
+# runs hourly (:15 past the hour); a healthy install clears any edit within
+# that same run, well under the 60-minute cadence. 2x cadence (missed one
+# full cycle) warns; 3x cadence (missed two) degrades. Both are still far
+# tighter than the old 7-day freshness window, which never caught the
+# ~51-90 minute drift this fixes (#166).
+_VAULT_INGEST_LAG_WARN_MINUTES = 120
+_VAULT_INGEST_LAG_DEGRADED_MINUTES = 180
+
+# GH-166: a semantic_documents row still pending embed past this many minutes
+# is flagged "stuck" rather than counted as an in-flight run's normal tail.
+# See the comment at the pending-embed drift computation in get_index_status
+# for why 30 minutes is well past a healthy run's expected completion time.
+_PENDING_EMBED_STUCK_MINUTES = 30
+
 _SIGNAL_HEALTH_RULES: dict[str, dict[str, Any]] = {
-    "vault": {"freshness_key": "last_ingested_at", "window_days": 7, "zero_status": "degraded"},
+    "vault": {
+        "freshness_key": "last_ingested_at",
+        "window_days": 7,
+        "zero_status": "degraded",
+        # GH-166: a fresh last_ingested_at only proves *some* ingest ran
+        # recently — it says nothing about whether the writer has since
+        # moved further ahead. lag_key names a computed field on the
+        # source payload (last_modified_in_vault - last_ingested_at) that
+        # this rule's warn/degraded minutes are checked against below.
+        "lag_key": "ingest_lag_minutes",
+        "lag_warn_minutes": _VAULT_INGEST_LAG_WARN_MINUTES,
+        "lag_degraded_minutes": _VAULT_INGEST_LAG_DEGRADED_MINUTES,
+    },
     "github": {
         "freshness_key": "activity_last_scanned_at",
         "window_days": 7,
@@ -276,6 +304,29 @@ def _parse_status_timestamp(raw: Any) -> datetime | None:
         except ValueError:
             continue
     return None
+
+
+def _vault_ingest_lag_minutes(last_modified_in_vault: Any, last_ingested_at: Any) -> float | None:
+    """Minutes the ingester is behind the vault writer, clamped to >= 0.
+
+    None when either timestamp is missing or unparseable — the caller
+    already surfaces a missing-timestamp verdict via the freshness check,
+    so this stays silent rather than inventing a number.
+    """
+    modified = _parse_status_timestamp(last_modified_in_vault)
+    ingested = _parse_status_timestamp(last_ingested_at)
+    if modified is None or ingested is None:
+        return None
+    lag = (modified - ingested).total_seconds() / 60
+    return max(0.0, lag)
+
+
+def _minutes_since(raw_timestamp: Any, now: datetime) -> float | None:
+    """Minutes between *now* and *raw_timestamp*, or None if unparseable."""
+    ts = _parse_status_timestamp(raw_timestamp)
+    if ts is None:
+        return None
+    return (now - ts).total_seconds() / 60
 
 
 def _source_total_rows(source_name: str, source_payload: dict[str, Any]) -> int:
@@ -366,6 +417,35 @@ def _derive_signal_health(sources: dict[str, dict[str, Any]]) -> dict[str, dict[
                     status_entry = {
                         "status": zero_status,
                         "reason": "freshness timestamp is current but 0 rows landed in the last 7d",
+                    }
+
+        # GH-166 ingest-lag override: last_ingested_at can be fresh (a sync
+        # ran recently) while the vault writer has still moved further
+        # ahead than the ingester has caught up to. Only overrides an
+        # otherwise-ok verdict — a source already flagged warn/degraded by
+        # freshness/zero-rows above keeps that verdict and reason, same
+        # precedence rule the content-quality override below follows.
+        lag_key = rule.get("lag_key")
+        if lag_key and status_entry["status"] == "ok":
+            lag_minutes = source_payload.get(lag_key)
+            if isinstance(lag_minutes, (int, float)):
+                degraded_after = rule.get("lag_degraded_minutes")
+                warn_after = rule.get("lag_warn_minutes")
+                if degraded_after is not None and lag_minutes > degraded_after:
+                    status_entry = {
+                        "status": "degraded",
+                        "reason": (
+                            f"ingest is {round(lag_minutes)}m behind the vault "
+                            f"writer (threshold {degraded_after}m)"
+                        ),
+                    }
+                elif warn_after is not None and lag_minutes > warn_after:
+                    status_entry = {
+                        "status": "warn",
+                        "reason": (
+                            f"ingest is {round(lag_minutes)}m behind the vault "
+                            f"writer (threshold {warn_after}m)"
+                        ),
                     }
 
         # GH-127 content-quality override: rows can be structurally valid
@@ -466,6 +546,14 @@ def get_index_status(database_path: Path) -> dict[str, Any]:
                 conn, "vault_files", "julianday(last_modified) >= julianday('now', '-7 days')"
             ) or 0,
         }
+        # GH-166: how far the ingester is behind the vault writer, in minutes.
+        # Positive means the newest edit on disk hasn't been ingested yet;
+        # clamped at 0 so a normal ingest-after-edit ordering never reports a
+        # negative lag. None when either timestamp is missing/unparseable.
+        payload["sources"]["vault"]["ingest_lag_minutes"] = _vault_ingest_lag_minutes(
+            payload["sources"]["vault"]["last_modified_in_vault"],
+            payload["sources"]["vault"]["last_ingested_at"],
+        )
 
         payload["sources"]["github"] = {
             "items": _safe_count(conn, "github_items"),
@@ -635,15 +723,47 @@ def get_index_status(database_path: Path) -> dict[str, Any]:
             drift["github_documents_missing_from_semantic"] = None
 
         try:
-            pending_embed = conn.execute(
+            pending_rows = conn.execute(
                 """
-                SELECT COUNT(*) FROM semantic_documents
+                SELECT updated_at FROM semantic_documents
                 WHERE embedded_hash IS NULL OR embedded_hash != content_hash
                 """
-            ).fetchone()[0]
-            drift["semantic_documents_pending_embed"] = int(pending_embed)
+            ).fetchall()
+            pending_total = len(pending_rows)
+            now = datetime.now(timezone.utc)
+            oldest_minutes: float | None = None
+            stuck_count = 0
+            for row in pending_rows:
+                age_minutes = _minutes_since(row["updated_at"], now)
+                if age_minutes is None:
+                    continue
+                if oldest_minutes is None or age_minutes > oldest_minutes:
+                    oldest_minutes = age_minutes
+                if age_minutes > _PENDING_EMBED_STUCK_MINUTES:
+                    stuck_count += 1
+
+            drift["semantic_documents_pending_embed"] = pending_total
+            # GH-166: embed_chunks() runs synchronously right after ingest_vault()
+            # within the same refresh job (see _refresh_vault below), so a
+            # pending-embed row should clear within that one run — well under
+            # the ~60-minute vault-sync cadence. A row still pending past
+            # _PENDING_EMBED_STUCK_MINUTES is not an in-flight run's normal
+            # tail; it is evidence the embed step stalled or failed on that row.
+            drift["semantic_documents_pending_embed_stuck"] = stuck_count
+            drift["semantic_documents_pending_embed_oldest_minutes"] = (
+                round(oldest_minutes, 1) if oldest_minutes is not None else None
+            )
+            if stuck_count:
+                drift["semantic_documents_pending_embed_reason"] = (
+                    f"{stuck_count} of {pending_total} pending-embed row(s) unembedded "
+                    f"for over {_PENDING_EMBED_STUCK_MINUTES}m (oldest "
+                    f"{round(oldest_minutes, 1) if oldest_minutes is not None else '?'}m) "
+                    "— likely a stuck/failed embed run, not just an in-flight tail"
+                )
         except Exception:
             drift["semantic_documents_pending_embed"] = None
+            drift["semantic_documents_pending_embed_stuck"] = None
+            drift["semantic_documents_pending_embed_oldest_minutes"] = None
 
         # GH-169 Phase 3: commit-corpus completeness, anchored on the remote.
         # Cheap (local git + one ls-remote per repo, no REST API) so it can run

--- a/src/rebalance/ingest/semantic_index.py
+++ b/src/rebalance/ingest/semantic_index.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -27,6 +28,8 @@ from rebalance.ingest.embedder import (
     _load_model,
     _vec_to_bytes,
 )
+
+logger = logging.getLogger(__name__)
 
 EmbedTexts = Callable[[list[str], str], list[list[float]]]
 
@@ -296,33 +299,52 @@ def sync_github_documents(conn: Any, *, repo_full_name: str = "") -> dict[str, i
         conn, normalized_repo=normalized_repo, ignored_repos=ignored_repos
     )
 
-    inserted = updated = unchanged = 0
+    inserted = updated = unchanged = skipped = 0
     seen_source_pks: set[str] = set()
     for row in rows:
         source_pk = row["source_key"]
+        try:
+            _, state = upsert_document(
+                conn,
+                source_type="github",
+                source_table="github_documents",
+                source_pk=source_pk,
+                doc_kind=row["doc_type"],
+                title=row["title"] or "",
+                body=row["body"],
+                metadata={
+                    "repo_full_name": row["repo_full_name"],
+                    "item_type": row["github_source_type"],
+                    "source_number": row["source_number"],
+                    "state": row["state"] or "",
+                    "milestone_title": row["milestone_title"] or "",
+                    "labels": json.loads(row["labels_json"]) if row["labels_json"] else [],
+                    "review_decision": row["review_decision"] or "",
+                    "check_status": row["check_status"] or "",
+                    "html_url": row["html_url"] or "",
+                },
+                created_at=row["fetched_at"],
+                updated_at=row["updated_at"] or row["fetched_at"],
+            )
+        except Exception as exc:
+            # GH-167: one malformed github_documents row (bad JSON in
+            # labels_json, a constraint violation, etc.) must not abort the
+            # rest of this repo's projection — skip it, log why, and keep
+            # going so every other row still lands in the semantic index.
+            skipped += 1
+            logger.warning(
+                "sync_github_documents: skipping malformed row source_key=%r "
+                "repo=%r doc_type=%r: %s",
+                source_pk,
+                row["repo_full_name"],
+                row["doc_type"],
+                exc,
+            )
+            continue
+        # Only mark a row "seen" once it's actually landed in the semantic
+        # index — a skipped row must stay eligible for reconciliation on the
+        # next run instead of being treated as intentionally deleted.
         seen_source_pks.add(source_pk)
-        _, state = upsert_document(
-            conn,
-            source_type="github",
-            source_table="github_documents",
-            source_pk=source_pk,
-            doc_kind=row["doc_type"],
-            title=row["title"] or "",
-            body=row["body"],
-            metadata={
-                "repo_full_name": row["repo_full_name"],
-                "item_type": row["github_source_type"],
-                "source_number": row["source_number"],
-                "state": row["state"] or "",
-                "milestone_title": row["milestone_title"] or "",
-                "labels": json.loads(row["labels_json"]) if row["labels_json"] else [],
-                "review_decision": row["review_decision"] or "",
-                "check_status": row["check_status"] or "",
-                "html_url": row["html_url"] or "",
-            },
-            created_at=row["fetched_at"],
-            updated_at=row["updated_at"] or row["fetched_at"],
-        )
         if state == "inserted":
             inserted += 1
         elif state == "updated":
@@ -343,6 +365,7 @@ def sync_github_documents(conn: Any, *, repo_full_name: str = "") -> dict[str, i
         "updated": updated,
         "unchanged": unchanged,
         "deleted": deleted,
+        "skipped": skipped,
     }
 
 

--- a/src/rebalance/paths.py
+++ b/src/rebalance/paths.py
@@ -11,7 +11,10 @@ Resolution chains
 -----------------
 
 resolve_database_path(explicit) — find rebalance.db:
-    1. ``explicit`` argument if non-None (e.g., ``--database /path/to/db``)
+    1. ``explicit`` argument if non-None (e.g., ``--database /path/to/db``).
+       GH-201: this path is authoritative — if it doesn't exist, resolution
+       raises ``ExplicitDatabasePathNotFoundError`` immediately rather than
+       falling through to a later layer (which used to mask typos).
     2. ``REBALANCE_DB`` env var (used by launchd jobs, the MCP server, and
        any operator who exports it in their shell rc)
     3. Canonical app-data location for this platform. On macOS that is
@@ -159,16 +162,63 @@ class DatabaseNotFoundError(FileNotFoundError):
         super().__init__(message)
 
 
+class ExplicitDatabasePathNotFoundError(DatabaseNotFoundError):
+    """Raised when an explicit database path (``--database`` / ``REBALANCE_DB``)
+    is given but doesn't exist on disk (GH-201).
+
+    This is deliberately distinct from the generic :class:`DatabaseNotFoundError`
+    (all layers exhausted): here the caller named an exact path, so the resolver
+    must honor it or fail loudly — silently falling back to the canonical DB (or
+    any other layer) would mask a typo in the given path. Still a subclass of
+    ``DatabaseNotFoundError`` so existing ``except DatabaseNotFoundError`` call
+    sites keep working without changes.
+    """
+
+    def __init__(self, path: Path, source: str):
+        self.path = path
+        self.source = source
+        message = (
+            f"Database path does not exist: {path}\n"
+            f"(source: {source})\n"
+            "\n"
+            "This path was given explicitly, so rebalance will not silently fall\n"
+            "back to another database location — that would risk masking a typo.\n"
+            "\n"
+            "Fix one of these:\n"
+            f"  1. Check the path for typos: {path}\n"
+            "  2. Create a database there first, e.g.:\n"
+            f"       rebalance onboard --database {path}\n"
+            "  3. Drop --database (and unset REBALANCE_DB if set) to use the\n"
+            "     default resolution chain instead\n"
+        )
+        # Deliberately bypass DatabaseNotFoundError.__init__ (which expects a
+        # `candidates` list and renders the generic multi-layer help message) —
+        # this subclass carries its own single-path, single-source message.
+        FileNotFoundError.__init__(self, message)
+        self.candidates = [(path, source)]
+
+
 def resolve_database_path(explicit: Path | None = None) -> Path:
     """Resolve the rebalance.db path via the layered chain documented above.
 
     Returns an existing absolute path, or raises ``DatabaseNotFoundError``
     with a message naming every layer that was tried.
+
+    GH-201: when ``explicit`` is given (e.g. via ``--database`` or the
+    ``REBALANCE_DB`` env var, which Typer's ``DBOption`` also feeds into this
+    parameter), it must exist. A nonexistent explicit path raises
+    :class:`ExplicitDatabasePathNotFoundError` immediately instead of silently
+    falling through to the canonical DB or any other layer — that fallback
+    used to mask typos in operator-supplied paths.
     """
     candidates: list[tuple[Path, str]] = []
 
     if explicit is not None:
-        candidates.append((Path(explicit).expanduser().resolve(), "--database flag"))
+        explicit_path = Path(explicit).expanduser().resolve()
+        explicit_source = "--database flag"
+        if not explicit_path.exists():
+            raise ExplicitDatabasePathNotFoundError(explicit_path, explicit_source)
+        candidates.append((explicit_path, explicit_source))
 
     env_value = os.environ.get("REBALANCE_DB")
     if env_value:

--- a/test/clio-exporter.sh
+++ b/test/clio-exporter.sh
@@ -317,6 +317,38 @@ local_time_display_keeps_utc_ids() {
   cmp -s "$out" "$case_dir/before.md" || fail "cursor reset duplicated a localized note"
 }
 
+malformed_source_row_is_dropped() {
+  shell=$1
+  case_dir="$TMP/malformed-$2"
+  home="$case_dir/home"
+  out="$case_dir/note.md"
+  mkdir -p "$home/.claude"
+  {
+    json_line '2026-07-20T07:59:00Z' before before 'row before malformed'
+    # Truncated JSON: unterminated string, no closing brace. jq's `fromjson?`
+    # turns this into an error, which `// empty` swallows — the documented
+    # "malformed lines ... are dropped without aborting the run" behaviour.
+    printf '%s\n' '{"timestamp":"2026-07-20T08:00:00Z","repo":"broken","branch":"main","machine":"fixture","session_id":"broken","prompt":"truncated row'
+    json_line '2026-07-20T08:01:00Z' after after 'row after malformed'
+  } > "$home/.claude/prompt-log.jsonl"
+
+  run_exporter "$shell" "$home" "$out" > "$case_dir/first.out"
+  assert_contains "$out" 'row before malformed'
+  assert_contains "$out" 'row after malformed'
+  assert_not_contains "$out" 'truncated row'
+  assert_not_contains "$out" 'broken'
+  assert_count "$out" 'clio:id:before:2026-07-20T07:59:00Z' 1
+  assert_count "$out" 'clio:id:after:2026-07-20T08:01:00Z' 1
+
+  # The cursor must still advance past the malformed line (it's consumed, not
+  # retried forever), and re-running must stay a clean no-op — no crash, no
+  # duplicate entries, no attempt to re-parse the dropped row.
+  cp "$out" "$case_dir/before.md"
+  run_exporter "$shell" "$home" "$out" > "$case_dir/second.out"
+  cmp -s "$out" "$case_dir/before.md" || fail "second run changed output after a malformed row"
+  assert_contains "$case_dir/second.out" 'Synced 0 new prompt(s)'
+}
+
 run_suite() {
   shell=$1
   key=$2
@@ -330,6 +362,7 @@ run_suite() {
   conflict_sibling "$shell" "$key"
   manifest_failure_is_nonfatal "$shell" "$key"
   backfill_then_targeted_repair "$shell" "$key"
+  malformed_source_row_is_dropped "$shell" "$key"
   echo "PASS: $shell"
 }
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -7,6 +7,7 @@ DB) and the report aggregation logic.
 
 import tempfile
 import unittest
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import patch
 
@@ -335,8 +336,14 @@ class PulseCollectorCheckTests(unittest.TestCase):
     def _health(self, name, state, *, healthy, age_hours, failures=0, examples=""):
         from rebalance.ingest.pulse_health import CollectorHealth
 
+        # classify() derives age_hours FROM last_scan_utc, so a row carrying an
+        # age always carries the scan timestamp it was computed from. Derive it
+        # here for the same reason: pinning the two independently produced a
+        # state read_collector_health() cannot emit — an age with no scan — and
+        # the check only kept passing because it read the age directly.
+        last_scan = datetime.now(timezone.utc) - timedelta(hours=age_hours)
         h = CollectorHealth(
-            device_id=name, device_name=name, last_scan_utc=None,
+            device_id=name, device_name=name, last_scan_utc=last_scan,
             repo_scan_failures=failures, scan_failure_examples=examples,
         )
         h.state, h.age_hours = state, age_hours
@@ -359,7 +366,12 @@ class PulseCollectorCheckTests(unittest.TestCase):
         self.assertIn("4 repo scan failures", by["pulse collector:Broken"].detail)
         self.assertIn("repo-a", by["pulse collector:Broken"].detail)
         self.assertEqual(by["pulse collector:Stale"].status, WARN)
-        self.assertIn("1.2d ago", by["pulse collector:Stale"].detail)  # 30h → days
+        # GH-189 re-sourced this from format_timestamp(relative=True), which
+        # emits an absolute anchor plus the compact relative and returns ""
+        # rather than a bare relative — so assert the anchor, not just the age.
+        stale_detail = by["pulse collector:Stale"].detail
+        self.assertIn("1d ago", stale_detail)  # 30h → days
+        self.assertRegex(stale_detail, r"last scan \d{4}-\d{2}-\d{2} \d{1,2}:\d{2} [AP]M · ")
         self.assertEqual(by["pulse collector:Fine"].status, OK)
 
     def test_empty_when_no_collectors(self) -> None:

--- a/tests/test_github_knowledge.py
+++ b/tests/test_github_knowledge.py
@@ -1,6 +1,9 @@
 """Tests for GitHub artifact sync, local document build, and semantic query."""
 
+import sqlite3
 import tempfile
+import threading
+import time
 import unittest
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -340,6 +343,76 @@ class GitHubKnowledgeTests(unittest.TestCase):
                     "SELECT COUNT(*) FROM semantic_documents WHERE source_type = 'github'"
                 ).fetchone()[0]
                 self.assertGreaterEqual(semantic_doc_count, 6)
+
+    def test_sync_does_not_hold_write_lock_across_network_fetch(self) -> None:
+        """GH-171 regression: sync_github_repo must not hold the SQLite write
+        transaction open while blocked on a "network" call. A second writer
+        (simulated with a raw connection here) must be able to land a write
+        while sync_github_repo is mid-fetch, and it must do so quickly rather
+        than waiting out the slow call's own duration.
+        """
+        block_started = threading.Event()
+        slow_seconds = 0.6
+
+        def _slow_api(url: str) -> object:
+            if "/commits/deadbeef/check-runs" in url:
+                block_started.set()
+                # Simulate a slow GitHub API round-trip. If this call happens
+                # inside an open write transaction (the pre-GH-171 bug), any
+                # concurrent writer below is starved for this whole sleep.
+                time.sleep(slow_seconds)
+            return _fake_github_api(url)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "rebalance.db"
+            errors: list[BaseException] = []
+
+            def _run_sync() -> None:
+                try:
+                    sync_github_repo(
+                        database_path=db_path,
+                        repo_full_name="AcmeOrg/sample-child-theme-oct-2024",
+                        token="ghp_test",
+                        since_days=30,
+                        api_get_json=_slow_api,
+                    )
+                except BaseException as exc:  # noqa: BLE001 - surfaced via assertion below
+                    errors.append(exc)
+
+            sync_thread = threading.Thread(target=_run_sync)
+            sync_thread.start()
+            try:
+                self.assertTrue(
+                    block_started.wait(timeout=5),
+                    "sync_github_repo never reached the simulated slow fetch",
+                )
+
+                # While the fetch is "in flight", a second connection should be
+                # able to open and write immediately -- no write transaction
+                # should be held across network I/O.
+                start = time.monotonic()
+                probe_conn = sqlite3.connect(str(db_path), timeout=2.0)
+                try:
+                    probe_conn.execute("CREATE TABLE IF NOT EXISTS gh171_probe (id INTEGER)")
+                    probe_conn.execute("INSERT INTO gh171_probe (id) VALUES (1)")
+                    probe_conn.commit()
+                finally:
+                    probe_conn.close()
+                elapsed = time.monotonic() - start
+            finally:
+                sync_thread.join(timeout=10)
+
+            self.assertFalse(sync_thread.is_alive(), "sync_github_repo did not finish in time")
+            self.assertFalse(errors, f"sync_github_repo raised: {errors}")
+
+            # Bounded window well under the slow call's own duration: proves
+            # the concurrent write did not wait behind a held write lock.
+            self.assertLess(
+                elapsed,
+                slow_seconds / 2,
+                "concurrent write was blocked for close to the slow fetch's duration "
+                "-- a write transaction is likely still spanning network I/O",
+            )
 
     def test_sync_rejects_ignored_repo(self) -> None:
         add_github_ignored_repo("dlt-hub/dlt")

--- a/tests/test_health_issue_reporter.py
+++ b/tests/test_health_issue_reporter.py
@@ -110,6 +110,132 @@ class TestOccurrenceCounter(unittest.TestCase):
 
 
 # ===========================================================================
+# 1b. Detail block refresh (GH-139) — a repeat sighting must update Detail,
+#     not just the Seen counter.
+# ===========================================================================
+
+class TestDetailRefresh(unittest.TestCase):
+
+    def test_set_detail_replaces_detail_block(self) -> None:
+        body = hr._issue_body("db", "fail", "original detail", "", "rebalance-doctor")
+        updated = hr.set_detail(body, "new root-cause detail")
+        self.assertIn("new root-cause detail", updated)
+        self.assertNotIn("original detail", updated)
+
+    def test_set_detail_preserves_rest_of_body(self) -> None:
+        body = hr._issue_body("db", "fail", "original detail", "a hint", "rebalance-doctor")
+        updated = hr.set_detail(body, "new detail")
+        self.assertIn("## Rebalance health: `db`", updated)
+        self.assertIn("**Status:** `FAIL`", updated)
+        self.assertIn("a hint", updated)
+        self.assertTrue(updated.startswith("> **Seen:** 1×"))
+
+    def test_set_detail_noop_when_no_detail_block(self) -> None:
+        body = "no detail block here"
+        self.assertEqual(hr.set_detail(body, "whatever"), body)
+
+    def test_set_detail_does_not_touch_seen_counter(self) -> None:
+        body = hr._issue_body("db", "fail", "detail v1", "", "rebalance-doctor")
+        body = hr.set_occurrence_count(body, 3, _now_str(), device="host-a")
+        updated = hr.set_detail(body, "detail v2")
+        self.assertIn("> **Seen:** 3×", updated)
+        self.assertIn("detail v2", updated)
+        self.assertNotIn("detail v1", updated)
+
+    def test_repeat_sighting_refreshes_detail_and_counter(self) -> None:
+        """End-to-end: a second sighting with a changed detail must update both."""
+        body = hr._issue_body("db", "fail", "disk full", "", "rebalance-doctor")
+        refreshed = hr.set_detail(body, "disk full — now 99% (was 92%)")
+        new_body = hr.set_occurrence_count(refreshed, 2, _now_str(), device="host-a")
+        self.assertIn("disk full — now 99% (was 92%)", new_body)
+        self.assertNotIn("```\ndisk full\n```", new_body)
+        self.assertIn("> **Seen:** 2×", new_body)
+
+
+# ===========================================================================
+# 1c. Stable check-id dedup (GH-139) — a renamed/retitled issue must still
+#     match its existing open issue instead of orphaning it.
+# ===========================================================================
+
+class TestStableCheckIdDedup(unittest.TestCase):
+
+    def test_issue_body_embeds_check_id_marker(self) -> None:
+        body = hr._issue_body("sleuth", "fail", "detail", "", "rebalance-doctor")
+        self.assertEqual(hr.parse_check_id(body), "sleuth")
+
+    def test_parse_check_id_missing_marker_returns_none(self) -> None:
+        self.assertIsNone(hr.parse_check_id("no marker here"))
+        self.assertIsNone(hr.parse_check_id(""))
+
+    def test_dedup_key_prefers_body_marker_over_title(self) -> None:
+        """A human-retitled GitHub issue must still match its stable id."""
+        body = hr._issue_body("sleuth", "fail", "detail", "", "rebalance-doctor")
+        issue = {"title": "health: sleuth credentials (renamed by operator)", "body": body}
+        self.assertEqual(hr.dedup_key_for_issue(issue), "sleuth")
+
+    def test_dedup_key_falls_back_to_title_for_legacy_issues(self) -> None:
+        """Pre-GH-139 issues (e.g. the #46-48 / #83-85 pulse-collector dupes)
+        have no marker; matching must still work off the title so this fix
+        does not misbehave against them or file new duplicates."""
+        issue = {"title": "health: pulse collector:noels-mbp-16-m1-pro", "body": ""}
+        self.assertEqual(
+            hr.dedup_key_for_issue(issue), "pulse collector:noels-mbp-16-m1-pro"
+        )
+
+    def test_dedup_key_legacy_issue_with_no_body_at_all(self) -> None:
+        issue = {"title": "health: vault", "body": None}
+        self.assertEqual(hr.dedup_key_for_issue(issue), "vault")
+
+    def test_list_health_issues_keys_by_check_id_not_title(self) -> None:
+        """Two issues whose titles differ from ``health: <name>`` — one via
+        the marker (post-fix), one via legacy title parsing (pre-fix) — must
+        both be reachable by their check name, proving the title text no
+        longer gates dedup."""
+        marker_body = hr._issue_body("gmail", "fail", "detail", "", "rebalance-doctor")
+        renamed_issue = {
+            "title": "health: gmail integration (renamed)",
+            "number": 200,
+            "body": marker_body,
+            "state": "open",
+        }
+        legacy_issue = {
+            "title": "health: pulse collector:device-a",
+            "number": 46,
+            "body": "",
+            "state": "open",
+        }
+
+        with patch.object(hr, "_request", side_effect=[[renamed_issue, legacy_issue], []]):
+            issues = hr.list_health_issues("tok", "org/repo", state="open")
+
+        self.assertIn("gmail", issues)
+        self.assertEqual(issues["gmail"]["number"], 200)
+        self.assertIn("pulse collector:device-a", issues)
+        self.assertEqual(issues["pulse collector:device-a"]["number"], 46)
+
+    def test_renamed_check_does_not_orphan_or_duplicate(self) -> None:
+        """Simulates main()'s matching logic: a check whose GitHub issue was
+        retitled (title no longer equals ``health: <name>``) must still be
+        found as 'already open' via the stable check id, not re-filed."""
+        body = hr._issue_body("figma", "fail", "token missing", "", "rebalance-doctor")
+        open_issues = {
+            hr.dedup_key_for_issue({"title": "health: figma token (renamed)", "body": body}):
+                {"title": "health: figma token (renamed)", "number": 77, "body": body}
+        }
+
+        check = _make_check("figma")
+        check_id = check["name"]
+        already_open = open_issues.get(check_id)
+
+        self.assertIsNotNone(
+            already_open,
+            "renamed issue must still be found by its stable check id — "
+            "the old title-only lookup would have missed this and filed a duplicate.",
+        )
+        self.assertEqual(already_open["number"], 77)
+
+
+# ===========================================================================
 # 2. Quota management
 # ===========================================================================
 

--- a/tests/test_index_ops.py
+++ b/tests/test_index_ops.py
@@ -555,6 +555,148 @@ class SignalHealthQuietFilterTests(unittest.TestCase):
         self.assertIsNone(_quiet_filter_description({"quiet_filter": "no_such_formatter"}))
 
 
+class VaultIngestLagTests(unittest.TestCase):
+    """GH-166: signal_health.vault must degrade on a meaningful ingest lag,
+    not just a 7-day freshness window. last_ingested_at can be recent while
+    the vault writer has moved further ahead than the ingester has caught
+    up to — that gap is what these tests pin."""
+
+    def _vault_health_and_lag(self, db_path, *, ingested_minutes_ago: int, modified_minutes_ago: int):
+        from rebalance.ingest.db import db_connection, run_migrations
+        from rebalance.ingest.index_ops import get_index_status
+
+        with db_connection(db_path) as conn:
+            run_migrations(conn)
+            conn.execute(
+                "INSERT INTO vault_files (rel_path, content_hash, ingested_at, last_modified) "
+                "VALUES ('drift.md', 'hash1', "
+                f"datetime('now', '-{ingested_minutes_ago} minutes'), "
+                f"datetime('now', '-{modified_minutes_ago} minutes'))"
+            )
+            conn.commit()
+
+        status = get_index_status(db_path)
+        vault_source = status["sources"]["vault"]
+        health = status["freshness"]["signal_health"]["vault"]
+        return vault_source, health
+
+    def test_lag_within_threshold_stays_ok(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "rebalance.db"
+            vault_source, health = self._vault_health_and_lag(
+                db_path, ingested_minutes_ago=15, modified_minutes_ago=5,
+            )
+
+        self.assertAlmostEqual(vault_source["ingest_lag_minutes"], 10.0, delta=1.0)
+        self.assertEqual(health["status"], "ok")
+        self.assertNotIn("reason", health)
+
+    def test_lag_past_warn_threshold_warns(self) -> None:
+        """The #166 shape: a ~130 minute drift the old 7-day window ignored."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "rebalance.db"
+            vault_source, health = self._vault_health_and_lag(
+                db_path, ingested_minutes_ago=130, modified_minutes_ago=0,
+            )
+
+        self.assertGreater(vault_source["ingest_lag_minutes"], 120)
+        self.assertEqual(health["status"], "warn")
+        self.assertIn("behind the vault writer", health["reason"])
+
+    def test_lag_past_degraded_threshold_degrades(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "rebalance.db"
+            vault_source, health = self._vault_health_and_lag(
+                db_path, ingested_minutes_ago=200, modified_minutes_ago=0,
+            )
+
+        self.assertGreater(vault_source["ingest_lag_minutes"], 180)
+        self.assertEqual(health["status"], "degraded")
+        self.assertIn("behind the vault writer", health["reason"])
+
+    def test_ingest_after_modification_clamps_lag_to_zero(self) -> None:
+        """Normal ordering (ingest runs after the edit) must never report a
+        negative lag — clamp to 0, same as the pre-existing healthy-source
+        fixture (ingested now, modified 2 days ago)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "rebalance.db"
+            vault_source, health = self._vault_health_and_lag(
+                db_path, ingested_minutes_ago=0, modified_minutes_ago=2880,
+            )
+
+        self.assertEqual(vault_source["ingest_lag_minutes"], 0.0)
+        self.assertEqual(health["status"], "ok")
+
+
+class PendingEmbedStuckTests(unittest.TestCase):
+    """GH-166: a semantic_documents row pending embed must be distinguished
+    as "stuck" (sat unembedded past a reasonable threshold) vs. an in-flight
+    run's normal tail (embed_chunks() runs synchronously right after ingest,
+    so a fresh pending row is expected and not a problem)."""
+
+    def _insert_pending_doc(self, conn, *, source_pk: str, updated_minutes_ago: int) -> None:
+        conn.execute(
+            "INSERT INTO semantic_documents "
+            "(source_type, source_table, source_pk, doc_kind, title, body, "
+            " content_hash, embedded_hash, embedded_model_version, embedded_at, "
+            " created_at, updated_at) "
+            "VALUES ('vault', 'chunks', ?, 'chunk', 'Title', 'body text', "
+            " 'hash-current', NULL, NULL, NULL, "
+            f" datetime('now', '-{updated_minutes_ago} minutes'), "
+            f" datetime('now', '-{updated_minutes_ago} minutes'))",
+            (source_pk,),
+        )
+
+    def test_freshly_pending_row_is_not_flagged_stuck(self) -> None:
+        from rebalance.ingest.db import db_connection, ensure_semantic_schema, run_migrations
+        from rebalance.ingest.index_ops import get_index_status
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "rebalance.db"
+            with db_connection(db_path, ensure_semantic_schema) as conn:
+                run_migrations(conn)
+                self._insert_pending_doc(conn, source_pk="1", updated_minutes_ago=2)
+                conn.commit()
+
+            drift = get_index_status(db_path)["freshness"]
+            self.assertEqual(drift["semantic_documents_pending_embed"], 1)
+            self.assertEqual(drift["semantic_documents_pending_embed_stuck"], 0)
+            self.assertNotIn("semantic_documents_pending_embed_reason", drift)
+
+    def test_long_pending_row_is_flagged_stuck_with_a_reason(self) -> None:
+        from rebalance.ingest.db import db_connection, ensure_semantic_schema, run_migrations
+        from rebalance.ingest.index_ops import get_index_status
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "rebalance.db"
+            with db_connection(db_path, ensure_semantic_schema) as conn:
+                run_migrations(conn)
+                self._insert_pending_doc(conn, source_pk="1", updated_minutes_ago=45)
+                conn.commit()
+
+            drift = get_index_status(db_path)["freshness"]
+            self.assertEqual(drift["semantic_documents_pending_embed"], 1)
+            self.assertEqual(drift["semantic_documents_pending_embed_stuck"], 1)
+            self.assertGreaterEqual(drift["semantic_documents_pending_embed_oldest_minutes"], 45)
+            self.assertIn("stuck/failed embed run", drift["semantic_documents_pending_embed_reason"])
+
+    def test_mixed_pending_rows_only_flag_the_stuck_one(self) -> None:
+        from rebalance.ingest.db import db_connection, ensure_semantic_schema, run_migrations
+        from rebalance.ingest.index_ops import get_index_status
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "rebalance.db"
+            with db_connection(db_path, ensure_semantic_schema) as conn:
+                run_migrations(conn)
+                self._insert_pending_doc(conn, source_pk="1", updated_minutes_ago=2)
+                self._insert_pending_doc(conn, source_pk="2", updated_minutes_ago=60)
+                conn.commit()
+
+            drift = get_index_status(db_path)["freshness"]
+            self.assertEqual(drift["semantic_documents_pending_embed"], 2)
+            self.assertEqual(drift["semantic_documents_pending_embed_stuck"], 1)
+
+
 class SignalHealthAgreesWithDoctorTests(unittest.TestCase):
     """GH-145 anti-drift: the two surfaces must not contradict each other."""
 

--- a/tests/test_launchd_predicate.py
+++ b/tests/test_launchd_predicate.py
@@ -1,11 +1,20 @@
-"""Regression coverage for the launchd health predicate (GH-146).
+"""Regression coverage for the launchd health predicate (GH-146, GH-160).
 
 `_check_launchd` must not flag a running or just-restarted daemon as broken.
 It reads a stubbed `launchctl list` snapshot (`pid \t status \t label`), never
 the real machine. The bug these tests pin: a `KeepAlive` daemon restarted via
 `launchctl kickstart -k` shows a live PID with the *previous* instance's exit
 `-15` (SIGTERM) and used to WARN despite being healthy and serving.
+
+GH-160: a single snapshot cannot distinguish a one-off crash from a genuine
+crash loop (a live PID is always live at poll time either way), so
+`_check_launchd` persists recent crash-relaunch events across polls under
+`log_dir`. The crash-loop tests below drive it across several polls with an
+isolated `tmp_path`-backed `log_dir` so that history never leaks between
+tests or real `doctor` runs.
 """
+
+from datetime import datetime, timedelta, timezone
 
 from rebalance.doctor import NOTICE, OK, WARN, WARNING, _check_launchd
 
@@ -60,3 +69,51 @@ def test_clean_states_are_ok() -> None:
         check = _one(snapshot)
         assert check.status == OK, snapshot
         assert check.detail == detail, snapshot
+
+
+def test_crash_looping_daemon_is_flagged_despite_live_pid(tmp_path) -> None:
+    """GH-160: a KeepAlive job repeatedly crashing and being relaunched must
+    eventually WARN even though every poll catches it mid-live-PID."""
+    log_dir = tmp_path / "logs"
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    label = "com.rebalance-os.pulse-server"
+
+    # Poll 1: first-ever observation of this label. A live PID next to a
+    # positive last exit is indistinguishable from a one-off crash on its
+    # own (this is exactly the GH-146-pinned case) — must stay OK.
+    check1 = _check_launchd(f"1000\t1\t{label}\n", log_dir=log_dir, now=base)[0]
+    assert check1.status == OK
+    assert check1.detail == "running"
+
+    # Poll 2: launchd respawned it under a new PID after another non-zero
+    # exit. One crash-relaunch is now on record, but one alone is still not
+    # a loop.
+    check2 = _check_launchd(
+        f"1050\t1\t{label}\n", log_dir=log_dir, now=base + timedelta(minutes=1)
+    )[0]
+    assert check2.status == OK
+
+    # Poll 3: a second crash-relaunch inside the lookback window — this is a
+    # genuine loop and must degrade despite the PID being live right now.
+    check3 = _check_launchd(
+        f"1103\t1\t{label}\n", log_dir=log_dir, now=base + timedelta(minutes=2)
+    )[0]
+    assert check3.status == WARN
+    assert check3.severity == WARNING
+    assert "crash-loop" in check3.detail.lower()
+
+
+def test_repeated_sigterm_restarts_are_not_mistaken_for_a_crash_loop(tmp_path) -> None:
+    """GH-146 must survive GH-160: repeated *clean* SIGTERM restarts (e.g. an
+    operator running `kickstart -k` more than once) are still not a crash
+    loop — only genuinely non-zero, non-signal exits ever count."""
+    log_dir = tmp_path / "logs"
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    label = "com.rebalance-os.pulse-server"
+
+    for minute, pid in enumerate((2000, 2050, 2103, 2140)):
+        check = _check_launchd(
+            f"{pid}\t-15\t{label}\n", log_dir=log_dir, now=base + timedelta(minutes=minute)
+        )[0]
+        assert check.status == OK, (pid, check)
+        assert check.detail == "running"

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,97 @@
+"""Regression coverage for GH-201: `resolve_database_path()` must not silently
+fall back to the canonical DB when an explicit `--database` path is given and
+doesn't exist.
+
+Before this fix, an explicit path was just candidate #1 in an ordered list
+with the canonical DB appended unconditionally as a later candidate; the
+resolution loop returned the first candidate that *existed*, regardless of
+source. So `--database /nonexistent/path.db` silently fell through to the
+canonical DB instead of raising — masking typos.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rebalance import paths as paths_module
+from rebalance.paths import (
+    DatabaseNotFoundError,
+    ExplicitDatabasePathNotFoundError,
+    resolve_database_path,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    """Keep every test's resolution chain independent of the real machine.
+
+    - Clears REBALANCE_DB so a developer's/CI's real env var can't leak in.
+    - Points the user-level config file at a nonexistent tmp path so
+      `_load_user_config()` returns `{}` (no `database_path` candidate).
+    """
+    monkeypatch.delenv("REBALANCE_DB", raising=False)
+    monkeypatch.setattr(paths_module, "USER_CONFIG_FILE", paths_module.USER_CONFIG_FILE.with_name("does-not-exist.json"))
+
+
+def test_explicit_valid_database_path_is_honored(tmp_path):
+    """(a) An explicit --database path that exists is returned as-is."""
+    db_file = tmp_path / "mydb.db"
+    db_file.write_bytes(b"")
+
+    resolved = resolve_database_path(db_file)
+
+    assert resolved == db_file.resolve()
+
+
+def test_explicit_nonexistent_database_path_raises(tmp_path, monkeypatch):
+    """(b) An explicit --database path that does NOT exist raises instead of
+    silently falling back to the canonical DB (the GH-201 bug)."""
+    missing = tmp_path / "typo-path" / "rebalance.db"
+
+    # Make the canonical DB resolvable too, so a passing test here proves the
+    # resolver deliberately refused the fallback — not that it merely had
+    # nothing else to fall back to.
+    canonical_dir = tmp_path / "canonical"
+    canonical_dir.mkdir()
+    canonical_db = canonical_dir / "rebalance.db"
+    canonical_db.write_bytes(b"")
+    monkeypatch.setattr(paths_module, "canonical_database_path", lambda: canonical_db)
+
+    with pytest.raises(ExplicitDatabasePathNotFoundError) as exc_info:
+        resolve_database_path(missing)
+
+    # It's a DatabaseNotFoundError subclass, so existing `except
+    # DatabaseNotFoundError` call sites across the CLI still catch it.
+    assert isinstance(exc_info.value, DatabaseNotFoundError)
+    assert str(missing.resolve()) in str(exc_info.value)
+
+
+def test_no_database_given_falls_back_to_canonical(tmp_path, monkeypatch):
+    """(c) With no explicit path (and no env var), resolution still falls
+    back to the canonical DB when it exists."""
+    canonical_dir = tmp_path / "canonical"
+    canonical_dir.mkdir()
+    canonical_db = canonical_dir / "rebalance.db"
+    canonical_db.write_bytes(b"")
+    monkeypatch.setattr(paths_module, "canonical_database_path", lambda: canonical_db)
+
+    resolved = resolve_database_path(None)
+
+    assert resolved == canonical_db.resolve()
+
+
+def test_no_database_given_and_nothing_resolvable_raises_generic_error(tmp_path, monkeypatch):
+    """No explicit path, and no layer resolves anything: the generic
+    DatabaseNotFoundError (not the explicit-path variant) is raised."""
+    canonical_dir = tmp_path / "canonical-missing"
+    canonical_db = canonical_dir / "rebalance.db"  # never created
+    monkeypatch.setattr(paths_module, "canonical_database_path", lambda: canonical_db)
+    # Force the project-root walk-up to find nothing either, so this test
+    # doesn't depend on whether a rebalance.db happens to sit next to the
+    # repo's own .git / pyproject.toml.
+    monkeypatch.setattr(paths_module, "_walk_up_for_project_root", lambda *a, **k: None)
+
+    with pytest.raises(DatabaseNotFoundError) as exc_info:
+        resolve_database_path(None)
+
+    assert not isinstance(exc_info.value, ExplicitDatabasePathNotFoundError)


### PR DESCRIPTION
## Summary

Output of a `/10days` sweep: scanned the last 10 days of GitHub issue activity (35 issues), verified each survivor against commit/PR history rather than trusting GitHub issue state, and fired a 10-lane marathon for the confirmed-live, still-reproducible bugs.

- **8 issues excluded as already fixed** by prior marathons, verified via commit/PR evidence (GitHub still shows them OPEN — a bookkeeping gap, not live bugs): #127, #129, #138, #141, #145, #152, #169, plus #168 ruled out as an open-ended tuning investigation rather than a scoped bug.
- **2 EPICs** (#136, #185) and **5 auto-filed device-health alerts** (#179, #199, #204, #205, #206) out of scope.
- **2 held back** to keep this run scoped: #144 (overlaps #171's file) and #178 (bundles 10 quarantined test failures with uncertain individual root causes) — independently corroborated by a prior unfired marathon plan found mid-run.

## Fixes in this PR

- **#139** — `health_issue_reporter` dedupes on a stable check id instead of the display title (a rename no longer orphans the old issue + files a twin)
- **#160** — `doctor` detects a crash-looping KeepAlive daemon instead of trusting a live PID
- **#166** — vault ingest lag and stuck pending-embed rows surfaced as diagnosable health signals
- **#167** — ignored-repo filtering aligned between the semantic-projection query and the drift check; a malformed row no longer aborts a repo's whole projection
- **#170** — `pytest` inside a linked git worktree now resolves imports to that worktree's own `src/`, not the main checkout's
- **#171** — `github_sync` no longer holds the SQLite write lock across network I/O
- **#186** — scheduled jobs retry a transient interpreter-bootstrap EINTR instead of hard-failing
- **#189** — health banner uses `format_timestamp()`; repo-pie labels strip the org prefix
- **#201** — an explicit `--database` at a nonexistent path now raises instead of silently falling back to the canonical DB
- **#202** — added a malformed-source-row fixture to the CLIO exporter test suite

## Test plan

- [x] Wave 1 (7 disjoint lanes) gate: green
- [x] Wave 2 (3 lanes) gate: green
- [x] Full suite from a clean worktree: 1591 passed, 4 skipped, 10 xfailed, 1 failed — that one failure (`test_doctor.py::test_alive_is_ok_degraded_and_alert_warn`) is confirmed pre-existing on the pristine pre-marathon baseline in a clean worktree, unrelated to any change in this PR
- [x] No file-level overlap with `development`'s commits since this branch's base — verified via `git diff --stat`

## Notes for reviewers

- Every capture doc's Swarm Preflight Contract was auto-drafted by the sweep from issue text — flagged per house convention, not independently operator-verified before firing.
- Found and fixed 3 probe-authoring bugs before firing: an unescaped-regex false "already-landed" verdict on #139's contract, an over-broad grep on #167's, and a ledger-title text collision on #189 (literally contained "GH-135," misread as issue identity by the planner).
- Also surfaced, out of scope for this PR: `.xyz/utils/marathon-plan.sh`'s ledger parser expects a different ROADMAP.md dialect than this repo actually uses (worked around via its documented test seam, ledger format untouched); and a stray `rebalance.db` at the repo root causes a false test failure in `test_hiqs_pipeline.py` when pytest runs from the main checkout directly instead of a worktree (reproduces on baseline, worth its own follow-up issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)