### PR TITLE
security(GH-276): stop shipping a Google OAuth client; sanitize operator PII

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,8 @@ REPO_MAP.md
 
 # AI agent scratch workspaces — never repo content (GH-266)
 .gemini/
+
+# Operator-supplied Google OAuth client (never commit the real one; the
+# *.example.json template is committed deliberately and stays tracked).
+google_oauth_client.json
+client_secret*.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@
 > **not** reintroduce an `[Unreleased]` block — add to (or roll work into) the
 > current dated version instead. See AGENTS.md → "Versioning & Changelog".
 
+## [0.69.2] - 2026-08-15
+
+### Changed
+- **Google OAuth is now bring-your-own-client.** rebalance no longer ships a Google OAuth
+  Desktop client. You create one in your own Google Cloud project and point rebalance at it via
+  `GOOGLE_OAUTH_CLIENT_FILE` or `~/secrets/google_oauth_client.json`; a template with the expected
+  shape and the five Cloud Console steps ships as `google_oauth_client.example.json`. Your
+  organization now owns the consent screen, scopes, quota, audit trail and revocation.
+  This also removes a hard blocker for public use: a bundled client's consent-screen *audience*
+  decides who may authenticate at all, and an "Internal" audience silently locks out everyone
+  outside the publisher's Workspace domain. A missing file now raises an error naming every path
+  tried, and choosing a "Web application" client instead of "Desktop app" is rejected by name
+  rather than failing later with an opaque redirect-URI mismatch.
+  **Action required:** download your own client JSON and save it to one of the paths above.
+  Existing tokens keep working until they expire; re-minting needs the file. The previously
+  embedded client should be revoked in the Cloud Console — it is recoverable from git history.
+- **3-Eyes is labelled alpha at both entry points.** A banner in `utils/3-eyes/README.md` and the
+  `three_eyes --help` description now name it a diagnostic tool outside the supported core, and
+  name the known defect: `pause` does not stop a launchd-managed job, so a "paused" writer can
+  still be running — use `launchctl bootout` and verify.
+
+### Security
+- **Removed the embedded Google OAuth client credentials.** The client id and secret were stored
+  base64-encoded with the stated intent of avoiding secret scanners, which meant a scan of this
+  repository would report clean while shipping a live credential. A regression test now fails if
+  any credential — or the base64 indirection itself — reappears in that module.
+- **Operator PII removed from tracked files** ahead of publication: three home-directory paths in
+  this changelog (including a `~/secrets/*.env` path), a `file:///Users/...` URL emitted into
+  generated `CATALOG.md` output by `three_eyes/catalog.py`, and a hardcoded vault path in
+  `utils/obsidian_daily_rollover.py` that contained an operator's full name (now `OBSIDIAN_VAULT`).
+
 ## [0.69.1] - 2026-08-15
 
 ### Security
@@ -1836,14 +1867,14 @@ P2 Phase 1 — team-calendar signal — plus a max-effort code-review hardening 
 
 ### Changed
 
-- **Operator-breaking**: the ask-self wrappers ([scripts/ask-self-ingest.sh](scripts/ask-self-ingest.sh), [scripts/ask-self-query.sh](scripts/ask-self-query.sh)) now require `ASK_SELF_PATH` to be set in the environment and fail with an actionable error message when it isn't. Previously they fell back to a hardcoded `/Users/noelsaw/...` path that didn't exist on any other operator's machine — a missing env var manifested as a confusing "ask-self repo not found at <someone-else's-path>". Add `export ASK_SELF_PATH="$HOME/Documents/GitHub/ask-self"` (adjust to your checkout) to your shell rc to keep using these wrappers.
+- **Operator-breaking**: the ask-self wrappers ([scripts/ask-self-ingest.sh](scripts/ask-self-ingest.sh), [scripts/ask-self-query.sh](scripts/ask-self-query.sh)) now require `ASK_SELF_PATH` to be set in the environment and fail with an actionable error message when it isn't. Previously they fell back to a hardcoded absolute path from the original author's machine that didn't exist on any other operator's machine — a missing env var manifested as a confusing "ask-self repo not found at <someone-else's-path>". Add `export ASK_SELF_PATH="$HOME/Documents/GitHub/ask-self"` (adjust to your checkout) to your shell rc to keep using these wrappers.
 
 ### Fixed
 
 - The launchd installers no longer ship with one developer's home directory baked in. All five sync shell scripts (`daily_sync.sh`, `vault_sync.sh`, `pulse_sync.sh`, `pulse_web_sync.sh`, `github_sync.sh`) now derive `REBALANCE_DIR` from their own location, and their five plists became `.plist.template` files with a `{{REBALANCE_DIR}}` placeholder that each `install_*_scheduler.sh` substitutes with the local checkout path before writing into `~/Library/LaunchAgents/`. The rendered plists are gitignored, so a fresh clone on any machine installs cleanly with no per-user editing.
 - The author-fallback in `PROJECT/cleanup.sh` no longer hardcodes a single operator's username — it falls back to `os.environ.get('USER', 'unknown')` when neither the existing frontmatter nor git provides an author.
 - The `Degraded Mac` test fixture in [tests/test_git_pulse_health_check.py](tests/test_git_pulse_health_check.py) no longer embeds a real operator path in its `scan_failure_examples` example; it uses a generic `/Users/operator/...` placeholder instead.
