### PR TITLE
chore: sync version declarations to 0.68.7, record the GH-250 work, fix License file field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,49 @@
 > **not** reintroduce an `[Unreleased]` block — add to (or roll work into) the
 > current dated version instead. See AGENTS.md → "Versioning & Changelog".
 
+## [0.68.7] - 2026-08-06
+
+### Fixed
+- **The direct-commit sync was destroying its own embeddings on every run, and had
+  quietly grown the database to 13.5 GiB — 92% of it garbage.** Each sync deleted every
+  direct-commit document and re-inserted it with a fresh identifier, so the vectors keyed
+  to the old identifiers were orphaned rather than removed. Eighteen runs a day, ~15.5k
+  orphans each, accumulating unbounded: 2.68 million dead vectors holding 10.2 GiB.
+  The same pass then re-embedded ~15.5k byte-identical documents it had just recreated,
+  which is roughly 280k needless embedding operations a day and the main reason the
+  embedding stage stayed hot enough to keep tripping the memory guard.
+
+  The writer now updates in place, keyed on a stable source identifier, and preserves
+  both the identifier and the content hash when the content has not changed — so an
+  unchanged commit keeps its vector and is never re-embedded. Orphan growth has been
+  confirmed flat across fourteen sync cycles since. Reclaiming the space that already
+  accumulated is a separate, operator-run maintenance step, deliberately not automated.
+
+### Added
+- **A hard zero-orphan invariant in the health check, for both embedding families.**
+  Twelve gigabytes accumulated over roughly nine days with nothing raising an alarm,
+  which was a detection gap as much as a writer bug. The check now fails outright on any
+  orphaned vector and reports real table sizes and their share of the database.
+
+  Two deliberate choices: the companion backlog check counts absolute unembedded
+  documents rather than a coverage ratio, because coverage oscillates widely within a
+  single sync cycle (measured 9.7% missing and 67.9% missing on the same day, both
+  healthy) and a ratio would page during normal operation; and table sizes are measured
+  without relying on page-level statistics, which report zero bytes for a virtual table.
+- **A tested toolchain for the reclaim itself** — writer fencing with verification and
+  restore, and a batched, resumable, checkpointing delete-and-rebuild that refuses to run
+  against the real database without an explicit acknowledgement, refuses to overwrite an
+  existing rebuild target, and aborts rather than reporting success if a checkpoint comes
+  back blocked or if the live vector count changes. Nothing has been run against
+  production data.
+
+### Changed
+- The test suite now probes for a usable GPU device out of process and skips the tests
+  that need one when it is absent. Previously those tests called the framework directly,
+  which aborts the whole process rather than raising when no device is reachable — so a
+  single unreachable-GPU environment destroyed every other test's result in the same run.
+  An in-test guard could not catch it, because a process abort is not an exception.
+
 ## [0.68.6] - 2026-08-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 > **not** reintroduce an `[Unreleased]` block — add to (or roll work into) the
 > current dated version instead. See AGENTS.md → "Versioning & Changelog".
 
-## [0.68.7] - 2026-08-06
+## [0.68.7] - 2026-08-07
 
 ### Fixed
 - **The direct-commit sync was destroying its own embeddings on every run, and had

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -16,7 +16,7 @@ Description: The store tells the truth about its own size — finish GH-250 end 
 GH_URL:
 Front-door reviewed:
 Shakedown reviewed:
-License file: No
+License file: Yes
 
 Release: 0.70.0
 Iterations: 0.70.0-0.70.9
@@ -28,4 +28,4 @@ Description: A red build means new breakage — empty the GH-178 quarantine (10 
 GH_URL:
 Front-door reviewed:
 Shakedown reviewed:
-License file: No
+License file: Yes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rebalance-os"
-version = "0.68.1"
+version = "0.68.7"
 description = "Local-first workday operating system with MCP tools and Obsidian ingest"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/rebalance/__init__.py
+++ b/src/rebalance/__init__.py
@@ -28,7 +28,7 @@ import logging
 import os
 
 __all__ = ["__version__"]
-__version__ = "0.68.1"
+__version__ = "0.68.7"
 
 
 def _configure_logging() -> None:


### PR DESCRIPTION
Two corrections to release metadata. No product code, no behaviour change.

## 1. Three sources disagreed about what version this is

```
pyproject.toml             0.68.1   (last touched 2026-07-30)
src/rebalance/__init__.py  0.68.1
CHANGELOG.md (newest)      0.68.6
```

`import rebalance; rebalance.__version__` reported **0.68.1** on a tree that had shipped through **0.68.6** — so both the packaging metadata and the runtime were five releases behind. All three now read **0.68.7**.

The second declaration in `src/rebalance/__init__.py` is the one worth noting: a sync that only touched `pyproject.toml` would have left the runtime still reporting the wrong version, and nothing would have caught it.

The gap exists because **#253 merged without a changelog entry or a version bump**, which AGENTS.md → "Versioning & Changelog" requires at commit/merge time. This adds the missing entry, covering what actually shipped there: the direct-commit writer fix, the zero-orphan invariant in the health check, the reclaim toolchain, and the out-of-process GPU probe in the test suite. Written in plain language with no file paths, per that same section's changelog rule.

### Why PATCH and not MINOR

The health-check invariant is arguably a feature, which by semver would make this `0.69.0`. But `0.69.0` is reserved in `RELEASES.md` as the **"Reclaim"** release for the reclaim *execution* (GH-250 R4/R5), which has not run. Consuming that number here would leave the planned release describing work already shipped. Keeping the toolchain in the `0.68.x` line lets `0.69.0` keep meaning what the ledger says it means.

Flagging it rather than burying it — if you'd rather this be `0.69.0` and the Reclaim release move to `0.70.0`, that's a one-line change to each and I'll do it.

### Landed as 0.68.7, not 0.68.6

`development` shipped its own `0.68.6` (the uninstaller, #258) while this was in flight. The entry was renumbered on rebase and placed **above** it to keep the file newest-first; #258's entry is untouched.

## 2. `License file: No` was wrong

I set that field on the strength of `ls LICENSE*` returning nothing. Wrong check: the repo carries the full Apache 2.0 text as `APACHE-LICENSE-2.0.txt`. A license file is present, so both entries now read `Yes`.

**Separate nit, deliberately not encoded in the ledger:** GitHub only auto-detects a license from a file named `LICENSE` / `LICENSE.txt` / `LICENSE.md`, so the repository sidebar shows no license until it's renamed or copied. That's a real pre-open-source item for the 0.69.0 / 0.70.0 window, but it's about discoverability, not about whether the project is licensed.

## Verification

```
$ grep '^version' pyproject.toml            → 0.68.7
$ grep '__version__ =' src/rebalance/__init__.py → 0.68.7
$ head -1 changelog heading                 → ## [0.68.7] - 2026-08-06
$ python -c 'import rebalance; print(rebalance.__version__)' → 0.68.7

$ pytest tests/ -k version                  → 4 passed
$ bash utils/pdda/pdda.sh releases          → errors=0 warns=0 info=0
$ rebalance doctor                          → exit 1, 2 FAIL (unchanged)
```

Those two `doctor` FAILs are the GH-250 orphan invariants, correct and expected until the reclaim runs.

## CI note

`development` is red on 5 pre-existing failures in the 3-Eyes test folder (#232) — unrelated to this branch, and the substance of the planned 0.70.0. A version-string change cannot affect them; check against #232's baseline rather than reading red as new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
