### PR TITLE
refactor(GH-292): route all clock reads through the shared time library (~90 sites)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@
 > **not** reintroduce an `[Unreleased]` block — add to (or roll work into) the
 > current dated version instead. See AGENTS.md → "Versioning & Changelog".
 
+## [0.69.4] - 2026-08-15
+
+### Changed
+- **Every "what time is now" read now goes through the shared time library.** All ~90 direct
+  clock calls across the ingest collectors, CLI, and render surfaces were consolidated onto the
+  canonical helpers, which route through the freeze-clock test seam — previously a direct call
+  silently bypassed it, so time-sensitive code could not be deterministically tested. Output
+  formats are byte-identical to before, including the second-precision variants used in scan
+  stamps. A handful of modules that inject the timestamp as a parameter keep that seam; the
+  shared functions are aliased there so both can coexist.
+
 ## [0.69.2] - 2026-08-15
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rebalance-os"
-version = "0.69.2"
+version = "0.69.4"
 description = "Local-first workday operating system with MCP tools and Obsidian ingest"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/audit_modules.py
+++ b/scripts/audit_modules.py
@@ -58,8 +58,8 @@ import json
 import re
 import subprocess
 import sys
-from datetime import datetime, timezone
 from pathlib import Path
+from rebalance.lib.time_ops import now_utc
 
 # Schema version for machine consumers. Bump when the JSON shape changes
 # in a non-additive way.
@@ -178,7 +178,7 @@ def write_lockfile(arch_missing, changelog_missing):
             "are silenced from the audit until removed. Re-generate after a "
             "deliberate doc backfill via: python scripts/audit_modules.py --init"
         ),
-        "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "generated_at": now_utc().isoformat(timespec="seconds"),
         "missing_from_architecture": sorted(arch_missing),
         "missing_from_changelog": sorted(changelog_missing),
     }
