### PR TITLE
docs: name the dev extra, and where to run pytest from

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,11 @@ python3 -m venv .venv
 > On Linux / Windows / Intel Mac, drop the `embeddings` extra:
 > `pip install -e ".[calendar]"` (semantic search will be unavailable; everything else works).
 
+> **To run the test suite**, add the `dev` extra — it is not included above:
+> `.venv/bin/pip install -e ".[dev]"`, then `.venv/bin/pytest tests/` from the repo root.
+> Run it from the repo root; `pytest` invoked from inside `src/rebalance/` puts that
+> directory on `sys.path`, where the local `mcp/` package shadows the installed MCP SDK.
+
 ### Step 2 — Ingest your vault
 
 ```bash


### PR DESCRIPTION
Two lines closing the last shakedown finding that belongs in the RC.

**A fresh clone cannot run the test suite.** The documented Step 1 install carries no `pytest`, and the `dev` extra that provides it is never mentioned in the README. Shakedown cells 1–3 all died with `No module named pytest` against a candidate installed exactly as the README instructs.

**And it records where to run pytest from.** Cell 3 (nested directory) fails at collection:

```
mcp/server.py:6: from mcp.server.fastmcp import FastMCP
E ImportError: cannot import name 'create_server' from partially initialized
  module 'rebalance.mcp.server' (most likely due to a circular import)
```

Running `pytest` from inside `src/rebalance/` puts that directory on `sys.path`, where our own `mcp/` subpackage shadows the installed MCP SDK. Not #255 resurfacing — that was a relative path and is fixed. This is a name collision with a third-party dependency.

Renaming the subpackage would be the real fix and is not RC work. Telling people where to run the suite from costs one sentence and prevents the ambush.
