### PR TITLE
security(deps): bump js-yaml to 4.3.1 (GHSA-5p4m-2wfm-xmqj)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@
 > **not** reintroduce an `[Unreleased]` block — add to (or roll work into) the
 > current dated version instead. See AGENTS.md → "Versioning & Changelog".
 
+## [0.69.1] - 2026-08-15
+
+### Security
+- **`js-yaml` 4.3.0 → 4.3.1 in the pulse-tree-view extension lockfile** (GHSA-5p4m-2wfm-xmqj,
+  CVE-2026-59870). Quadratic CPU consumption resolving `!!omap`, so a crafted YAML document can
+  stall the parser — a denial of service, not a disclosure. Scope is narrow and worth stating
+  plainly: `js-yaml` is a transitive **dev** dependency of one VS Code extension, absent from the
+  Python package a user installs and from every path the README's Getting Started walks. Lockfile
+  only — the dependency was not promoted to a direct or runtime dependency, and `package.json` is
+  unchanged.
+
 ## [0.69.0] - 2026-08-14
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rebalance-os"
-version = "0.69.0"
+version = "0.69.1"
 description = "Local-first workday operating system with MCP tools and Obsidian ingest"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/rebalance/__init__.py
+++ b/src/rebalance/__init__.py
@@ -28,7 +28,7 @@ import logging
 import os
 
 __all__ = ["__version__"]
-__version__ = "0.69.0"
+__version__ = "0.69.1"
 
 
 def _configure_logging() -> None:

--- a/vscode-extensions/pulse-tree-view/package-lock.json
+++ b/vscode-extensions/pulse-tree-view/package-lock.json
@@ -545,9 +545,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Closes the one open Dependabot alert on `development`.

| | |
|---|---|
| Advisory | GHSA-5p4m-2wfm-xmqj / CVE-2026-59870, high |
| Package | `js-yaml` 4.3.0 → 4.3.1 |
| Where | `vscode-extensions/pulse-tree-view/package-lock.json` |
| Impact | Quadratic CPU consumption resolving `!!omap` — denial of service, not disclosure |

**Narrower than the severity label suggests.** `js-yaml` is a transitive **dev** dependency of one VS Code extension. It is not in the Python package a user installs, and not on any path the README's Getting Started walks. It does not gate the 0.70.0 public RC.

**Lockfile only.** `npm install js-yaml@4.3.1` was tried first and rejected: it added `js-yaml` to `package.json` as a direct **runtime** dependency, widening the extension's dependency surface to fix a dev-only problem. `npm update js-yaml --package-lock-only` upgrades in place. The lock entry keeps `"dev": true`, which is the check that the surface did not move; `package.json` is unchanged.

Version bumped 0.69.0 → 0.69.1 with a CHANGELOG entry, per the no-`[Unreleased]` convention in AGENTS.md.