### PR TITLE
fix(GH-275/255/242): unblock the Green Board RC gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,10 +224,20 @@ download is the only large transfer and happens once.
 
 ### Step 1 — Clone and install
 
+**Before you start, check your Python.** rebalance needs **3.12 or newer**:
+
+```bash
+python3 --version
+```
+
+If that prints 3.11 or lower — or `command not found` — install a newer Python first and
+use it below in place of `python3`. Ubuntu 22.04 ships 3.10, so `apt install python3.12`
+(or a `deadsnakes` PPA) is required there; on macOS, `brew install python@3.13`.
+
 ```bash
 git clone https://github.com/Hypercart-Dev-Tools/rebalance-OS.git
 cd rebalance-OS
-/opt/homebrew/bin/python3.13 -m venv .venv
+python3 -m venv .venv
 .venv/bin/pip install -e ".[embeddings,calendar]"
 ```
 

--- a/test/clio-capture.sh
+++ b/test/clio-capture.sh
@@ -134,5 +134,22 @@ run_suite() {
 }
 
 command -v jq >/dev/null 2>&1 || fail "jq is required to run this harness"
+
+# GH-242: the second cell is only meaningful when the two interpreters are actually
+# different binaries. On a host where `bash` on PATH resolves to /bin/bash they are the
+# same file, and running the suite twice produced two PASS lines that together proved
+# nothing more than one. Report the truth instead of the reassuring number.
+run_second_cell() {
+  local first_resolved second_resolved
+  first_resolved="$(readlink -f "$(command -v bash)" 2>/dev/null || command -v bash)"
+  second_resolved="$(readlink -f /bin/bash 2>/dev/null || echo /bin/bash)"
+  if [ "$first_resolved" = "$second_resolved" ]; then
+    echo "SKIP: /bin/bash — same interpreter as \`bash\` on this host ($first_resolved);"
+    echo "      a second run would repeat the first, not widen coverage."
+    return 0
+  fi
+  run_suite /bin/bash system-bash
+}
+
 run_suite bash default-bash
-run_suite /bin/bash system-bash
+run_second_cell

--- a/test/clio-exporter.sh
+++ b/test/clio-exporter.sh
@@ -367,5 +367,22 @@ run_suite() {
 }
 
 [ -x "$EXPORTER" ] || fail "exporter is not executable: $EXPORTER"
+
+# GH-242: the second cell is only meaningful when the two interpreters are actually
+# different binaries. On a host where `bash` on PATH resolves to /bin/bash they are the
+# same file, and running the suite twice produced two PASS lines that together proved
+# nothing more than one. Report the truth instead of the reassuring number.
+run_second_cell() {
+  local first_resolved second_resolved
+  first_resolved="$(readlink -f "$(command -v bash)" 2>/dev/null || command -v bash)"
+  second_resolved="$(readlink -f /bin/bash 2>/dev/null || echo /bin/bash)"
+  if [ "$first_resolved" = "$second_resolved" ]; then
+    echo "SKIP: /bin/bash — same interpreter as \`bash\` on this host ($first_resolved);"
+    echo "      a second run would repeat the first, not widen coverage."
+    return 0
+  fi
+  run_suite /bin/bash system-bash
+}
+
 run_suite bash default-bash
-run_suite /bin/bash system-bash
+run_second_cell

--- a/tests/test_gh250_fencing.py
+++ b/tests/test_gh250_fencing.py
@@ -1,8 +1,13 @@
 import os
 import subprocess
+from pathlib import Path
+
 import pytest
 
-SCRIPT_PATH = "utils/gh250/fence-writers.sh"
+# Resolved from this file's own location, not the caller's CWD (GH-255): a bare
+# relative path made the whole module pass from the repo root and fail anywhere else.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = str(REPO_ROOT / "utils" / "gh250" / "fence-writers.sh")
 
 @pytest.fixture
 def run_env(tmp_path):


### PR DESCRIPTION
Three fixes that have to land before the #276 release gates can produce meaningful evidence.

## #275 — README Step 1 only worked on a Homebrew Mac

`README.md:230` told every reader to run `/opt/homebrew/bin/python3.13`. On a clean
`ubuntu:22.04` container the documented Getting Started path dies on its third line with
exit 127.

Swapping in `python3` is **necessary but not sufficient** — 22.04 ships Python 3.10, below
the 3.12+ floor, and that floor was only stated in the cross-platform table well above Step 1.
Both halves are fixed: portable invocation, plus the version prerequisite stated where the
reader actually hits it, with the check command and the per-platform remedy.

**Not verified by execution.** This machine has Homebrew Python and cannot reproduce the
failure. Confirmation belongs to the non-Homebrew host in the #276 front-door gate.

## #255 — one real cause, and one that was never real

**Real:** `tests/test_gh250_fencing.py:5` set `SCRIPT_PATH = "utils/gh250/fence-writers.sh"` —
a bare relative string. Nine subprocess tests passed from the repo root and raised
`FileNotFoundError` anywhere else. Now resolved from `__file__`. Relative since `be25c79e`
(2026-08-04), so not a recent regression.

**Not real:** the QA artifact recorded ten foreign-CWD failures. Nine were the above. The
tenth — and a further fourteen in `test_uninstall_rebalance.py` that appeared under some
orderings — were **an artifact of the sandbox the measurement ran in**, not a repo defect.
`scripts/uninstall_rebalance.sh` uses a bash heredoc; creating its temp file was denied, so
the plist comparison silently failed and the script refused a job it should have removed.
Re-measured without the sandbox, `test_uninstall_rebalance.py` passes 51/51 from `/tmp`.

Worth stating plainly: a `2>/dev/null` on that heredoc's `python3` call is what made the
failure silent, and that same suppression is why it read as a CWD bug for a day.

## #242 — a second interpreter pass that never ran

Both CLIO suites called `run_suite` twice, with `bash` and `/bin/bash`, and printed two
`PASS` lines. Wherever `bash` on `PATH` resolves to `/bin/bash` — this host included — those
are the same binary, so the second PASS restated the first.

The second cell now resolves both interpreters and reports `SKIP` with the reason and the
resolved path when they are identical. It still runs where they genuinely differ.

## Verification — actually run

| Check | Result |
|---|---|
| `pytest tests/` from repo root | **1 failed, 1726 passed**, 10 xfailed (2m44s) — see below |
| `pytest <abs>/tests/` from `/tmp` | **1 failed, 1722 passed**, 4 skipped, 10 xfailed |
| `pytest <abs>/tests/` from `src/rebalance` (fencing module) | 9 passed |
| `bash test/clio-exporter.sh` | `PASS: bash` then `SKIP: /bin/bash — same interpreter…` |
| `bash test/clio-capture.sh` | `PASS: bash` then `SKIP: /bin/bash — same interpreter…` |

**The one failure is pre-existing and unrelated to this branch.** Confirmed by checking out
`development` and running it there: `test_launchd_predicate.py::test_running_daemon_with_positive_last_exit_is_ok`
fails identically on the base commit, from both working directories. It asserts `OK` but gets
`warn`, because the GH-160 crash-relaunch state it reads is this machine's real state rather
than a fixture's — a test-isolation defect, and possibly a genuine signal that
`pulse-web-sync` is crash-looping. Filed separately rather than fixed silently here.

`rebalance doctor` was **not** run for this PR — it was not affected by any file touched here.

Closes #275, #255, #242.