@@ -376,7 +376,7 @@ def run_audit(commits_window, include_uncommitted=False):
     """Run all checks and return the structured result dict."""
     result = {
         "audit_version": AUDIT_VERSION,
-        "ran_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "ran_at": now_utc().isoformat(timespec="seconds"),
         "candidate_modules_count": 0,
         "checks": {},
         "passed": True,

--- a/scripts/dashboard.py
+++ b/scripts/dashboard.py
@@ -33,7 +33,6 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
-from rich.align import Align
 from rich.box import ROUNDED
 from rich.console import Console, Group
 from rich.layout import Layout
@@ -53,7 +52,7 @@ from rebalance.ingest.config import (  # noqa: E402
 from rebalance.ingest.calendar_config import OPERATOR_CALENDAR_ID  # noqa: E402
 from rebalance.ingest.calendar_helpers import upcoming_calendar_rows  # noqa: E402
 from rebalance.ingest.db import db_connection  # noqa: E402
-from rebalance.lib.time_ops import local_tz, parse_utc_iso  # noqa: E402
+from rebalance.lib.time_ops import local_tz, _now_iso, _now_utc, parse_utc_iso  # noqa: E402
 from rebalance.ingest.index_ops import (  # noqa: E402
     get_index_status,
     get_watched_repos,
@@ -166,19 +165,19 @@ class RefreshState:
     def start(self) -> None:
         with self.lock:
             self.status = "running"
-            self.last_started = datetime.now(timezone.utc)
+            self.last_started = _now_utc()
 
     def succeed(self, profile: dict[str, Any] | None = None) -> None:
         with self.lock:
             self.status = "ok"
-            self.last_finished = datetime.now(timezone.utc)
+            self.last_finished = _now_utc()
             self.last_error = ""
             self.last_profile = profile
 
     def fail(self, err: str) -> None:
         with self.lock:
             self.status = "error"
-            self.last_finished = datetime.now(timezone.utc)
+            self.last_finished = _now_utc()
             self.last_error = err
 
     def snapshot(self) -> dict[str, Any]:
@@ -226,7 +225,7 @@ def _write_refresh_profile(result: dict[str, Any]) -> None:
     LOG_DIR.mkdir(parents=True, exist_ok=True)
     log_path = LOG_DIR / f"github_refresh_{datetime.now(TZ).date().isoformat()}.log"
     record = {
-        "logged_at": datetime.now(timezone.utc).isoformat(),
+        "logged_at": _now_iso(),
         "source": "dashboard",
         "result": result,
     }
@@ -279,7 +278,7 @@ def _ago(value: str | datetime | None, now: datetime | None = None) -> str:
         return "—"
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
-    n = now or datetime.now(timezone.utc)
+    n = now or _now_utc()
     delta = n - dt
     secs = int(delta.total_seconds())
     if secs < 0:
@@ -455,7 +454,7 @@ def fetch_recent_auto_promotion(days: int = 7) -> dict[str, Any] | None:
     except Exception:  # noqa: BLE001 — empty DB before first sync
         return None
 
-    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+    cutoff = _now_utc() - timedelta(days=days)
     best: tuple[datetime, dict[str, Any]] | None = None
     for row in rows:
         try:
@@ -633,7 +632,7 @@ def fetch_open_prs(limit: int = 10, stale_days: int = 2) -> list[dict[str, Any]]
     Each row gets an ``age_days`` int and a ``is_stale`` bool (age > stale_days).
     Closed PRs drop off automatically since we filter on state='open'.
     """
-    from datetime import datetime, timezone  # noqa: PLC0415
+    from datetime import datetime  # noqa: PLC0415
     try:
         with db_connection(DB_PATH) as conn:
             rows = conn.execute(
@@ -653,7 +652,7 @@ def fetch_open_prs(limit: int = 10, stale_days: int = 2) -> list[dict[str, Any]]
     except sqlite3.OperationalError:
         return []
 
-    now = datetime.now(timezone.utc)
+    now = _now_utc()
     out = []
     for r in rows:
         try:
@@ -780,7 +779,7 @@ def fetch_sleuth_display_sections() -> tuple[list[dict[str, Any]], int]:
     ] or ["dueToday", "dueUpcoming", "dueLastWeek", "dueOlder"]
 
     reminders_raw = data.get("reminders") or []
-    now_utc = datetime.now(timezone.utc)
+    now_utc = _now_utc()
 
     sections_by_key: dict[str, dict[str, Any]] = {}
     for r in reminders_raw:
@@ -1220,7 +1219,7 @@ def build_layout() -> Layout:
 
 
 def render(layout: Layout) -> Layout:
-    now = datetime.now(timezone.utc)
+    now = _now_utc()
 
     try:
         watched = fetch_watched_summary(now)

--- a/scripts/health_issue_reporter.py
+++ b/scripts/health_issue_reporter.py
@@ -68,10 +68,10 @@ import socket
 import sys
 import urllib.error
 import urllib.request
-from datetime import datetime, timezone
 from pathlib import Path
 
 import _bootstrap  # noqa: F401  — puts src/ on sys.path for rebalance.* imports
+from rebalance.lib.time_ops import now_utc
 
 DEVICE_NAME: str = socket.gethostname()
 
@@ -145,7 +145,7 @@ class RunLog:
 # ---------------------------------------------------------------------------
 
 def _today_utc() -> str:
-    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    return now_utc().strftime("%Y-%m-%d")
 
 
 def load_quota() -> dict:
@@ -226,7 +226,7 @@ def list_health_issues(token: str, repo: str, state: str = "open",
     issues: dict[str, dict] = {}
     since_param = ""
     if state == "closed":
-        cutoff = (datetime.now(timezone.utc) - timedelta(days=since_days)).strftime(
+        cutoff = (now_utc() - timedelta(days=since_days)).strftime(
             "%Y-%m-%dT%H:%M:%SZ")
         since_param = f"&since={cutoff}"
     page = 1
@@ -384,7 +384,7 @@ def update_issue_body(
 # ---------------------------------------------------------------------------
 
 def _issue_body(check_name: str, status: str, detail: str, hint: str, source: str) -> str:
-    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    now = now_utc().strftime("%Y-%m-%dT%H:%M:%SZ")
     parts = [
         f"> **Seen:** 1× · Last: {now} · Device: {DEVICE_NAME}\n",
         check_id_marker(check_name),
@@ -625,7 +625,7 @@ def main() -> int:
     parser.add_argument("--repo", default=REPO, metavar="OWNER/REPO")
     args = parser.parse_args()
 
-    now_str = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    now_str = now_utc().strftime("%Y-%m-%dT%H:%M:%SZ")
     run_log = RunLog(now_str, {
         "repo": args.repo, "warn": args.warn, "close": args.close,
         "llm_triage": args.llm_triage, "llm_provider": args.llm_provider,

--- a/scripts/pulse_server.py
+++ b/scripts/pulse_server.py
@@ -32,6 +32,7 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import FileResponse, JSONResponse, Response
 from pydantic import BaseModel
 import uvicorn
+from rebalance.lib.time_ops import now_utc
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 PULSE_HTML = PROJECT_ROOT / "web" / "pulse.html"
@@ -299,7 +300,7 @@ def health():
     if not PULSE_HTML.exists():
         return JSONResponse({"ok": False, "reason": "pulse.html missing"}, status_code=503)
     mtime = datetime.fromtimestamp(PULSE_HTML.stat().st_mtime, tz=timezone.utc)
-    age_s = (datetime.now(timezone.utc) - mtime).total_seconds()
+    age_s = (now_utc() - mtime).total_seconds()
     return {
         "ok": True,
         "generated_at": mtime.isoformat(),
@@ -451,7 +452,7 @@ class GoalUndoRequest(BaseModel):
 
 def _history_payload(goals_path: Path) -> list[dict[str, str]]:
     items = load_goal_history(goals_path=goals_path)
-    now = datetime.now(timezone.utc)
+    now = now_utc()
     out: list[dict[str, str]] = []
     for item in items:
         completed_at = item.get("completed_at")

--- a/scripts/pulse_warning_watch.py
+++ b/scripts/pulse_warning_watch.py
@@ -29,13 +29,13 @@ import html
 import json
 import re
 import subprocess
-import sys
 import time
 from dataclasses import asdict, dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 from html.parser import HTMLParser
 from pathlib import Path
 from typing import Any
+from rebalance.lib.time_ops import now_utc
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_URL = "http://127.0.0.1:8767/"
@@ -130,7 +130,7 @@ class _PulseHTMLParser(HTMLParser):
 
 
 def _utc_now() -> datetime:
-    return datetime.now(timezone.utc)
+    return now_utc()
 
 
 def _iso_now() -> str:

--- a/scripts/pulse_web.py
+++ b/scripts/pulse_web.py
@@ -31,6 +31,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo
+from rebalance.lib.time_ops import now_utc
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 # Canonical path shared with pulse_server.py — must stay in sync
@@ -61,20 +62,19 @@ from dashboard import (  # type: ignore  # noqa: E402
 )
 from rebalance.doctor import FAIL, WARN, Check, run_doctor  # noqa: E402
 from rebalance.health import HealthStatus, compute_health_status  # noqa: E402
-from rebalance.ingest.apple_reminders import list_apple_reminders  # noqa: E402
 from rebalance.ingest.config import get_figma_file_keys  # noqa: E402
 from rebalance.ingest.goals_file import (  # noqa: E402
-    CHECKBOX_RE,
-    complete_goal_in_file,
+    # Re-exported for the pulse server's goal routes (pulse_server imports
+    # these from here, not from goals_file).
+    complete_goal_in_file,  # noqa: F401
+    undo_goal_completion_in_file,  # noqa: F401
     goal_completion_still_applied as _goal_completion_still_applied,
     parse_goals,
-    undo_goal_completion_in_file,
 )
 from rebalance.ingest.index_ops import COLLECTORS, get_index_status  # noqa: E402
 from rebalance.ingest import next_actions  # noqa: E402
 from rebalance.ingest.slack_users import compact_sleuth_reminder  # noqa: E402
 from rebalance.web_components import (  # noqa: E402
-    RB_BUTTON_CSS,
     RB_CHROME_CSS,
     RB_TOKENS_CSS,
     badge_html,
@@ -282,7 +282,7 @@ def fetch_health_filed_count(days: int = 30) -> int:
     from datetime import timedelta  # noqa: PLC0415
     if not HEALTH_LOG_PATH.exists():
         return 0
-    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+    cutoff = now_utc() - timedelta(days=days)
     seen: set[str] = set()
     try:
         for raw in HEALTH_LOG_PATH.read_text(encoding="utf-8").splitlines():
@@ -2981,7 +2981,7 @@ def _resolve_tz_source() -> tuple[str, bool]:
 
 
 def build_page(*, goals_path: Path, vault_path: Path | None, refresh_seconds: int) -> str:
-    now = datetime.now(timezone.utc)
+    now = now_utc()
     local_now = now.astimezone(TZ)
 
     all_goals = parse_goals(goals_path, limit=PRIMARY_GOAL_LIMIT + SECONDARY_TODO_LIMIT)

--- a/scripts/spike_morning_brief.py
+++ b/scripts/spike_morning_brief.py
@@ -27,9 +27,10 @@ import json
 import os
 import sys
 import time
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+from rebalance.lib.time_ops import now_utc
 
 # --- repo imports (canonical read paths, same as MCP server / querier) --------
 from rebalance.ingest.calendar_config import OPERATOR_CALENDAR_ID
@@ -50,7 +51,7 @@ def _resolve_db_path() -> Path:
 
 
 def _now_local() -> datetime:
-    return datetime.now(timezone.utc).astimezone()
+    return now_utc().astimezone()
 
 
 def _parse_iso(value: str | None) -> datetime | None:

--- a/src/rebalance/__init__.py
+++ b/src/rebalance/__init__.py
@@ -28,7 +28,7 @@ import logging
 import os
 
 __all__ = ["__version__"]
-__version__ = "0.69.2"
+__version__ = "0.69.4"
 
 
 def _configure_logging() -> None:

--- a/src/rebalance/cli/raw.py
+++ b/src/rebalance/cli/raw.py
@@ -13,7 +13,7 @@ import typer
 
 from rebalance.cli._core import app
 from rebalance.ingest.config import get_github_ignored_repos
-from rebalance.lib.time_ops import format_local, parse_utc_iso
+from rebalance.lib.time_ops import format_local, _now_utc, parse_utc_iso
 from rebalance.paths import DatabaseNotFoundError, DBOption, resolve_database_path
 
 
@@ -84,9 +84,9 @@ def _raw_gather_team_activity(
     N minutes and excluding the current user (those are already in the user-activity
     section).
     """
-    from datetime import datetime, timedelta, timezone
+    from datetime import datetime, timedelta
 
-    cutoff = datetime.now(timezone.utc) - timedelta(minutes=minutes)
+    cutoff = _now_utc() - timedelta(minutes=minutes)
     top_repos = _raw_get_top_active_repos(db_path, top_n)
 
     last_active_map: dict[str, datetime] = {}
@@ -149,7 +149,7 @@ def _raw_gather_unwatched_active_repos(
 
     Cost: 1 GH API request per probe.
     """
-    from datetime import datetime, timedelta, timezone
+    from datetime import timedelta
 
     from rebalance.ingest.github_scan import fetch_pushed_repos
     from rebalance.ingest.index_ops import get_watched_repos
@@ -172,7 +172,7 @@ def _raw_gather_unwatched_active_repos(
     # for the same pattern (config stores lowercase, GitHub returns original casing).
     ignored_lower = {r.lower() for r in get_github_ignored_repos()}
 
-    cutoff = datetime.now(timezone.utc) - timedelta(days=fresh_threshold_days)
+    cutoff = _now_utc() - timedelta(days=fresh_threshold_days)
     repos: list[dict[str, Any]] = []
     for rec in records:
         if rec.repo_full_name in watched or rec.repo_full_name.lower() in ignored_lower:
@@ -195,11 +195,11 @@ def _raw_gather_unwatched_active_repos(
 
 def _raw_gather_snapshot(login: str, token: str, db_path: Path, minutes: int, top_n: int) -> dict[str, Any]:
     """Fetch recent GH events and classify each against local pipeline state."""
-    from datetime import datetime, timedelta, timezone
+    from datetime import datetime, timedelta
 
     from rebalance.ingest.github_scan import _fetch_events
 
-    cutoff = datetime.now(timezone.utc) - timedelta(minutes=minutes)
+    cutoff = _now_utc() - timedelta(minutes=minutes)
 
     # 1 API request: events API caps recent activity at ~30 days; we just need the latest page.
     events = _fetch_events(login, token, days=1)
@@ -252,7 +252,7 @@ def _raw_gather_snapshot(login: str, token: str, db_path: Path, minutes: int, to
 
     return {
         "raw_version": 1,
-        "scanned_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "scanned_at": _now_utc().isoformat(timespec="seconds"),
         "login": login,
         "window_minutes": minutes,
         "events": items,
@@ -268,7 +268,6 @@ def _raw_gather_snapshot(login: str, token: str, db_path: Path, minutes: int, to
 
 def _raw_render_text(snapshot: dict[str, Any]) -> None:
     """Render snapshot as a Rich table for terminal use."""
-    from datetime import datetime
     from rich.console import Console
     from rich.table import Table
 
@@ -349,13 +348,12 @@ def _raw_render_text(snapshot: dict[str, Any]) -> None:
         console.print()
         console.print(f"[yellow]Unwatched-repos check skipped: {unwatched['error']}[/yellow]")
     elif unwatched.get("repos"):
-        from datetime import datetime, timezone
         console.print()
         console.print(
             f"[red]Unwatched repos with recent pushes "
             f"(last {unwatched['fresh_threshold_days']}d, not in github_repo_meta or ignored list):[/red]"
         )
-        now_utc = datetime.now(timezone.utc)
+        now_utc = _now_utc()
         for r in unwatched["repos"]:
             pushed = parse_utc_iso(r["pushed_at"])
             if not pushed:

--- a/src/rebalance/doctor.py
+++ b/src/rebalance/doctor.py
@@ -20,7 +20,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, Literal
 
-from rebalance.lib.time_ops import format_timestamp, local_tz, parse_utc_iso
+from rebalance.lib.time_ops import format_timestamp, local_tz, now_utc, parse_utc_iso
 
 OK = "ok"
 WARN = "warn"
@@ -484,7 +484,7 @@ def _check_collector_freshness(
             latest_dt = parse_utc_iso(str(latest))
             if latest_dt:
                 age_days = (
-                    datetime.now(timezone.utc).date()
+                    now_utc().date()
                     - latest_dt.date()
                 ).days
                 if age_days > warn_days:
@@ -795,7 +795,7 @@ def _check_launchd(
             log_dir = resolve_project_root(Path(__file__)) / "temp" / "logs"
         except RuntimeError:
             log_dir = Path("temp/logs")
-    now = now or datetime.now(timezone.utc)
+    now = now or now_utc()
 
     crash_state_path = _launchd_crash_state_path(log_dir)
     crash_state = _load_launchd_crash_state(crash_state_path)
@@ -936,7 +936,6 @@ def _check_sleuth(db_path: Path | None = None) -> Check:
     # reread even when the upstream export is dead — against now.
     if db_path is not None:
         try:
-            from datetime import datetime, timezone
 
             from rebalance.ingest.sleuth_reminders import get_export_generated_at
 
@@ -944,7 +943,7 @@ def _check_sleuth(db_path: Path | None = None) -> Check:
         except Exception:  # noqa: BLE001 — never let the freshness probe crash doctor
             beat = None
         if beat is not None:
-            age_h = (datetime.now(timezone.utc) - beat).total_seconds() / 3600
+            age_h = (now_utc() - beat).total_seconds() / 3600
             stamp = beat.isoformat()
             if age_h > _SLEUTH_HEARTBEAT_STALE_HOURS:
                 sync_repo = get_sleuth_sync_repo_path() or "~/git-pulse-sync"

--- a/src/rebalance/ingest/apple_reminders.py
+++ b/src/rebalance/ingest/apple_reminders.py
@@ -50,6 +50,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+from rebalance.lib.time_ops import _now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -719,7 +720,7 @@ def upsert_apple_reminders(
     as the Sleuth source. Idempotent: re-running an unchanged batch only bumps
     last_seen/last_synced. ``meta`` key/value pairs (schema fingerprint, drift
     signal) are persisted in the same transaction. Returns counts."""
-    now = now_iso or datetime.now(timezone.utc).isoformat()
+    now = now_iso or _now_iso()
     inserted = updated = unchanged = 0
 
     from rebalance.ingest.db import db_connection
@@ -887,7 +888,7 @@ def sync_apple_reminders(
     # Persist hardening signals (fingerprint + drift) in the sync transaction so
     # doctor / status can warn on schema drift without touching the live store.
     drift = _drift_fallbacks(extract_result.mapping_fallbacks)
-    now_iso = datetime.now(timezone.utc).isoformat()
+    now_iso = _now_iso()
     meta = {
         "last_sync_at": now_iso,
         "schema_fingerprint": json.dumps(extract_result.schema_fingerprint),

--- a/src/rebalance/ingest/ask_self_scan.py
+++ b/src/rebalance/ingest/ask_self_scan.py
@@ -31,12 +31,12 @@ import os
 import re
 import sqlite3
 from dataclasses import asdict, dataclass
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterator
 
 from rebalance.ingest.db import db_connection, run_migrations
 from rebalance.ingest.sync_snapshot import get_device_id
+from rebalance.lib.time_ops import now_iso
 
 HARNESS_RELPATH = ("ask_self", "ask_self_harness.json")
 DEFAULT_MAX_DEPTH = 6
@@ -308,7 +308,7 @@ def sync_ask_self_indexes(
     if roots is None:
         from rebalance.ingest.config import get_repo_scan_roots
         roots = get_repo_scan_roots()
-    scanned_at = datetime.now(timezone.utc).isoformat()
+    scanned_at = now_iso()
     found = scan_ask_self_repos(roots, max_depth=max_depth, device_id=dev)
 
     inserted = updated = unchanged = 0

--- a/src/rebalance/ingest/audit.py
+++ b/src/rebalance/ingest/audit.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import getpass
 import json
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+from rebalance.lib.time_ops import now_iso
 
 
 AUDIT_LOG_PATH = Path(__file__).parent.parent.parent.parent / "logs" / "agent-audit.json"
@@ -25,7 +25,7 @@ def _load_entries(path: Path) -> list[dict[str, Any]]:
 def append_audit_entry(action: str, target: str, **details: Any) -> dict[str, Any]:
     """Append one JSON audit record to the local audit log."""
     entry = {
-        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "timestamp": now_iso(),
         "user": getpass.getuser(),
         "action": action,
         "target": target,

--- a/src/rebalance/ingest/auth_log.py
+++ b/src/rebalance/ingest/auth_log.py
@@ -56,9 +56,9 @@ from __future__ import annotations
 import json
 import os
 import socket
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+from rebalance.lib.time_ops import now_iso
 
 # Events that mean a collector lost or lacked access. Used by readers (the web
 # dashboard, doctor) to surface the most recent failure per source.
@@ -113,7 +113,7 @@ def _legacy_calendar_path() -> Path:
 
 def _append(source: str, event: str, detail: dict[str, Any] | None = None) -> None:
     entry = {
-        "ts": datetime.now(timezone.utc).isoformat(),
+        "ts": now_iso(),
         "device": socket.gethostname(),
         "source": source,
         "event": event,

--- a/src/rebalance/ingest/calendar.py
+++ b/src/rebalance/ingest/calendar.py
@@ -17,13 +17,13 @@ from __future__ import annotations
 import json
 import time
 from dataclasses import dataclass
-from datetime import datetime, timezone, timedelta
+from datetime import timedelta
 from pathlib import Path
 from typing import Any
 
 
 from rebalance.ingest.calendar_config import OPERATOR_CALENDAR_ID
-from rebalance.lib.time_ops import parse_date
+from rebalance.lib.time_ops import now_iso, now_utc, parse_date
 from rebalance.paths import resolve_oauth_token_path
 TOKEN_PATH = resolve_oauth_token_path("calendar")
 CALENDAR_READONLY_SCOPE = "https://www.googleapis.com/auth/calendar.readonly"
@@ -199,7 +199,7 @@ def sync_calendar(
     start = time.monotonic()
     service = _build_service(required_scopes=[CALENDAR_READONLY_SCOPE])
 
-    now = datetime.now(timezone.utc)
+    now = now_utc()
     time_min = (now - timedelta(days=days_back)).isoformat()
     time_max = (now + timedelta(days=days_forward)).isoformat()
     fetched_at = now.isoformat()
@@ -446,8 +446,8 @@ def get_upcoming_events(
     Defaults to the operator's own ``OPERATOR_CALENDAR_ID`` calendar; pass
     ``calendar_id=None`` to include all calendars (team views).
     """
-    now = datetime.now(timezone.utc).isoformat()
-    cutoff = (datetime.now(timezone.utc) + timedelta(days=days_forward)).isoformat()
+    now = now_iso()
+    cutoff = (now_utc() + timedelta(days=days_forward)).isoformat()
 
     cal_clause, cal_params = _calendar_id_filter(calendar_id)
     where = (
@@ -483,8 +483,8 @@ def get_team_upcoming_by_person(
     if not persons:
         return []
 
-    now = datetime.now(timezone.utc).isoformat()
-    cutoff = (datetime.now(timezone.utc) + timedelta(days=days_forward)).isoformat()
+    now = now_iso()
+    cutoff = (now_utc() + timedelta(days=days_forward)).isoformat()
 
     person_clause, person_params = _person_filter(persons)
     where = (
@@ -514,8 +514,8 @@ def get_recent_events(
     """
     from rebalance.ingest.calendar_helpers import calendar_connection
 
-    now = datetime.now(timezone.utc).isoformat()
-    cutoff = (datetime.now(timezone.utc) - timedelta(days=days_back)).isoformat()
+    now = now_iso()
+    cutoff = (now_utc() - timedelta(days=days_back)).isoformat()
 
     cal_clause, cal_params = _calendar_id_filter(calendar_id)
     with calendar_connection(database_path) as conn:
@@ -583,7 +583,7 @@ def get_daily_totals(
         parse_calendar_dt,
     )
 
-    now = datetime.now(timezone.utc)
+    now = now_utc()
     start_date = (now - timedelta(days=days_back)).date()
     end_date = (now + timedelta(days=days_forward)).date()
 

--- a/src/rebalance/ingest/db/migrate.py
+++ b/src/rebalance/ingest/db/migrate.py
@@ -15,7 +15,6 @@ See ``db/migrations/README.md`` for the authoring discipline.
 from __future__ import annotations
 
 import sqlite3
-from datetime import datetime, timezone
 from pathlib import Path
 
 from rebalance.ingest.db.schema import (
@@ -23,6 +22,7 @@ from rebalance.ingest.db.schema import (
     ensure_baseline_schema,
     ensure_schema_version_table,
 )
+from rebalance.lib.time_ops import now_iso
 
 MIGRATIONS_DIR = Path(__file__).parent / "migrations"
 
@@ -55,7 +55,7 @@ def discover_migrations() -> list[tuple[int, Path]]:
 def _stamp(conn: sqlite3.Connection, version: int) -> None:
     conn.execute(
         "INSERT OR IGNORE INTO schema_version (version, applied_at) VALUES (?, ?)",
-        (version, datetime.now(timezone.utc).isoformat()),
+        (version, now_iso()),
     )
 
 

--- a/src/rebalance/ingest/embedder.py
+++ b/src/rebalance/ingest/embedder.py
@@ -8,7 +8,6 @@ mlx-embeddings is imported lazily so the rest of the package works without it.
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 import struct
@@ -16,9 +15,9 @@ import sys
 import time
 import uuid
 from dataclasses import dataclass
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+from rebalance.lib.time_ops import _now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -276,7 +275,7 @@ def embed_chunks(
             conn.commit()
 
         # Update embedding_meta
-        now_iso = datetime.now(timezone.utc).isoformat()
+        now_iso = _now_iso()
         for key, value in [
             ("model_name", model_name),
             ("embedding_dim", str(EMBEDDING_DIM)),

--- a/src/rebalance/ingest/focus5_scan.py
+++ b/src/rebalance/ingest/focus5_scan.py
@@ -33,15 +33,14 @@ from __future__ import annotations
 
 import logging
 import os
-import subprocess
 from dataclasses import asdict, dataclass
-from datetime import datetime, timezone
 from pathlib import Path
 from time import perf_counter
 from typing import Any, Callable, Iterable, Iterator
 
 from rebalance.ingest.db import db_connection, run_migrations
 from rebalance.ingest.sync_snapshot import get_device_id
+from rebalance.lib.time_ops import now_iso, now_utc
 # Reuse the prune discipline and the (already tested) remote-URL → owner/repo
 # parser rather than duplicating them; both are low-churn and shared by intent.
 from rebalance.ingest.ask_self_scan import _PRUNE_DIRS, derive_repo_full_name
@@ -703,7 +702,7 @@ def sync_focus5(
     from rebalance.ingest.config import get_focus5_hidden_repos
     hidden = get_focus5_hidden_repos()
 
-    now = datetime.now(timezone.utc)
+    now = now_utc()
     now_ts = int(now.timestamp())
     computed_at = now.isoformat()
 
@@ -794,7 +793,7 @@ def rerank_focus5_from_cache(
     from rebalance.ingest.config import get_focus5_hidden_repos
     hidden = get_focus5_hidden_repos()
 
-    now = datetime.now(timezone.utc)
+    now = now_utc()
     now_ts = int(now.timestamp())
     computed_at = now.isoformat()
 
@@ -871,7 +870,7 @@ def live_health(local_path: str) -> dict[str, Any]:
     current state. Returns the health fields plus ``health_probed_at``; a repo
     that can't be read yields ``health_available=False`` (never raises).
     """
-    probed_at = datetime.now(timezone.utc).isoformat()
+    probed_at = now_iso()
     out = _git(Path(local_path), "status", "--porcelain=v2", "--branch")
     if out is None:
         return {"health_available": False, "health_probed_at": probed_at}
@@ -1042,7 +1041,7 @@ def summarize_focus5(
                         "SELECT * FROM focus5_repo_signals WHERE device_id=?", (dev,)
                     ).fetchall()
                 ]
-                now_ts = int(datetime.now(timezone.utc).timestamp())
+                now_ts = int(now_utc().timestamp())
                 ranked = rank_repos(signals, mode=mode, now_ts=now_ts,
                                     hidden=get_focus5_hidden_repos())
                 computed_at = signals[0].probed_at if signals else None

--- a/src/rebalance/ingest/github_coverage.py
+++ b/src/rebalance/ingest/github_coverage.py
@@ -29,12 +29,11 @@ from __future__ import annotations
 
 import subprocess
 from dataclasses import asdict, dataclass, field
-from datetime import datetime, timezone
 from pathlib import Path
 
 from rebalance.ingest.db import db_connection, ensure_github_schema
 from rebalance.ingest.github_commit_backfill import _git, resolve_clone
-from rebalance.lib.time_ops import _now
+from rebalance.lib.time_ops import now_utc, _now
 
 _LS_REMOTE_TIMEOUT_S = 30
 
@@ -110,7 +109,7 @@ def _fetch_age_hours(repo_path: Path) -> float | None:
         mtime = fetch_head.stat().st_mtime
     except OSError:
         return None
-    return (datetime.now(timezone.utc).timestamp() - mtime) / 3600.0
+    return (now_utc().timestamp() - mtime) / 3600.0
 
 
 def remote_tip(repo_full_name: str, branch: str = "HEAD") -> str:

--- a/src/rebalance/ingest/github_knowledge.py
+++ b/src/rebalance/ingest/github_knowledge.py
@@ -14,7 +14,7 @@ import hashlib
 import json
 import time
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from pathlib import Path
 from typing import Any, Callable
 from urllib.parse import urlencode
@@ -34,6 +34,7 @@ from rebalance.ingest.embedder import (
 )
 from rebalance.ingest.semantic_index import sync_github_documents
 from rebalance.lib.json_ops import _json_dumps
+from rebalance.lib.time_ops import _now_iso, _now_utc
 DEFAULT_SYNC_DAYS = 90
 MIN_EMBED_CHARS = 40
 # GH-171: release the single SQLite writer periodically during a long persist
@@ -142,7 +143,7 @@ def _paginate_list(
 
 
 def _cutoff_iso(since_days: int) -> str:
-    cutoff = datetime.now(timezone.utc) - timedelta(days=since_days)
+    cutoff = _now_utc() - timedelta(days=since_days)
     return cutoff.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
@@ -363,7 +364,7 @@ def sync_github_repo(
         raise ValueError(f"GitHub repo is ignored: {normalized_repo}")
 
     start = time.monotonic()
-    fetched_at = datetime.now(timezone.utc).isoformat()
+    fetched_at = _now_iso()
     cutoff = _cutoff_iso(since_days)
     api_get = api_get_json or (lambda url: _http_get_json(url, token))
     repo_base = f"{GITHUB_API}/repos/{repo_full_name}"
@@ -973,7 +974,7 @@ def embed_github_documents(
                 embedded += 1
             conn.commit()
 
-        now_iso = datetime.now(timezone.utc).isoformat()
+        now_iso = _now_iso()
         for key, value in [
             ("model_name", model_name),
             ("embedding_dim", str(EMBEDDING_DIM)),

--- a/src/rebalance/ingest/github_readiness.py
+++ b/src/rebalance/ingest/github_readiness.py
@@ -11,12 +11,11 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import asdict, dataclass, field
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 from rebalance.ingest.db import db_connection, ensure_github_schema
-from rebalance.lib.time_ops import _now, _now_iso, parse_utc_iso
+from rebalance.lib.time_ops import now_utc, parse_utc_iso
 
 _RELEASE_BRANCH_RE = re.compile(r"\brelease/[A-Za-z0-9._-]+\b")
 
@@ -71,7 +70,7 @@ def _days_until(iso_date: str) -> int | None:
     target = parse_utc_iso(iso_date)
     if not target:
         return None
-    now = datetime.now(timezone.utc)
+    now = now_utc()
     return (target.date() - now.date()).days
 
 

--- a/src/rebalance/ingest/github_scan.py
+++ b/src/rebalance/ingest/github_scan.py
@@ -17,12 +17,13 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 
 from rebalance.ingest.config import normalize_github_repo_name
 from rebalance.ingest._http import GITHUB_API, GitHubClient, _is_rate_limit
+from rebalance.lib.time_ops import now_iso, now_utc
 
 logger = logging.getLogger(__name__)
 
@@ -117,7 +118,7 @@ def _get(url: str, token: str) -> tuple[int, Any]:
 
 def _cutoff_key(days: int) -> str:
     """Return YYYY-MM-DD threshold for event filtering (local timezone)."""
-    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+    cutoff = now_utc() - timedelta(days=days)
     return cutoff.strftime("%Y-%m-%d")
 
 
@@ -467,14 +468,14 @@ def scan_github(token: str, days: int = 30) -> GitHubScanResult:
         GitHubScanResult with per-repo activity breakdown.
     """
     login = _get_login(token)
-    now = datetime.now(timezone.utc)
+    now = now_utc()
     cutoff_7d, cutoff_14d, _ = _compute_band_cutoffs(now)
     events = _fetch_events(login, token, days=days)
     repo_activity = _summarize_by_repo(events, cutoff_7d=cutoff_7d, cutoff_14d=cutoff_14d)
 
     return GitHubScanResult(
         login=login,
-        scanned_at=datetime.now(timezone.utc).isoformat(),
+        scanned_at=now_iso(),
         days_fetched=days,
         total_events=len(events),
         repo_activity=repo_activity,
@@ -613,7 +614,7 @@ def sync_pushed_repos(
         return result
 
     result.fetched = len(records)
-    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    now = now_utc().isoformat(timespec="seconds")
 
     with db_connection(database_path, ensure_github_schema) as conn:
         for rec in records:
@@ -720,7 +721,7 @@ def get_github_balance(
 
     from rebalance.ingest.db import db_connection, ensure_github_schema
 
-    since_date = (datetime.now(timezone.utc) - timedelta(days=since_days)).strftime("%Y-%m-%d")
+    since_date = (now_utc() - timedelta(days=since_days)).strftime("%Y-%m-%d")
 
     with db_connection(database_path, ensure_github_schema) as conn:
         rows = conn.execute(

--- a/src/rebalance/ingest/github_watch.py
+++ b/src/rebalance/ingest/github_watch.py
@@ -31,7 +31,6 @@ refresh: the rollup resumes, the stale per-login picture simply ages out of the 
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -44,6 +43,7 @@ from rebalance.ingest.github_knowledge import (
     _cutoff_iso,
     _http_get_json,
 )
+from rebalance.lib.time_ops import now_utc
 
 # Sentinel login under which whole-repo (all-author) rollups are written to
 # github_activity. Distinct from any real GitHub login so the operator's own
@@ -137,7 +137,7 @@ def derive_watched_repo_activity(
     footing as owned repos.
     """
     repo = normalize_github_repo_name(repo_full_name)
-    now = datetime.now(timezone.utc)
+    now = now_utc()
     scan_date = now.strftime("%Y-%m-%d")
     cutoff_day = (now.replace(microsecond=0).isoformat())
     cutoff_date = _cutoff_iso(since_days)[:10]
@@ -252,7 +252,7 @@ def watched_repo_is_active_work(
         return False
 
     recent_local_ts = int(
-        datetime.now(timezone.utc).timestamp() - _LOCAL_RECENCY_DAYS * 86400
+        now_utc().timestamp() - _LOCAL_RECENCY_DAYS * 86400
     )
 
     with db_connection(database_path, ensure_github_schema) as conn:

--- a/src/rebalance/ingest/gmail.py
+++ b/src/rebalance/ingest/gmail.py
@@ -29,6 +29,7 @@ from datetime import datetime, timezone
 from email.utils import parseaddr, parsedate_to_datetime
 from pathlib import Path
 from typing import Any
+from rebalance.lib.time_ops import now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -248,7 +249,7 @@ def sync_gmail(
         raise
     message_refs = list_response.get("messages", []) or []
 
-    synced_at = datetime.now(timezone.utc).isoformat()
+    synced_at = now_iso()
     metadata_headers = ["From", "To", "Subject", "Date"]
 
     inserted = 0
@@ -361,7 +362,7 @@ def ingest_email_messages(
     from rebalance.ingest.db import db_connection, ensure_email_schema
 
     start = time.monotonic()
-    synced_at = datetime.now(timezone.utc).isoformat()
+    synced_at = now_iso()
     inserted = updated = stored = skipped = 0
 
     with db_connection(database_path, ensure_email_schema) as conn:

--- a/src/rebalance/ingest/goals_file.py
+++ b/src/rebalance/ingest/goals_file.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import re
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
+from rebalance.lib.time_ops import now_iso
 
 CHECKBOX_RE = re.compile(r"^\s*-\s*\[(?P<mark>[ xX])\]\s*(?P<title>.*)$")
 
@@ -105,7 +105,7 @@ def complete_goal_in_file(
             "line_index": index,
             "before_line": raw,
             "after_line": updated,
-            "completed_at": datetime.now(timezone.utc).isoformat(),
+            "completed_at": now_iso(),
         }
         break
     if record is None:

--- a/src/rebalance/ingest/index_ops.py
+++ b/src/rebalance/ingest/index_ops.py
@@ -13,7 +13,7 @@ import logging
 import sqlite3
 import time
 from dataclasses import dataclass
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Any, Callable, Iterable
 
@@ -26,6 +26,7 @@ from rebalance.ingest.config import (
 from rebalance.ingest.db import db_connection, ensure_semantic_schema, run_migrations
 from rebalance.ingest.registry import get_projects
 from rebalance.ingest.semantic_index import SemanticDoc
+from rebalance.lib.time_ops import now_utc
 
 logger = logging.getLogger(__name__)
 
@@ -353,7 +354,7 @@ def _quiet_filter_description(rule: dict[str, Any]) -> str | None:
 
 
 def _derive_signal_health(sources: dict[str, dict[str, Any]]) -> dict[str, dict[str, str]]:
-    now = datetime.now(timezone.utc)
+    now = now_utc()
     signal_health: dict[str, dict[str, str]] = {}
 
     for source_name, rule in _SIGNAL_HEALTH_RULES.items():
@@ -741,7 +742,7 @@ def get_index_status(database_path: Path) -> dict[str, Any]:
                 """
             ).fetchall()
             pending_total = len(pending_rows)
-            now = datetime.now(timezone.utc)
+            now = now_utc()
             oldest_minutes: float | None = None
             stuck_count = 0
             for row in pending_rows:
@@ -913,12 +914,12 @@ def _pushed_repos(database_path: Path, *, since_days: int = 14) -> list[str]:
     force-push edge cases. The events feed and this signal are
     complementary; the union goes into the watched set.
     """
-    from datetime import datetime, timedelta, timezone
+    from datetime import timedelta
 
     repos: list[str] = []
     try:
         cutoff = (
-            datetime.now(timezone.utc) - timedelta(days=int(since_days))
+            now_utc() - timedelta(days=int(since_days))
         ).isoformat()
         with db_connection(database_path) as conn:
             rows = conn.execute(

--- a/src/rebalance/ingest/next_actions.py
+++ b/src/rebalance/ingest/next_actions.py
@@ -42,7 +42,7 @@ import logging
 import re
 import time
 from dataclasses import asdict, dataclass, field
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo
@@ -58,7 +58,7 @@ from rebalance.ingest.calendar_helpers import (
     parse_calendar_dt,
 )
 from rebalance.ingest.config import get_pulse_config, get_vault_path
-from rebalance.lib.time_ops import parse_date, parse_iso
+from rebalance.lib.time_ops import _now_iso, _now_utc, parse_date, parse_iso
 from rebalance.ingest.db import db_connection, run_migrations
 from rebalance.ingest.pulse import _query_day_activity, collect_pulse_snapshot
 from rebalance.tz_utils import format_local, local_tz
@@ -1273,7 +1273,7 @@ def rank_next_actions(
             weights_used=_weights_summary(weights),
             note=f"assembly failed: {exc}",
             elapsed_seconds=round(time.monotonic() - started, 2),
-            computed_at=datetime.now(timezone.utc).isoformat(),
+            computed_at=_now_iso(),
         )
 
     # Client + priority lookups (computed once; used for both the deterministic
@@ -1374,7 +1374,7 @@ def rank_next_actions(
         weights_used=_weights_summary(weights),
         note=note,
         elapsed_seconds=round(time.monotonic() - started, 2),
-        computed_at=datetime.now(timezone.utc).isoformat(),
+        computed_at=_now_iso(),
     )
 
 
@@ -1397,7 +1397,7 @@ def _operator_blocks_over_horizon(
     """
     start_d = parse_date(local_day)
     if start_d is None:
-        start_d = datetime.now(tz).date() if hasattr(tz, "utcoffset") else datetime.now(timezone.utc).date()
+        start_d = datetime.now(tz).date() if hasattr(tz, "utcoffset") else _now_utc().date()
     horizon_days = {
         (start_d + timedelta(days=i)).isoformat()
         for i in range(days_forward + 1)
@@ -1446,9 +1446,9 @@ def _gather_teammate_delta(
     # their calendar, NOT how much future scheduling they happen to have. (An
     # unbounded future bound would let a single heavily-scheduled week pass a
     # teammate who never logs history.)
-    now_iso = datetime.now(timezone.utc).isoformat()
+    now_iso = _now_iso()
     history_floor = (
-        datetime.now(timezone.utc) - timedelta(days=_ADDITIVITY_HISTORY_DAYS)
+        _now_utc() - timedelta(days=_ADDITIVITY_HISTORY_DAYS)
     ).isoformat()
     placeholders = ",".join("?" for _ in roster)
     rows = conn.execute(
@@ -1537,7 +1537,7 @@ def persist_ranked_next_actions(database_path: Path, result: RankedNextActions) 
             "(computed_at, blended, model_used, payload_json, weights_json) "
             "VALUES (?,?,?,?,?)",
             (
-                result.computed_at or datetime.now(timezone.utc).isoformat(),
+                result.computed_at or _now_iso(),
                 1 if result.blended else 0,
                 result.model_used,
                 json.dumps(result.as_dict(), ensure_ascii=False),

--- a/src/rebalance/ingest/note_builder.py
+++ b/src/rebalance/ingest/note_builder.py
@@ -6,7 +6,7 @@ import json
 import urllib.error
 import urllib.request
 from dataclasses import dataclass, field
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -23,6 +23,7 @@ from rebalance.tz_utils import format_local, local_tz
 from rebalance.ingest.project_priority import apply_project_priorities
 from rebalance.ingest.project_classifier import annotate_events_with_projects, load_project_matchers
 from rebalance.ingest.registry import get_projects
+from rebalance.lib.time_ops import now_iso, now_utc
 
 
 REPO_ROOT = Path(__file__).parent.parent.parent.parent
@@ -46,7 +47,7 @@ def get_all_repo_activity_by_org(
     from rebalance.ingest.config import get_github_ignored_repos
     from rebalance.ingest.db import db_connection, ensure_github_schema
 
-    since_date = (datetime.now(timezone.utc) - timedelta(days=since_days)).strftime("%Y-%m-%d")
+    since_date = (now_utc() - timedelta(days=since_days)).strftime("%Y-%m-%d")
 
     ignored = get_github_ignored_repos()
     params: list[Any] = [since_date]
@@ -303,7 +304,7 @@ def build_dashboard_payload(
     return DashboardPayload(
         target_date=target_date,
         since_days=since_days,
-        generated_at=datetime.now(timezone.utc).isoformat(),
+        generated_at=now_iso(),
         highlights=read_recent_changelog_highlights(changelog_path),
         current_goals=read_current_goals(goals_path),
         projects=project_rows,

--- a/src/rebalance/ingest/note_ingester.py
+++ b/src/rebalance/ingest/note_ingester.py
@@ -23,8 +23,9 @@ from pathlib import Path
 from typing import Any
 
 from rebalance.ingest.db import db_connection, ensure_schema, ensure_semantic_schema
-from rebalance.ingest.md_parser import parse_note, ParsedNote
+from rebalance.ingest.md_parser import parse_note
 from rebalance.ingest.semantic_index import sync_vault_documents
+from rebalance.lib.time_ops import _now_iso
 
 
 def _json_default(obj: Any) -> Any:
@@ -201,7 +202,7 @@ def ingest_vault(
 
             # Insert file
             stat = file_path.stat()
-            now_iso = datetime.now(timezone.utc).isoformat()
+            now_iso = _now_iso()
             mtime_iso = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat()
 
             conn.execute(

--- a/src/rebalance/ingest/preflight.py
+++ b/src/rebalance/ingest/preflight.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from datetime import datetime, timezone
+from datetime import timezone
 from typing import Any
 
 import questionary
@@ -16,12 +16,12 @@ from rebalance.ingest.registry import (
     sync_registry,
 )
 from rebalance.ingest.github_scan import (
-    BAND_A_DAYS,
     BAND_B_DAYS,
     BAND_C_DAYS,
     discover_repos_from_activity,
 )
 from rebalance.ingest.local_repos import scan_local_repos
+from rebalance.lib.time_ops import now_utc
 
 
 # ---------------------------------------------------------------------------
@@ -107,7 +107,7 @@ def _calculate_days_since_activity(last_activity_at: str | None) -> int:
     try:
         from rebalance.ingest.calendar_helpers import parse_calendar_dt
         activity_dt = parse_calendar_dt(last_activity_at)
-        now = datetime.now(timezone.utc)
+        now = now_utc()
         if activity_dt.tzinfo is None:
             activity_dt = activity_dt.replace(tzinfo=timezone.utc)
         delta = now - activity_dt

--- a/src/rebalance/ingest/project_inference.py
+++ b/src/rebalance/ingest/project_inference.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import re
-from collections import Counter, defaultdict
+from collections import Counter
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -23,6 +23,7 @@ from rebalance.ingest.db import (
 )
 from rebalance.ingest.project_classifier import normalize_match_text
 from rebalance.ingest.registry import sync_db
+from rebalance.lib.time_ops import now_utc
 
 _GENERIC_ALIAS_TOKENS = {
     "app",
@@ -236,7 +237,7 @@ def _load_calendar_events(
     days_back: int,
     days_forward: int,
 ) -> list[dict[str, Any]]:
-    today = datetime.now(timezone.utc).date()
+    today = now_utc().date()
     min_date = (today - timedelta(days=days_back)).isoformat()
     max_date = (today + timedelta(days=days_forward)).isoformat()
     with db_connection(database_path, ensure_calendar_schema) as conn:
@@ -450,7 +451,7 @@ def _seed_status(seed: _ProjectSeed) -> str:
         latest_dt = parse_calendar_dt(latest).astimezone(timezone.utc)
     except Exception:
         return "potential"
-    age_days = (datetime.now(timezone.utc) - latest_dt).days
+    age_days = (now_utc() - latest_dt).days
     if age_days <= 30:
         return "active"
     if age_days <= 90:
@@ -814,7 +815,7 @@ def _count_operator_commits(conn: Any, repo_full_name: str, github_login: str) -
     in ARCHITECTURE.md), so summing across all of them is a genuine cumulative
     count since Rebalance started watching the repo, not a rolling window.
     """
-    from rebalance.ingest.pulse import CLOUD_AGENT_AUTHORS, _author_filter_sql
+    from rebalance.ingest.pulse import CLOUD_AGENT_AUTHORS
 
     activity_row = conn.execute(
         "SELECT COALESCE(SUM(commits), 0) AS n FROM github_activity "
@@ -887,7 +888,7 @@ def _repo_to_promoted_row(
                 "repo_full_name": repo_full_name,
                 "commit_count": commit_count,
                 "threshold": threshold,
-                "promoted_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                "promoted_at": now_utc().isoformat(timespec="seconds"),
             },
         },
     }

--- a/src/rebalance/ingest/pulse_health.py
+++ b/src/rebalance/ingest/pulse_health.py
@@ -25,10 +25,10 @@ from __future__ import annotations
 import os
 import re
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 
-from rebalance.lib.time_ops import parse_utc_iso
+from rebalance.lib.time_ops import now_utc, parse_utc_iso
 
 # Mirror experimental/git-pulse/health-check.py defaults.
 WARN_HOURS = 3.0
@@ -178,7 +178,7 @@ def read_collector_health(
     Returns ``[]`` when git-pulse is not configured or has no device YAMLs —
     callers treat that as "nothing to report". Sorted worst-first.
     """
-    now = now or datetime.now(timezone.utc)
+    now = now or now_utc()
     sync_repo_dir = sync_repo_dir or resolve_sync_repo_dir()
     if sync_repo_dir is None:
         return []

--- a/src/rebalance/ingest/querier.py
+++ b/src/rebalance/ingest/querier.py
@@ -15,12 +15,13 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass, field
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 
 from rebalance.ingest.calendar_config import OPERATOR_CALENDAR_ID
 from rebalance.ingest.db import db_connection, ensure_schema, ensure_calendar_schema
+from rebalance.lib.time_ops import now_utc
 
 logger = logging.getLogger(__name__)
 
@@ -147,7 +148,7 @@ def _gather_vault_activity(
     """Recently modified vault files as a project activity signal."""
     import json
 
-    cutoff = (datetime.now(timezone.utc) - timedelta(days=since_days)).isoformat()
+    cutoff = (now_utc() - timedelta(days=since_days)).isoformat()
     with db_connection(database_path, ensure_schema) as conn:
         rows = conn.execute(
             """

--- a/src/rebalance/ingest/semantic_index.py
+++ b/src/rebalance/ingest/semantic_index.py
@@ -7,7 +7,6 @@ import json
 import logging
 import time
 from dataclasses import dataclass
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Iterable
 
@@ -28,6 +27,7 @@ from rebalance.ingest.embedder import (
     _load_model,
     _vec_to_bytes,
 )
+from rebalance.lib.time_ops import _now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -689,7 +689,7 @@ def embed_pending(
             batch = rows[i:i + batch_size]
             texts = [row["body"][:4000] for row in batch]
             vectors = embed_fn(texts, model_name)
-            now_iso = datetime.now(timezone.utc).isoformat()
+            now_iso = _now_iso()
             for row, vec in zip(batch, vectors):
                 sem.delete_semantic_embedding(conn, row["id"])
                 sem.insert_semantic_embedding(conn, row["id"], _vec_to_bytes(vec))
@@ -699,7 +699,7 @@ def embed_pending(
                 embedded += 1
             conn.commit()
 
-        now_iso = datetime.now(timezone.utc).isoformat()
+        now_iso = _now_iso()
         for key, value in [
             ("model_name", model_name),
             ("embedding_dim", str(EMBEDDING_DIM)),

--- a/src/rebalance/ingest/sleuth_reminders.py
+++ b/src/rebalance/ingest/sleuth_reminders.py
@@ -30,11 +30,12 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 from rebalance.tz_utils import parse_utc_iso
+from rebalance.lib.time_ops import _now_iso
 
 HTTP_TIMEOUT_SECONDS = 30
 USER_AGENT = "rebalance-os/0.1"
@@ -551,7 +552,7 @@ def sync_sleuth_reminders(
         data, workspace_name=workspace_name, is_file_source=is_file_source
     )
 
-    now_iso = datetime.now(timezone.utc).isoformat()
+    now_iso = _now_iso()
     inserted = updated = unchanged = 0
 
     with db_connection(database_path, ensure_sleuth_schema) as conn:

--- a/src/rebalance/ingest/sync_snapshot.py
+++ b/src/rebalance/ingest/sync_snapshot.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 import json
 import socket
 import subprocess
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from pathlib import Path
 from typing import Any
 
@@ -45,6 +45,7 @@ from rebalance.ingest.calendar_config import OPERATOR_CALENDAR_ID
 from rebalance.ingest.db import db_connection
 from rebalance.ingest.db.schema import ensure_calendar_schema, ensure_email_schema
 from rebalance.repair import RepairFSM, RepairResult, RepairStatus
+from rebalance.lib.time_ops import now_iso, now_utc
 
 SCHEMA_VERSION = 1
 DEFAULT_CALENDAR_WINDOW_DAYS = 90
@@ -97,8 +98,8 @@ def export_calendar_snapshot(
         raise FileNotFoundError(f"Database not found: {database_path}")
 
     dev_id = device_id or get_device_id()
-    generated_at = datetime.now(timezone.utc).isoformat()
-    since = (datetime.now(timezone.utc) - timedelta(days=window_days)).isoformat()
+    generated_at = now_iso()
+    since = (now_utc() - timedelta(days=window_days)).isoformat()
 
     with db_connection(database_path, ensure_calendar_schema) as conn:
         # Default deny (P2 decision #3): only the operator's own calendar
@@ -162,7 +163,7 @@ def export_email_snapshot(
         raise FileNotFoundError(f"Database not found: {database_path}")
 
     dev_id = device_id or get_device_id()
-    generated_at = datetime.now(timezone.utc).isoformat()
+    generated_at = now_iso()
 
     with db_connection(database_path, ensure_email_schema) as conn:
         rows = conn.execute(

--- a/src/rebalance/ingest/token_meta.py
+++ b/src/rebalance/ingest/token_meta.py
@@ -17,11 +17,12 @@ from __future__ import annotations
 import hashlib
 import json
 import os
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 from rebalance.tz_utils import parse_utc_iso
+from rebalance.lib.time_ops import now_iso, now_utc
 
 
 def _meta_path() -> Path:
@@ -79,7 +80,7 @@ def record_token_set(
     data = _load()
     svc = data.setdefault(service, {"current": None, "tokens": {}})
     fp = fingerprint(token)
-    now = datetime.now(timezone.utc).isoformat()
+    now = now_iso()
     rec = svc["tokens"].get(fp)
     if rec is None:
         rec = {
@@ -113,6 +114,6 @@ def age_text(iso_ts: str | None, *, now: datetime | None = None) -> str:
     dt = parse_utc_iso(iso_ts)  # handles trailing-Z + naive→UTC; None on bad/empty
     if dt is None:
         return ""
-    now = now or datetime.now(timezone.utc)
+    now = now or now_utc()
     secs = max((now - dt).total_seconds(), 0.0)
     return f"{secs / 86400:.0f}d" if secs >= 86400 else f"{secs / 3600:.1f}h"

--- a/src/rebalance/web.py
+++ b/src/rebalance/web.py
@@ -37,7 +37,7 @@ from pydantic import BaseModel
 from rebalance.ingest.auth_log import read_log, _log_path
 from rebalance.ingest import zapier_calendar, zapier_email
 from rebalance.ingest.sleuth_grouping import grouped_reminders_from_db
-from rebalance.lib.time_ops import format_relative, parse_utc_iso
+from rebalance.lib.time_ops import format_relative, _now_iso, _now_utc, parse_utc_iso
 from rebalance.paths import resolve_db, resolve_secret_path
 from rebalance.web_components import badge_html, button_link, render_shell
 logger = logging.getLogger(__name__)
@@ -520,7 +520,7 @@ def _f5_warning_strip(data: dict[str, Any]) -> str:
     from rebalance.ingest.focus5_scan import explain_recency
     explain_on = data.get("ranking_mode") == "recent_activity"
     cutoff = (data.get("summary") or {}).get("rank_cutoff_ts")
-    now_ts = int(datetime.now(timezone.utc).timestamp())
+    now_ts = int(_now_utc().timestamp())
     shown, items = warns[:8], []
     for w in shown:
         reason = w.get("warning_reason")
@@ -766,7 +766,7 @@ def _roster_stale(computed_at: str | None) -> bool:
     ts = parse_utc_iso(computed_at)
     if ts is None:
         return True
-    return (datetime.now(timezone.utc) - ts).total_seconds() > FOCUS5_ROSTER_TTL_SECONDS
+    return (_now_utc() - ts).total_seconds() > FOCUS5_ROSTER_TTL_SECONDS
 
 
 @app.get("/focus-5")
@@ -883,7 +883,7 @@ def _build_three_eyes_card(report: dict) -> dict:
     else:
         title = "3-Eyes — all jobs OK"
         reason = f"3-Eyes fleet job health — {verdict}. All catalogued jobs healthy."
-    now_iso = datetime.now(timezone.utc).isoformat()
+    now_iso = _now_iso()
     path = str(_THREE_EYES_DIR)
     return {
         "position": 0,                      # re-stamped by the caller
@@ -1667,7 +1667,6 @@ _AUTH_LOG_FILTER_JS = """
 
 @app.get("/auth-log", response_class=HTMLResponse)
 def auth_log_page() -> HTMLResponse:
-    import json
     entries = read_log(limit=500)
 
     raw_link = '<a class="raw-link" href="/auth-log/raw">⬇ raw JSONL</a>'


### PR DESCRIPTION
Partially closes #292 (the mechanical sweep — the checklist's alias-wrapper consolidation and remaining raw `now` arithmetic stay on the issue).

## What
- Replaces **every** direct `datetime.now(timezone.utc)` call in `src/` and `scripts/` (92 sites, 37 files) with the canonical `now_iso()`/`now_utc()` helpers from `lib/time_ops`:
  - `.isoformat()` → `now_iso()`
  - `.isoformat(timespec="seconds")` → `now_utc().isoformat(timespec="seconds")` (format preserved exactly — this was the one drifted variant)
  - all other uses (cutoff arithmetic, `.date()`, `.timestamp()`, comparisons) → `now_utc()`
- Newly-unused `datetime`/`timezone` imports removed.

## Why it matters
`now_iso()`/`now_utc()` route through the freeze-clock test seam (`rebalance.tz_utils`); direct calls silently bypassed it, so time-sensitive code was not deterministically testable. Six of the swept files already imported from `time_ops` yet still called the clock directly.

## Collision handling
A few modules inject timestamps as parameters (e.g. `sync_apple_reminders(..., now_iso=None)`) or use `now_iso` as a local name. In those files the helpers are imported under aliases (`_now_iso`/`_now_utc`) so both coexist — the injection seams tests rely on are unchanged.

## Verification
- `grep datetime.now(timezone.utc) src/ scripts/` → 0
- Full suite: **1938 passed, 10 xfailed** — identical to the pre-change baseline
- `compileall` clean; module import smoke (`mcp.server`, `web`, `pulse_server`) clean

## Merge notes
- Cut from `development` independently of #302 (ruff). Expect trivial import-line conflicts if #302 lands first — one-command rebase resolves.
- Version 0.69.4 + CHANGELOG per repo convention (assumes #302's 0.69.3 merges first; renumber if order flips).