### PR TITLE
fix(github): prune direct-commit vectors with their documents (GH-248)

### DIFF
--- a/src/rebalance/ingest/github_direct_commits.py
+++ b/src/rebalance/ingest/github_direct_commits.py
@@ -244,6 +244,20 @@ def sync_direct_commit_documents(database_path: Path) -> int:
     """Materialize non-PR-overlapping direct commits into the GitHub document corpus."""
     now = _now()
     with db_connection(database_path, ensure_github_schema) as conn:
+        # GH-248: drop the vectors in the same transaction as the documents.
+        # The re-insert below takes fresh autoincrement ids, so any embedding
+        # left keyed to an old id is unreachable forever -- and vec0 never
+        # reclaims the slot. Churning ~15.5k documents per run this way
+        # orphaned 2.65M vectors (10.8 GB, 99% of the vector table) in ~9 days.
+        # delete_item_children() already gets this ordering right; match it.
+        stale_doc_ids = [
+            row["id"]
+            for row in conn.execute(
+                "SELECT id FROM github_documents WHERE doc_type = 'direct_commit'"
+            ).fetchall()
+        ]
+        if stale_doc_ids:
+            gh.delete_github_embeddings_for_docs(conn, stale_doc_ids)
         conn.execute("DELETE FROM github_documents WHERE doc_type = 'direct_commit'")
         rows = conn.execute(
             """

--- a/tests/test_github_direct_commits.py
+++ b/tests/test_github_direct_commits.py
@@ -172,3 +172,149 @@ class DirectCommitCaptureTests(unittest.TestCase):
         self.assertEqual(len(candidates), 1)
         self.assertIn("utils/CLIO/README.md", candidates[0]["evidence"])
         self.assertIn("direct branch push", candidates[0]["why"])
+
+
+class DirectCommitEmbeddingPruningTests(unittest.TestCase):
+    """GH-248: re-syncing direct commits must not orphan their vectors.
+
+    ``sync_direct_commit_documents`` deletes every ``direct_commit`` document and
+    re-inserts it with a fresh autoincrement id. Before GH-248 it left the old
+    ``github_embeddings`` rows behind, keyed to ids that no longer existed. vec0
+    never reclaims those slots, so the vector table grew without bound (2.65M
+    orphans / 10.8 GB observed in production, 99% of the table).
+
+    The invariant these tests pin is the one the reclaim plan needs: after any
+    number of syncs, every vector's ``doc_id`` resolves to a live document.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.db_path = Path(self._tmp.name) / "rebalance.db"
+
+    def _seed_direct_commit(self, sha: str) -> None:
+        """Land one non-PR-overlapping direct commit so a document is produced."""
+        with db_connection(self.db_path, ensure_github_schema) as conn:
+            gh.upsert_direct_commit(
+                conn,
+                (
+                    REPO,                            # repo_full_name
+                    sha,                             # sha
+                    f"push-{sha[:7]}",               # event_id
+                    "refs/heads/main",               # ref
+                    "noelsaw1",                      # author_login
+                    "Noel",                          # author_name
+                    f"direct commit {sha[:7]}",      # message
+                    "2026-07-18T03:06:18Z",          # committed_at
+                    f"https://github.com/{REPO}/commit/{sha}",
+                    "complete",                      # path_coverage
+                    "2026-07-18T03:06:20Z",          # discovered_at
+                    "2026-07-18T03:06:20Z",          # fetched_at
+                ),
+            )
+            conn.commit()
+
+    def _embed_all_pending(self) -> int:
+        """Stand in for the embedder: give every pending document a vector."""
+        with db_connection(self.db_path, ensure_github_schema) as conn:
+            doc_ids = [
+                row["id"]
+                for row in conn.execute(
+                    "SELECT id FROM github_documents WHERE doc_type = 'direct_commit'"
+                ).fetchall()
+            ]
+            for doc_id in doc_ids:
+                # 1024 float32s -- the production vec0 declaration.
+                gh.upsert_github_embedding(conn, doc_id, b"\x00" * (1024 * 4))
+                gh.mark_github_document_embedded(conn, doc_id)
+            conn.commit()
+        return len(doc_ids)
+
+    def _counts(self) -> tuple[int, int, int]:
+        """(documents, vectors, orphaned vectors)."""
+        with db_connection(self.db_path, ensure_github_schema) as conn:
+            docs = conn.execute(
+                "SELECT COUNT(*) FROM github_documents WHERE doc_type = 'direct_commit'"
+            ).fetchone()[0]
+            vectors = conn.execute(
+                "SELECT COUNT(*) FROM github_embeddings"
+            ).fetchone()[0]
+            orphans = conn.execute(
+                """
+                SELECT COUNT(*) FROM github_embeddings e
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM github_documents d WHERE d.id = e.doc_id
+                )
+                """
+            ).fetchone()[0]
+        return docs, vectors, orphans
+
+    def test_repeated_syncs_leave_one_vector_per_live_document(self) -> None:
+        self._seed_direct_commit(SHA)
+
+        # Sync + embed three times. Each sync re-creates the document with a new
+        # id; without the fix each round would strand the previous round's vector.
+        for round_number in range(1, 4):
+            self.assertEqual(sync_direct_commit_documents(self.db_path), 1)
+            self.assertEqual(self._embed_all_pending(), 1)
+            docs, vectors, orphans = self._counts()
+            with self.subTest(round=round_number):
+                self.assertEqual(docs, 1, "one direct_commit document expected")
+                self.assertEqual(
+                    orphans,
+                    0,
+                    f"round {round_number}: {orphans} vector(s) point at a "
+                    "deleted document -- vec0 never reclaims these",
+                )
+                self.assertEqual(
+                    vectors,
+                    docs,
+                    f"round {round_number}: {vectors} vectors for {docs} "
+                    "documents -- expected exactly one each",
+                )
+
+    def test_sync_prunes_vectors_for_documents_it_deletes(self) -> None:
+        """The narrow unit: a sync that drops a document drops its vector too."""
+        self._seed_direct_commit(SHA)
+        self.assertEqual(sync_direct_commit_documents(self.db_path), 1)
+        self._embed_all_pending()
+
+        with db_connection(self.db_path, ensure_github_schema) as conn:
+            first_id = conn.execute(
+                "SELECT id FROM github_documents WHERE doc_type = 'direct_commit'"
+            ).fetchone()["id"]
+
+        # Re-sync: the document is deleted and re-inserted under a NEW id.
+        self.assertEqual(sync_direct_commit_documents(self.db_path), 1)
+        with db_connection(self.db_path, ensure_github_schema) as conn:
+            second_id = conn.execute(
+                "SELECT id FROM github_documents WHERE doc_type = 'direct_commit'"
+            ).fetchone()["id"]
+            stranded = conn.execute(
+                "SELECT COUNT(*) FROM github_embeddings WHERE doc_id = ?",
+                (first_id,),
+            ).fetchone()[0]
+
+        self.assertNotEqual(
+            first_id, second_id, "re-insert should take a fresh autoincrement id"
+        )
+        self.assertEqual(
+            stranded, 0, f"vector for deleted document {first_id} was not pruned"
+        )
+
+    def test_multiple_documents_all_pruned_on_resync(self) -> None:
+        """Scale the invariant past one row -- production churns ~15.5k."""
+        shas = [f"{i:040x}" for i in range(1, 6)]
+        for sha in shas:
+            self._seed_direct_commit(sha)
+
+        self.assertEqual(sync_direct_commit_documents(self.db_path), len(shas))
+        self.assertEqual(self._embed_all_pending(), len(shas))
+        self.assertEqual(self._counts(), (len(shas), len(shas), 0))
+
+        self.assertEqual(sync_direct_commit_documents(self.db_path), len(shas))
+        self.assertEqual(self._embed_all_pending(), len(shas))
+        docs, vectors, orphans = self._counts()
+        self.assertEqual(orphans, 0, f"{orphans} orphaned vectors after re-sync")
+        self.assertEqual(vectors, len(shas), "vector count must not grow per sync")
+        self.assertEqual(docs, len(shas))


### PR DESCRIPTION
Closes the root cause behind GH-248's vector bloat.

## The bug

`sync_direct_commit_documents()` deleted every `direct_commit` document and re-inserted it with a fresh autoincrement id on **every** sync, leaving the matching `github_embeddings` rows stranded at ids that no longer existed. sqlite-vec's `vec0` never reclaims a slot, so the vector table grew without bound.

Measured before the fix:

| | |
|---|---|
| `github_embeddings_vector_chunks00` | **12.19 GB — 92.3%** of a 13.22 GB database |
| vectors total | 2,673,280 |
| orphaned (no live document) | **2,647,214 — 99.02%** |
| matched to a live document | 26,098 |

~15.5k documents churn per run × 18 `github_sync` runs/day ≈ 280k orphans/day → 2.65M in **~9.4 days**, matching both the log-retention window and the 464 MB `rebalance.db.pre-0005.bak`.

## The fix

14 lines. Collect the doomed ids, call the **already-existing** `gh.delete_github_embeddings_for_docs()` before the document delete, same transaction — the ordering `delete_item_children()` already used. No new helper, no new abstraction.

I audited the other three document-delete paths for the same defect: `delete_item_children` and `purge_github_repo` both already prune embeddings first, and `clear_github_embeddings` is paired with a hash reset. **This was the only leak**, so the root-cause fix is complete rather than partial.

## Tests

`DirectCommitEmbeddingPruningTests` — 3 tests pinning the invariant: after any number of syncs, every vector's `doc_id` resolves to a live document.

Critically, these were **verified to fail without the fix** (4 failures), and round 1 passes while rounds 2–3 fail — correct, because the leak only manifests on re-sync. A test that passed round 1 unconditionally would have proven nothing.

```
tests/test_github_direct_commits.py .......  7 passed, 3 subtests passed
test_db_github + test_github_knowledge + test_github_coverage
  + test_github_reconciliation .............  28 passed
```

`rebalance doctor` passes (one pre-existing unrelated figma-staleness warning).

## Scope

**This does not reclaim the existing ~10.8 GB.** That is deliberately staged behind an operational runbook and writer-fencing preconditions — a Codex adversarial review of the original reclaim plan returned 6 blockers, and reclaiming before this writer fix landed would have let the next sync immediately re-orphan everything. Remaining work is tracked in the canonical follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)