### PR TITLE
docs(RELEASES): plan 0.69.0 Reclaim and 0.70.0 Green Board

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,12 +6,26 @@ target release names/dates; it is not a history of what shipped (that's CHANGELO
 learned belong there at ship time, not duplicated here). Contract lives in PROJECT/PDDA.md ->
 "RELEASES.md — release ledger". Add new fields only when a real need shows up.
 
-Release: 0.1.0
+Release: 0.69.0
+Iterations: 0.69.0-0.69.9
 Status: Draft
-Target Date:
-Codename: n/a
-Description: EXAMPLE — replace this with your first real release, or delete this block once real entries exist below.
+Target Date: 2026-08-15
+Codename: Reclaim
+Milestone:
+Description: The store tells the truth about its own size — finish GH-250 end to end: observe the writer fix holding across three sync cycles (R1), execute the ~10.2 GiB reclaim behind the runbook (R4), backfill and re-embed what the leak destroyed (R5), and land with doctor's two orphan invariants reporting OK against real data instead of FAIL.
 GH_URL:
 Front-door reviewed:
 Shakedown reviewed:
-License file:
+License file: No
+
+Release: 0.70.0
+Iterations: 0.70.0-0.70.9
+Status: Draft
+Target Date: 2026-09-15
+Codename: Green Board
+Milestone:
+Description: A red build means new breakage — empty the GH-178 quarantine (10 real commit-threshold auto-promotion defects, not flakes), fix the working-directory dependence in GH-255, repair the 5 utils/3-eyes CI failures, and end on a development branch whose green run is worth believing.
+GH_URL:
+Front-door reviewed:
+Shakedown reviewed:
+License file: No


### PR DESCRIPTION
Plans two upcoming releases in `RELEASES.md`. Docs only — one file, no code, no schema, no scheduled-job behaviour touched.

## Why this is an edit to a file that says not to edit it

`PROJECT/PDDA.md` → "RELEASES.md — release ledger" is explicit that this file is an optional planning aid and that a maintainer should **not** proactively populate it, precisely because an LLM maintainer will otherwise erode it into a second history of what shipped. That guardrail allows exactly one trigger: *"Edit it only when an operator explicitly asks for release planning."* This PR is that request, and nothing here records shipped work.

## What landed

The file previously held only the `0.1.0` **EXAMPLE** placeholder, whose own text says to delete it once real entries exist. Replaced with two blocks:

| Release | Codename | Target | Theme |
|---|---|---|---|
| **0.69.0** | Reclaim | 2026-08-15 | the store tells the truth about its own size |
| **0.70.0** | Green Board | 2026-09-15 | a red build means *new* breakage |

**0.69.0 "Reclaim"** — GH-250 end to end: observe the writer fix holding across three sync cycles (R1), execute the ~10.2 GiB reclaim behind the tested runbook (R4), backfill and re-embed what the leak destroyed (R5), and finish with `doctor`'s two orphan invariants reporting OK against real data instead of FAIL. The root cause and the whole toolchain landed in #253; **this release is the execution**, which is the part that needs a human at the keyboard.

**0.70.0 "Green Board"** — empty the GH-178 quarantine (10 real commit-threshold auto-promotion defects, not flakes), fix the working-directory dependence in #255, and repair the 5 `utils/3-eyes` failures that are red on `development` right now.

## Judgment calls, so they can be overruled rather than guessed at

- **Both descriptions are forward-looking, not changelog lines.** PDDA's admission rule rejects a block whose `Description:` merely restates what changed — that belongs in `CHANGELOG.md` and nowhere else. Each of these names an arc with a measurable end state.
- **`Iterations` bands reserved** (`0.69.0-0.69.9`, `0.70.0-0.70.9`) so patch versions ship into `CHANGELOG.md` without earning their own block here. Per the contract, when a band is exhausted it gets widened, not enumerated.
- **`Milestone:` left blank** — `gh api repos/:owner/:repo/milestones` returns empty; this repo has no GitHub milestones. Creating them is an operator action, and the field is deliberately not warned on when absent.
- **`License file: No`** is a measured fact, not a placeholder: there is no `LICENSE` in the repo.
- **No third block for the HiQS spin-out**, deliberately. Two were requested, and given its six-phase clean-room plan it may warrant a `1.0.0` or its own repo rather than a point release.

## Verification

```
$ bash utils/pdda/pdda.sh releases
SUMMARY [pdda-check-releases] errors=0 warns=0 info=0

$ bash utils/pdda/pdda.sh releases-current
• 0.69.0 (Reclaim) — Draft      Iterations: 0.69.0-0.69.9   Target Date: 2026-08-15
• 0.70.0 (Green Board) — Draft  Iterations: 0.70.0-0.70.9   Target Date: 2026-09-15
```

Both blocks parse, both surface as in-progress, no findings.

## CI note

`development` is currently red — 5 pre-existing failures in `utils/3-eyes/tests/` (`test_adoption_wave3` `KeyError: 'prompt-log-to-md'`, and three `test_breaker_semantics_p6` exit-code assertions). They are unrelated to this branch and are what 0.70.0 exists to fix. This PR changes one markdown file and cannot affect them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