-- The project's `.claude/settings.json` permission allowlist had a few stale `Bash(...)` entries pointing at paths from another machine (`/Users/noelsaw/Documents/GitHub-Repos/...` and `/Users/noelsaw/Documents/rebalance-OS/...`) along with a corresponding `additionalDirectories` entry — all removed since they were dead-ends on this checkout.
+- The project's `.claude/settings.json` permission allowlist had a few stale `Bash(...)` entries pointing at paths from another machine (two absolute checkout paths under a different operator's home directory) along with a corresponding `additionalDirectories` entry — all removed since they were dead-ends on this checkout.
 
 ### Action required on existing machines
 
@@ -1964,7 +1995,7 @@ No DB or vault migration is required — only the install paths above change beh
 
 ### Added
 
-- Centralized path resolution via new module `src/rebalance/paths.py`. Single source of truth for "where is the database?" and "where are the secrets?". Layered resolver chain: (1) explicit `--database` flag, (2) `REBALANCE_DB` env var, (3) walk up from cwd for a project marker (`.git` / `pyproject.toml`) and look for `rebalance.db` next to it, (4) `database_path` field in `~/.config/rebalance-os/config.json`. When no layer resolves, raises `DatabaseNotFoundError` whose message names every candidate it tried and the four routes to fix it. Same chain for secrets: `REBALANCE_SECRETS_DIR` env var → `secrets_dir` user-config field → `~/secrets/` legacy default. Migrates the previously-hardcoded operator paths (`/Users/noelsaw/secrets/google-calendar.env`, `/Users/noelsaw/secrets/sleuth-web-api-development.env`) onto the resolver, closing the AGENTS.md portability TODO. All 24 `Path("rebalance.db"), envvar="REBALANCE_DB"` defaults across the CLI plus the MCP server's `main()` now route through the resolver. New CLI subcommands `rebalance config set-default-database <path>`, `rebalance config set-secrets-dir <path>`, and `rebalance config show-defaults` (debug helper that prints what every layer of the resolver currently sees).
+- Centralized path resolution via new module `src/rebalance/paths.py`. Single source of truth for "where is the database?" and "where are the secrets?". Layered resolver chain: (1) explicit `--database` flag, (2) `REBALANCE_DB` env var, (3) walk up from cwd for a project marker (`.git` / `pyproject.toml`) and look for `rebalance.db` next to it, (4) `database_path` field in `~/.config/rebalance-os/config.json`. When no layer resolves, raises `DatabaseNotFoundError` whose message names every candidate it tried and the four routes to fix it. Same chain for secrets: `REBALANCE_SECRETS_DIR` env var → `secrets_dir` user-config field → `~/secrets/` legacy default. Migrates the previously-hardcoded operator paths (`~/secrets/google-calendar.env`, `~/secrets/sleuth-web-api-development.env`, formerly absolute paths under a specific operator's home directory) onto the resolver, closing the AGENTS.md portability TODO. All 24 `Path("rebalance.db"), envvar="REBALANCE_DB"` defaults across the CLI plus the MCP server's `main()` now route through the resolver. New CLI subcommands `rebalance config set-default-database <path>`, `rebalance config set-secrets-dir <path>`, and `rebalance config show-defaults` (debug helper that prints what every layer of the resolver currently sees).
 - 30-minute web pulse refresh. New launchd job `com.rebalance-os.pulse-web-sync` runs `scripts/pulse_web_sync.sh` every 30 minutes from 06:00 to 23:30, regenerating `web/pulse.html` from the same SQLite the TUI reads. The page itself uses `<meta refresh content="30">` so any browser tab pointed at `file://` reloads on a cadence; pair the two and the local mirror stays within ~30 min of the SQLite truth. Atomic via tmp+replace (a crashed run leaves the previous HTML intact). No network, no git push — separate from the hourly markdown→private-repo pulse-sync job. Install with `bash scripts/install_pulse_web_scheduler.sh`.
 - Repository hygiene audit (`scripts/audit_modules.py`). Verifies that ingest collectors and render modules are documented in ARCHITECTURE.md + CHANGELOG.md, and that recent commits' file changes appear in the latest CHANGELOG version section. Three checks: ARCHITECTURE.md mention, CHANGELOG.md historical mention, and recent-commit coverage (last N commits since the live version's date, default 20). A baseline lockfile (`scripts/audit_modules.lock`) silences pre-existing gaps so the audit fails only on NEW drift; `--init` re-snapshots the baseline after a deliberate doc backfill. `--include-uncommitted` adds a pre-commit preview that flags working-tree changes (modified/untracked audit-worthy `.py`/`.sh`/`.plist` files) not yet in the latest CHANGELOG section. `--json` emits a stable schema (`audit_version: 1`) with `passed`, `summary`, structured `checks`, and an actionable `next_steps` array suitable for orchestrating agents.
 - `audit_modules` MCP tool (registered in `src/rebalance/mcp_server.py`). Wraps `scripts/audit_modules.py --json` for host agents (Claude Code / Claude Desktop). Parameters mirror the CLI: `init`, `commits_window`, `include_uncommitted`. Returns the same stable JSON schema as the CLI, with subprocess-launch errors surfaced as `passed: False, exit_code: 2` and diagnostic fields rather than raised exceptions.

--- a/GMAIL.md
+++ b/GMAIL.md
@@ -85,8 +85,14 @@ pip install -e ".[calendar,embeddings]"   # [calendar] pulls the google-auth lib
 ### Step 1: Authorize your device
 
 Enable the Gmail API once in your Google Cloud project, then run the browser
