### PR TITLE
GH-231 + GH-233: two test-infrastructure fixes — tests that pass or fail based on the host, not the code

### DIFF
--- a/src/rebalance/ingest/pulse.py
+++ b/src/rebalance/ingest/pulse.py
@@ -1151,8 +1151,26 @@ def _push_repair_actions(target_repo: Path) -> dict[str, Any]:
 
 
 def _verify_remote_content(target_repo: Path, file_rel: str, expected: str) -> bool:
-    """Return True if origin/HEAD now contains exactly the expected file content."""
-    rc, out, _ = _run_git(["show", f"origin/HEAD:{file_rel}"], cwd=target_repo)
+    """Return True if the branch just pushed now contains exactly the expected file content.
+
+    GH-233: this used to read ``origin/HEAD``, which is the remote's *default* branch — not
+    necessarily the branch ``git push`` just wrote to. Two ways that went wrong:
+
+    * **Wrong ref.** ``_commit_and_push_if_changed`` runs a bare ``git push``, which pushes the
+      current branch to its upstream. On any branch other than the remote default, the check read
+      a different branch than the one that was written — reporting a mismatch for a good push, or
+      passing because some other branch happened to match.
+    * **Missing ref.** ``origin/HEAD`` is created at clone time from the remote's HEAD. A clone of
+      an empty remote never gets one, and pushing afterwards does not create it, so
+      ``git show origin/HEAD:<path>`` fails with "invalid object name" however correct the push was.
+
+    ``@{u}`` is by definition the ref the bare push targeted, so resolving it removes both cases.
+    A missing upstream is still a genuine failure: without one there is nothing to have pushed to.
+    """
+    rc, upstream, _ = _run_git(["rev-parse", "--abbrev-ref", "@{u}"], cwd=target_repo)
+    if rc != 0 or not upstream:
+        return False
+    rc, out, _ = _run_git(["show", f"{upstream}:{file_rel}"], cwd=target_repo)
     return rc == 0 and out == expected.strip()
 
 

--- a/tests/test_job_guard_wiring.py
+++ b/tests/test_job_guard_wiring.py
@@ -25,6 +25,21 @@ def _enable_guard(monkeypatch, tmp_path):
     """Re-enable the guard and isolate the lock dir from the real one."""
     monkeypatch.setenv("REBALANCE_JOB_GUARD", "1")
     monkeypatch.setenv("JOB_GUARD_LOCK_DIR", str(tmp_path / "locks"))
+    # GH-231: isolate the memory ceiling too, not just the lock dir.
+    #
+    # Without this the guard falls back to DEFAULT_MAX_COMPRESSOR_FRACTION (0.25 of physical RAM,
+    # utils/job_guard.py:132) and its preflight reads the machine's LIVE compressor usage. On a
+    # 32 GB machine that is an 8 GB ceiling; anything above it makes preflight() refuse to start,
+    # the child never launches, and the test fails as "child never acquired the lock" — a result
+    # about the machine, not about the locking these tests exist to verify.
+    #
+    # This bites hardest while the memory work in #209/#210/#215 is in flight, because that work
+    # is precisely about jobs driving the compressor to tens of GB. Invisible in CI, where the
+    # Linux runner is not under pressure.
+    #
+    # A test that means to exercise the ceiling should set this to a value that trips it, rather
+    # than relying on whatever the host happens to be doing.
+    monkeypatch.setenv("REBALANCE_JOB_GUARD_MAX_COMPRESSOR_GB", "999")
     # The module caches its load; drop it so LOCK_DIR is re-read per test.
     _job_guard._module = None
     _job_guard._load_attempted = False

--- a/tests/test_pulse_self_repair.py
+++ b/tests/test_pulse_self_repair.py
@@ -154,8 +154,22 @@ class TestPulseSelfRepair:
 
             # Verify the content actually landed on the remote — not silently dropped.
             # Must stay inside the with-block: tempdir is cleaned up on exit.
+            #
+            # GH-233: read the branch that was actually pushed (@{u}), not origin/HEAD. The remote
+            # here is created with `git init --bare` and cloned while still empty, and a clone of an
+            # empty remote never gets an origin/HEAD symref — pushing afterwards does not create one
+            # either. `git show origin/HEAD:pulse.md` therefore fails with "invalid object name"
+            # regardless of whether the push worked, which is a property of the fixture rather than
+            # of the code under test. `@{u}` is the ref the bare `git push` targeted.
+            upstream = subprocess.run(
+                ["git", "rev-parse", "--abbrev-ref", "@{u}"],
+                cwd=str(local),
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip()
             remote_content = subprocess.run(
-                ["git", "show", "origin/HEAD:pulse.md"],
+                ["git", "show", f"{upstream}:pulse.md"],
                 cwd=str(local),
                 capture_output=True,
                 text=True,


### PR DESCRIPTION
Two test-infrastructure fixes, cherry-picked onto a clean `development` so they can be
reviewed on their own. Both are environment-sensitivity bugs: the tests they touch pass or
fail based on the machine rather than the code.

## GH-231 — the job-guard fixture never pins the compressor ceiling

https://github.com/Hypercart-Dev-Tools/rebalance-OS/issues/231

Three tests in `tests/test_job_guard_wiring.py` fail on any machine under memory pressure,
because the fixture leaves the guard's compressor ceiling at its runtime default. The tests
intend to measure *locking* behaviour; without a pinned ceiling they instead measure how
busy the host happens to be.

`+15` lines: pin the ceiling in the fixture so the tests assert what they claim to assert.

## GH-233 — pulse self-repair verified the wrong branch

https://github.com/Hypercart-Dev-Tools/rebalance-OS/issues/233

`tests/test_pulse_self_repair.py` had two tests passing on Linux CI and failing on macOS.
The repair path reported success while push verification reported `content_mismatch`,
because verification checked the remote's **default** branch rather than the branch that was
actually pushed.

`+35/-3` across `src/rebalance/ingest/pulse.py` and its test.

## Why these are worth landing

Together they were the difference between a red and a green `pytest tests/`. A red suite
blocks any marathon that uses the full suite as its pre-advance gate — see
https://github.com/Claude-AI-Tools-Ventura-County/xyz-3-agents-swarm/issues/378 — so these
are load-bearing for automated runs, not only for local convenience.

They are also the kind of defect worth fixing on principle: a test whose result depends on
host memory pressure or on which OS runs it gives no signal at all.

## Verification

`pytest tests/test_job_guard_wiring.py tests/test_pulse_self_repair.py` — 22 passed, against
this branch's base (`origin/development`, no marathon commits present).

## Provenance

Both commits were originally authored 2026-07-30 and are preserved on
`research/marathon-2026-08-02-run2` and `research/marathon-2026-08-03-run2b`. This branch
carries only these two, cherry-picked onto current `development`, so the review is not mixed
with marathon output.