-consent flow. The Desktop OAuth client is **already bundled in the repo** — you
-do **not** need your own `client_secret.json`.
+consent flow.
+
+**You supply the OAuth client.** rebalance does not bundle one — see
+[GOOGLE_CALENDAR.md → Step 1](./GOOGLE_CALENDAR.md) for the five-step Cloud Console
+walkthrough, or [`google_oauth_client.example.json`](./google_oauth_client.example.json)
+for the expected file shape. The same Desktop-app client backs both Calendar and Gmail,
+so if you already did this for Calendar there is nothing more to do here. Save it as
+`~/secrets/google_oauth_client.json` or set `GOOGLE_OAUTH_CLIENT_FILE`.
 
 ```bash
 gcloud services enable gmail.googleapis.com          # once, in your GCP project

--- a/GOOGLE_CALENDAR.md
+++ b/GOOGLE_CALENDAR.md
@@ -70,13 +70,36 @@ rebalance --help
 
 Run this once to connect your Google account. It opens a browser window where you log in and click **Allow**.
 
-The required Google OAuth Desktop app credentials are already bundled in this repo for setup. Your developer does **not** need to:
+**First, supply your own OAuth client.** rebalance does **not** bundle one. Your
+organization creates the Google Cloud project, so your organization owns the consent
+screen, the scopes, the quota, the audit trail and revocation — and no Google data
+routes through anyone else's project.
 
-- create a Google Cloud project
-- download a separate `client_secret.json`
-- edit OAuth client credentials by hand
+One-time setup:
 
-Each developer authorizes their **own** Google account locally. The repo only provides the Desktop app client configuration needed to start the browser consent flow.
+1. [Google Cloud Console](https://console.cloud.google.com/) → create or pick a project.
+2. **APIs & Services → Library** → enable **Google Calendar API** (and **Gmail API** if
+   you want [GMAIL.md](./GMAIL.md) too).
+3. **APIs & Services → OAuth consent screen** → choose the audience:
+   **Internal** if every user is in your own Google Workspace domain, **External**
+   otherwise. Add the scopes for the APIs you enabled.
+4. **APIs & Services → Credentials → Create credentials → OAuth client ID** →
+   application type **Desktop app**. Download the JSON.
+5. Put it where rebalance looks:
+
+   ```bash
+   mkdir -p ~/secrets
+   mv ~/Downloads/client_secret_*.json ~/secrets/google_oauth_client.json
+   # or, to keep it anywhere else:
+   export GOOGLE_OAUTH_CLIENT_FILE=/path/to/client_secret.json
+   ```
+
+[`google_oauth_client.example.json`](./google_oauth_client.example.json) shows the
+expected shape. If the file is missing, setup fails with an error naming every path it
+tried — it does not fall back to anything.
+
+After that, each person authorizes their **own** Google account locally against your
+client.
 
 ```bash
 python scripts/setup_calendar_oauth.py --test
@@ -93,7 +116,7 @@ After clicking Allow, the script prints a list of your Google Calendars and thei
 > Your login token is saved to the OS **keyring** (primary) and a JSON fallback in
 > the out-of-repo secret store (`~/.config/rebalance-os/secrets/google-calendar-oauth`,
 > `0600`). It is never stored in the repo. The OAuth token belongs to the
-> authorizing user account on that machine, separate from the bundled Desktop app client.
+> authorizing user account on that machine, separate from your Desktop app client.
 >
 > **Both stores are written in one pass** — `setup_calendar_oauth.py` populates
 > keyring **and** the JSON fallback after consent, so no follow-up
@@ -191,7 +214,7 @@ rebalance calendar-daily-report
 
 You're done. The config already has the shared `calendar_id`, projects, and timezone — you only authorize once so the app can read your calendar on your behalf.
 
-> **Why does each person need to authorize?** The repo includes the shared OAuth Desktop app credentials, but each person must grant consent for their own Google account. Your token is saved to the keyring + a JSON fallback in the secret store (`~/.config/rebalance-os/secrets/google-calendar-oauth`) and never stored in the repo.
+> **Why does each person need to authorize?** Your organization supplies one OAuth client, but each person must grant consent for their own Google account. Your token is saved to the keyring + a JSON fallback in the secret store (`~/.config/rebalance-os/secrets/google-calendar-oauth`) and never stored in the repo.
 
 ---
 
@@ -540,9 +563,8 @@ To automate it on macOS or Linux, add it to your crontab (`crontab -e`):
 
 ### Durable tokens — stop the weekly re-auth
 
-If you keep having to re-authorize, the OAuth consent screen for the bundled
-client is in **"Testing"** publishing status, which expires refresh tokens after
-7 days.
+If you keep having to re-authorize, your OAuth consent screen is in **"Testing"**
+publishing status, which expires refresh tokens after 7 days.
 
 - **Google Workspace accounts:** set the consent screen **User Type → Internal**
   in the Cloud Console
@@ -560,7 +582,11 @@ the keyring + JSON fallback in one pass). The same client backs Gmail — see
 **Common questions**
 
 - **Is my calendar data stored anywhere online?** No — events are pulled to your local machine only and never uploaded.
-- **Do I need my own Google Cloud app or `client_secret.json`?** No — this repo already includes the Desktop app OAuth client configuration needed to start authorization on your machine.
+- **Do I need my own Google Cloud app or `client_secret.json`?** Yes. rebalance ships a
+  template, not a credential — see the setup steps above. This is deliberate: a bundled
+  client's consent screen, verification status and quota belong to whoever published it,
+  and its audience setting decides who is allowed to sign in at all. Owning the client
+  means owning those decisions.
 - **Can I change which calendar I use?** Yes — update `calendar_id` in your config and run `calendar-sync` again.
 - **An event I want to hide keeps showing up** — add a word from its title to `exclude_keywords` in your config.
 - **How do I force canonical project labels in the aggregator?** Add `custom_fields.calendar_aliases` in `Projects/00-project-registry.md`, then run `rebalance ingest sync --mode pull` into the same SQLite database used by calendar reports.

--- a/README.md
+++ b/README.md
@@ -324,7 +324,13 @@ You can still use the source-specific commands:
 
 ### Step 4 — Connect Google Calendar (optional)
 
-OAuth Desktop app credentials are already bundled in the repo. You do **not** need to create a Google Cloud project or download a `client_secret.json`.
+You supply your own OAuth client — rebalance does not bundle one, so your organization
+owns the consent screen, scopes, quota and revocation. It is a five-minute, one-time
+setup in the Google Cloud Console: enable the Calendar API, create a **Desktop app**
+OAuth client, and save the downloaded JSON as `~/secrets/google_oauth_client.json` (or
+point `GOOGLE_OAUTH_CLIENT_FILE` at it). Full walkthrough in
+[GOOGLE_CALENDAR.md](./GOOGLE_CALENDAR.md); expected file shape in
+[`google_oauth_client.example.json`](./google_oauth_client.example.json).
 
 **4a. Install with calendar support**
 

--- a/google_oauth_client.example.json
+++ b/google_oauth_client.example.json
@@ -1,0 +1,30 @@
+{
+  "_comment": [
+    "TEMPLATE — not a working credential. rebalance does not ship a Google OAuth client;",
+    "you create one in your own Google Cloud project so your organization owns consent,",
+    "scopes, quota, audit trail and revocation.",
+    "",
+    "How to get the real file:",
+    "  1. Google Cloud Console -> create or pick a project.",
+    "  2. APIs & Services -> Library -> enable Google Calendar API and/or Gmail API.",
+    "  3. APIs & Services -> OAuth consent screen -> choose the audience:",
+    "       Internal  = only accounts in your own Google Workspace domain",
+    "       External  = anyone with a Google account (needs verification for wide use)",
+    "     Add the scopes for the APIs you enabled.",
+    "  4. APIs & Services -> Credentials -> Create credentials -> OAuth client ID",
+    "     -> Application type: Desktop app. Download the JSON.",
+    "  5. Save it as ~/secrets/google_oauth_client.json, or set",
+    "     GOOGLE_OAUTH_CLIENT_FILE=/path/to/your/client_secret.json",
+    "",
+    "Delete this _comment key in your real file, or leave it — it is ignored.",
+    "Never commit the real file. client_secret for a Desktop app is not a password,",
+    "but it identifies your project and belongs in your secrets dir, not in git."
+  ],
+  "installed": {
+    "client_id": "REPLACE-ME.apps.googleusercontent.com",
+    "client_secret": "REPLACE-ME",
+    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+    "token_uri": "https://oauth2.googleapis.com/token",
+    "redirect_uris": ["http://localhost"]
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rebalance-os"
-version = "0.69.1"
+version = "0.69.2"
 description = "Local-first workday operating system with MCP tools and Obsidian ingest"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/setup_calendar_oauth.py
+++ b/scripts/setup_calendar_oauth.py
@@ -23,7 +23,10 @@ from rebalance.ingest.auth_log import (
     log_flow_succeeded,
     log_flow_failed,
 )
-from rebalance.ingest.google_oauth_client import build_google_oauth_client_config
+from rebalance.ingest.google_oauth_client import (
+    GoogleOAuthClientNotConfigured,
+    build_google_oauth_client_config,
+)
 from rebalance.paths import resolve_oauth_token_path
 
 READONLY_SCOPE = "https://www.googleapis.com/auth/calendar.readonly"
@@ -113,6 +116,12 @@ if __name__ == "__main__":
         print("  4. rebalance calendar-daily-report\n")
         if args.write_access:
             print("Write access is now enabled for calendar event creation.\n")
+
+    except GoogleOAuthClientNotConfigured as e:
+        # A missing client file is a setup step the operator has not done yet, not a
+        # crash. A traceback here buries the instructions that actually fix it.
+        print(f"\n❌ {e}\n")
+        exit(2)
 
     except Exception as e:
         print(f"\n❌ Error: {e}")

--- a/scripts/setup_gmail_oauth.py
+++ b/scripts/setup_gmail_oauth.py
@@ -33,7 +33,10 @@ from rebalance.ingest.auth_log import (
     log_flow_succeeded,
     log_flow_failed,
 )
-from rebalance.ingest.google_oauth_client import build_google_oauth_client_config
+from rebalance.ingest.google_oauth_client import (
+    GoogleOAuthClientNotConfigured,
+    build_google_oauth_client_config,
+)
 from rebalance.paths import resolve_oauth_token_path
 
 GMAIL_READONLY_SCOPE = "https://www.googleapis.com/auth/gmail.readonly"
@@ -113,6 +116,12 @@ if __name__ == "__main__":
         print("Next steps:")
         print("  1. rebalance config set-gmail-method oauth   # if currently on mcp")
         print("  2. rebalance doctor                          # verify gmail is green\n")
+
+    except GoogleOAuthClientNotConfigured as e:
+        # A missing client file is a setup step the operator has not done yet, not a
+        # crash. A traceback here buries the instructions that actually fix it.
+        print(f"\n❌ {e}\n")
+        exit(2)
 
     except Exception as e:
         print(f"\n❌ Error: {e}")

--- a/src/rebalance/__init__.py
+++ b/src/rebalance/__init__.py
@@ -28,7 +28,7 @@ import logging
 import os
 
 __all__ = ["__version__"]
-__version__ = "0.69.1"
+__version__ = "0.69.2"
 
 
 def _configure_logging() -> None:

--- a/src/rebalance/ingest/google_oauth_client.py
+++ b/src/rebalance/ingest/google_oauth_client.py
@@ -1,34 +1,137 @@
-"""Shared Google OAuth 2.0 Desktop client credentials.
+"""Google OAuth 2.0 Desktop client credentials — supplied by the operator.
 
 Both setup scripts (setup_calendar_oauth.py and setup_gmail_oauth.py) use the
-same rebalance-OS Desktop/Installed app client. This module is the single place
-to rotate the credentials — changing _CID/_CS here updates both flows at once.
+same Desktop/Installed app client. rebalance does **not** ship one: you create
+an OAuth client in your own Google Cloud project and point rebalance at it.
 
-Credentials are Base64-encoded to avoid overly-broad secret scanners that do
-not distinguish Desktop app secrets (not sensitive — requires user consent in
-the browser before any data is accessible) from Web app secrets (sensitive).
-See Google OAuth 2.0 for Installed Apps documentation.
+Why bring-your-own rather than a bundled client:
+
+- A bundled client belongs to whoever published it. Its consent screen, its
+  verification status, its quota and its rotation are all that publisher's —
+  and its audience setting decides who can authenticate at all. An "Internal"
+  consent screen restricts sign-in to the publisher's own Workspace domain,
+  which silently locks out every other user.
+- With your own client, your organization owns consent, scope review, quota,
+  audit trail and revocation. Nothing about your Google data routes through
+  someone else's project.
+
+Setup (once):
+
+1. Google Cloud Console → create or pick a project.
+2. APIs & Services → Enable **Google Calendar API** and **Gmail API** (only
+   the ones you intend to use).
+3. APIs & Services → OAuth consent screen. Pick the audience that matches your
+   situation: **Internal** if every user is in your own Workspace domain,
+   **External** otherwise. Add the scopes you enabled above.
+4. Credentials → Create credentials → **OAuth client ID** → application type
+   **Desktop app**. Download the JSON.
+5. Save it where rebalance looks, or point at it explicitly::
+
+       # option A — default location
+       mkdir -p ~/secrets && mv ~/Downloads/client_secret_*.json \\
+           ~/secrets/google_oauth_client.json
+
+       # option B — anywhere, named explicitly
+       export GOOGLE_OAUTH_CLIENT_FILE=/path/to/client_secret.json
+
+A template with the expected shape ships at
+``google_oauth_client.example.json`` in the repo root.
+
+Resolution order: ``GOOGLE_OAUTH_CLIENT_FILE`` → ``google_oauth_client.json``
+in the resolved secrets dir (``REBALANCE_SECRETS_DIR`` / user config /
+``~/secrets``). Missing or malformed files raise
+:class:`GoogleOAuthClientNotConfigured` naming every path that was tried.
 """
 
 from __future__ import annotations
 
-import base64
+import json
+import os
+from pathlib import Path
 
-_CID = "NDA5Mjk4MzQxOTg1LTFrdWI0dTFiMWJkMGxlZWEzYjc0ZDR2bW81Y3F2NzV0LmFwcHMuZ29vZ2xldXNlcmNvbnRlbnQuY29t"
-_CS  = "R09DU1BYLWNxWTA3a0VBZDJTTHM5RWg2MDRqV2NYRGxpQXo="
+from rebalance.paths import resolve_secret_path
 
-_OAUTH_AUTH_URI  = "https://accounts.google.com/o/oauth2/auth"
+CLIENT_FILE_ENV = "GOOGLE_OAUTH_CLIENT_FILE"
+CLIENT_FILE_NAME = "google_oauth_client.json"
+
+_OAUTH_AUTH_URI = "https://accounts.google.com/o/oauth2/auth"
 _OAUTH_TOKEN_URI = "https://oauth2.googleapis.com/token"
+
+_SETUP_HINT = (
+    "Create a Desktop-app OAuth client in your own Google Cloud project "
+    "(Console → APIs & Services → Credentials → OAuth client ID → Desktop app), "
+    f"then either save the downloaded JSON as the path above or set {CLIENT_FILE_ENV} "
+    "to point at it. See google_oauth_client.example.json for the expected shape, "
+    "and GOOGLE_CALENDAR.md / GMAIL.md for the full walkthrough."
+)
+
+
+class GoogleOAuthClientNotConfigured(RuntimeError):
+    """Raised when no operator-supplied OAuth client can be resolved."""
+
+
+def client_file_candidates() -> list[Path]:
+    """Every path consulted, in order. Public so errors and `doctor` agree."""
+    candidates: list[Path] = []
+    explicit = os.environ.get(CLIENT_FILE_ENV)
+    if explicit:
+        candidates.append(Path(explicit).expanduser())
+    candidates.append(resolve_secret_path(CLIENT_FILE_NAME))
+    return candidates
+
+
+def resolve_client_file() -> Path:
+    """Return the first existing candidate, or raise naming all of them."""
+    candidates = client_file_candidates()
+    for path in candidates:
+        if path.is_file():
+            return path
+    tried = "\n".join(f"  - {p}" for p in candidates)
+    raise GoogleOAuthClientNotConfigured(
+        f"No Google OAuth client credentials found. Tried:\n{tried}\n\n{_SETUP_HINT}"
+    )
 
 
 def build_google_oauth_client_config() -> dict:
-    """Return the installed-app client config dict for Google OAuth flows."""
+    """Return the installed-app client config dict for Google OAuth flows.
+
+    Reads the operator's own downloaded client JSON. Google writes it under an
+    ``installed`` key for Desktop apps; a ``web`` key means the wrong
+    application type was chosen, which is worth saying plainly rather than
+    failing later inside the flow with a redirect-URI mismatch.
+    """
+    path = resolve_client_file()
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise GoogleOAuthClientNotConfigured(
+            f"Could not read Google OAuth client credentials at {path}: {exc}\n\n{_SETUP_HINT}"
+        ) from exc
+
+    if "web" in raw and "installed" not in raw:
+        raise GoogleOAuthClientNotConfigured(
+            f"{path} holds a **Web application** OAuth client; rebalance needs a "
+            "**Desktop app** client. Create one of type 'Desktop app' and download it again."
+        )
+
+    section = raw.get("installed") or raw
+    client_id = section.get("client_id")
+    client_secret = section.get("client_secret")
+    if not client_id or not client_secret:
+        raise GoogleOAuthClientNotConfigured(
+            f"{path} is missing client_id and/or client_secret.\n\n{_SETUP_HINT}"
+        )
+
+    redirect_uris = section.get("redirect_uris") or ["http://localhost"]
+    if "http://localhost" not in redirect_uris:
+        redirect_uris = [*redirect_uris, "http://localhost"]
+
     return {
         "installed": {
-            "client_id":     base64.b64decode(_CID).decode(),
-            "client_secret": base64.b64decode(_CS).decode(),
-            "auth_uri":      _OAUTH_AUTH_URI,
-            "token_uri":     _OAUTH_TOKEN_URI,
-            "redirect_uris": ["http://localhost"],
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "auth_uri": section.get("auth_uri") or _OAUTH_AUTH_URI,
+            "token_uri": section.get("token_uri") or _OAUTH_TOKEN_URI,
+            "redirect_uris": redirect_uris,
         }
     }

--- a/tests/test_google_oauth_client.py
+++ b/tests/test_google_oauth_client.py
@@ -1,56 +1,126 @@
-"""Contract tests for the shared Google OAuth client credentials module.
+"""Contract tests for the operator-supplied Google OAuth client module.
 
-Written BEFORE the credential extraction (Phase 1 QA: contract tests land
-before module movement). Verifies the shared module produces the same decoded
-values that the original per-script constants produced.
+Rewritten for GH-276: rebalance no longer ships a Google OAuth client. The
+credentials are read from a file the operator downloads from their own Google
+Cloud project, so the contract under test changed from "reproduces the embedded
+constants" to "resolves the operator's file, or fails loudly naming every path
+it tried".
+
+The old golden-constant assertions were deleted rather than adapted — they
+pinned a bundled secret whose whole point was that it no longer exists.
 """
 
 from __future__ import annotations
 
-import base64
+import json
+import os
+import tempfile
 import unittest
-
-# The values the two scripts embedded before extraction — golden reference.
-_GOLDEN_CID_B64 = "NDA5Mjk4MzQxOTg1LTFrdWI0dTFiMWJkMGxlZWEzYjc0ZDR2bW81Y3F2NzV0LmFwcHMuZ29vZ2xldXNlcmNvbnRlbnQuY29t"
-_GOLDEN_CS_B64  = "R09DU1BYLWNxWTA3a0VBZDJTTHM5RWg2MDRqV2NYRGxpQXo="
-_GOLDEN_CID     = base64.b64decode(_GOLDEN_CID_B64).decode()
-_GOLDEN_CS      = base64.b64decode(_GOLDEN_CS_B64).decode()
+from pathlib import Path
+from unittest import mock
 
 
-class GoogleOAuthCredentialsContractTests(unittest.TestCase):
-    """build_google_oauth_client_config() must reproduce the original constants."""
+def _write_client(directory: Path, *, key: str = "installed", **overrides) -> Path:
+    payload = {
+        key: {
+            "client_id": "test-client.apps.googleusercontent.com",
+            "client_secret": "test-secret",
+            **overrides,
+        }
+    }
+    path = directory / "google_oauth_client.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
 
-    def _config(self) -> dict:
+
+class OperatorSuppliedClientTests(unittest.TestCase):
+    """build_google_oauth_client_config() reads the operator's own file."""
+
+    def _build(self):
         from rebalance.ingest.google_oauth_client import build_google_oauth_client_config
         return build_google_oauth_client_config()
 
-    def test_returns_installed_key(self) -> None:
-        cfg = self._config()
-        self.assertIn("installed", cfg)
+    def test_reads_client_from_env_pointed_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_client(Path(tmp))
+            with mock.patch.dict(os.environ, {"GOOGLE_OAUTH_CLIENT_FILE": str(path)}):
+                cfg = self._build()
+        self.assertEqual(cfg["installed"]["client_id"], "test-client.apps.googleusercontent.com")
+        self.assertEqual(cfg["installed"]["client_secret"], "test-secret")
 
-    def test_client_id_matches_golden(self) -> None:
-        cfg = self._config()
-        self.assertEqual(cfg["installed"]["client_id"], _GOLDEN_CID)
-
-    def test_client_secret_matches_golden(self) -> None:
-        cfg = self._config()
-        self.assertEqual(cfg["installed"]["client_secret"], _GOLDEN_CS)
-
-    def test_auth_uri(self) -> None:
-        cfg = self._config()
+    def test_defaults_are_filled_in(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_client(Path(tmp))
+            with mock.patch.dict(os.environ, {"GOOGLE_OAUTH_CLIENT_FILE": str(path)}):
+                cfg = self._build()
         self.assertEqual(cfg["installed"]["auth_uri"], "https://accounts.google.com/o/oauth2/auth")
-
-    def test_token_uri(self) -> None:
-        cfg = self._config()
         self.assertEqual(cfg["installed"]["token_uri"], "https://oauth2.googleapis.com/token")
-
-    def test_redirect_uris_contains_localhost(self) -> None:
-        cfg = self._config()
         self.assertIn("http://localhost", cfg["installed"]["redirect_uris"])
 
-    def test_idempotent_calls_return_equal_dicts(self) -> None:
-        from rebalance.ingest.google_oauth_client import build_google_oauth_client_config
-        self.assertEqual(build_google_oauth_client_config(), build_google_oauth_client_config())
+    def test_missing_file_raises_naming_every_candidate(self) -> None:
+        """The error has to be actionable: silence here is a support ticket."""
+        from rebalance.ingest.google_oauth_client import (
+            GoogleOAuthClientNotConfigured,
+            client_file_candidates,
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            env = {
+                "GOOGLE_OAUTH_CLIENT_FILE": str(Path(tmp) / "absent.json"),
+                "REBALANCE_SECRETS_DIR": str(Path(tmp) / "secrets"),
+            }
+            with mock.patch.dict(os.environ, env):
+                candidates = client_file_candidates()
+                with self.assertRaises(GoogleOAuthClientNotConfigured) as ctx:
+                    self._build()
+        message = str(ctx.exception)
+        for candidate in candidates:
+            self.assertIn(str(candidate), message)
+
+    def test_web_client_is_rejected_by_name(self) -> None:
+        """A Web client fails later with an opaque redirect_uri mismatch — say it now."""
+        from rebalance.ingest.google_oauth_client import GoogleOAuthClientNotConfigured
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_client(Path(tmp), key="web")
+            with mock.patch.dict(os.environ, {"GOOGLE_OAUTH_CLIENT_FILE": str(path)}):
+                with self.assertRaises(GoogleOAuthClientNotConfigured) as ctx:
+                    self._build()
+        self.assertIn("Desktop app", str(ctx.exception))
+
+    def test_malformed_json_raises_configured_error_not_json_error(self) -> None:
+        from rebalance.ingest.google_oauth_client import GoogleOAuthClientNotConfigured
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "google_oauth_client.json"
+            path.write_text("{ not json", encoding="utf-8")
+            with mock.patch.dict(os.environ, {"GOOGLE_OAUTH_CLIENT_FILE": str(path)}):
+                with self.assertRaises(GoogleOAuthClientNotConfigured):
+                    self._build()
+
+    def test_no_credential_is_embedded_in_the_module(self) -> None:
+        """The regression that matters: a real client must never come back."""
+        import rebalance.ingest.google_oauth_client as mod
+        source = Path(mod.__file__).read_text(encoding="utf-8")
+        self.assertNotIn("apps.googleusercontent.com\"", source)
+        self.assertNotIn("GOCSPX-", source)
+        self.assertNotIn("base64", source)
+
+
+class ShippedTemplateTests(unittest.TestCase):
+    """The committed template must stay a template."""
+
+    def _template(self) -> Path:
+        from rebalance.paths import find_project_root
+        root = find_project_root(Path(__file__))
+        assert root is not None
+        return root / "google_oauth_client.example.json"
+
+    def test_template_exists_and_parses(self) -> None:
+        data = json.loads(self._template().read_text(encoding="utf-8"))
+        self.assertIn("installed", data)
+
+    def test_template_holds_no_real_credential(self) -> None:
+        data = json.loads(self._template().read_text(encoding="utf-8"))
+        self.assertIn("REPLACE-ME", data["installed"]["client_id"])
+        self.assertEqual(data["installed"]["client_secret"], "REPLACE-ME")
 
 
 class AuthLogFlowSourceTests(unittest.TestCase):

--- a/utils/3-eyes/README.md
+++ b/utils/3-eyes/README.md
@@ -1,5 +1,17 @@
 # 3-Eyes — optional, experimental, always-safe local job supervisor
 
+> ## ⚠️ ALPHA — not fully working
+>
+> 3-Eyes ships in **alpha** and is **not** part of the supported core. It is a
+> diagnostic tool, and it has known open defects — including that `three_eyes pause`
+> does **not** stop a launchd-managed job, so a "paused" writer can still be running.
+> If you need a job genuinely stopped, use `launchctl bootout` and verify it.
+>
+> Treat 3-Eyes output as a hint, never as proof. Nothing in the core `rebalance`
+> product depends on it, and you can ignore this directory entirely.
+>
+> We tell you what's real, and what isn't yet — this one isn't yet.
+
 GH-195. One system unifying the three sentinels we run today — the XYZ debug
 flywheel, the Cactus Needle PDDA sentinel, and the Rebalance collector-health
 sentinel — under **one TOML registry, one set of circuit breakers + relief valves,

--- a/utils/3-eyes/three_eyes/__main__.py
+++ b/utils/3-eyes/three_eyes/__main__.py
@@ -213,7 +213,15 @@ def _cmd_uninstall(args) -> int:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="three_eyes", description="3-Eyes job supervisor (GH-195)")
+    parser = argparse.ArgumentParser(
+        prog="three_eyes",
+        description=(
+            "3-Eyes job supervisor (GH-195) — ALPHA, not fully working. "
+            "Diagnostic tool, not part of the supported core. Known defect: `pause` does "
+            "not stop a launchd-managed job, so a paused writer may still be running — use "
+            "`launchctl bootout` and verify. Treat its output as a hint, never as proof."
+        ),
+    )
     sub = parser.add_subparsers(dest="cmd", required=True)
 
     def _job_cmd(name, func, help_):

--- a/utils/3-eyes/three_eyes/catalog.py
+++ b/utils/3-eyes/three_eyes/catalog.py
@@ -99,7 +99,7 @@ def render(notes: dict | None = None) -> str:
         "> (committed curation) ⋈ live `three_eyes observe`. Refresh: `python -m three_eyes catalog --write`.",
         ">",
         "> Companion to [`DASHBOARD.md`](DASHBOARD.md) (what 3-Eyes *manages*) and",
-        "> [`~/bin/servers.md`](file:///Users/noelsaw/bin/servers.md) (ports/long-running servers).",
+        "> `~/bin/servers.md` (ports/long-running servers).",
         "",
         f"**Inventory:** {len([a for a in agents if not a.get('unreadable')])} launchd agents "
         f"({managed} 🟢 managed · {to_adopt} 🎯 to-adopt · {vendor} vendor/OS ignored"

--- a/utils/obsidian_daily_rollover.py
+++ b/utils/obsidian_daily_rollover.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -53,7 +54,9 @@ def _log_job(event: str, elapsed: float | None = None, exit_code: int | None = N
         log_job_failed("obsidian-rollover", exit_code or 1, elapsed)
 
 # --- Configuration -----------------------------------------------------------
-VAULT = Path("/Users/noelsaw/Documents/Noel Saw")
+# Operator-specific. Set OBSIDIAN_VAULT to your own vault; the former hardcoded
+# default named one operator's home directory and could not work anywhere else.
+VAULT = Path(os.environ.get("OBSIDIAN_VAULT", str(Path.home() / "Documents" / "Obsidian Vault")))
 TODAY_FILE = VAULT / "0. Today's Notes.md"
 YESTERDAY_FILE = VAULT / "0. Yesterday.md"
 


### PR DESCRIPTION
Cutover prep for the public release, done source-side so the sanitized clone is cut from an already-clean tree. Tracked in #276 (sections 9–11).

## 1. Google OAuth becomes bring-your-own-client

**Operator decision:** ship a template and instructions; each organization signs with its own client.

The repo embedded a live Desktop-app client id and secret, stored **base64-encoded**, and the module's own docstring gave the reason — *"to avoid overly-broad secret scanners."* That is the part worth naming: the release plan leans on a TruffleHog gate, and that gate would have reported this repository clean while publishing a working credential. A regression test now fails if a credential, or the base64 indirection itself, reappears.

It was also a hard blocker for public use. A consent screen's **audience** decides who may authenticate at all, and ours is **Internal** — chosen deliberately to stop the 7-day refresh-token expiry — which locks out everyone outside the publishing Workspace domain. Owning the client moves that decision to each organization instead of inheriting ours. **This closes the section 11 blocker.**

| | |
|---|---|
| Resolution order | `GOOGLE_OAUTH_CLIENT_FILE` → `google_oauth_client.json` in the secrets dir. No fallback. |
| Missing file | Error naming **every** path tried, plus the five Cloud Console steps |
| Wrong client type | A "Web application" client is rejected **by name**, rather than failing later with an opaque redirect-URI mismatch |
| Setup scripts | Print the fix and exit 2, instead of a traceback at someone who has not done a setup step |
| Template | `google_oauth_client.example.json`, annotated |
| Docs | README Step 4, GOOGLE_CALENDAR.md, GMAIL.md all claimed "already bundled, you do not need a Cloud project" — all three now say the opposite |

**Action required for existing installs:** download your own client JSON from the Cloud project you already own, save to `~/secrets/google_oauth_client.json`. Existing tokens keep working until they expire. **The embedded client should be revoked** — it is recoverable from git history.

## 2. 3-Eyes ships labelled alpha

Per the operator decision to ship it rather than drop it. Banner in `utils/3-eyes/README.md` and in `three_eyes --help`, both naming the known defect: `pause` does not stop a launchd-managed job, so a "paused" writer can still be running — use `launchctl bootout` and verify. That one cost a real aborted run, so it is named rather than left as a general caveat.

## 3. Operator PII removed from tracked files

- `CHANGELOG.md` — 3 home-directory paths including a `~/secrets/*.env` path
- `three_eyes/catalog.py` — a `file:///Users/...` URL emitted into generated `CATALOG.md` output
- `utils/obsidian_daily_rollover.py` — hardcoded vault path containing an operator's **full name**; now `OBSIDIAN_VAULT`

The CHANGELOG fix resolves a contradiction in the release plan, which required that file to ship verbatim while forbidding exactly those strings.

## Verification

```
.venv/bin/pytest tests/          1728 passed, 0 failed, 10 xfailed (2m03s)
.venv/bin/pytest tests/ utils/3-eyes/tests/   1937 passed, 0 failed (pre-OAuth change)
three_eyes --help                alpha banner renders
setup_calendar_oauth.py          missing client → names both paths, exit 2
```

Version 0.69.1 → 0.69.2 with a CHANGELOG entry carrying the action-required note.

**Still open in #276:** `.claude/settings.json` holds 7 machine-local paths (write-protected in my environment, needs scrubbing at cutover), and `phases/` + `logs/` are absent from the keep/drop manifest while containing operator paths.