### PR TITLE
fix(GH-293): route live diagnostics + assigned-issues search through the shared GitHub client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@
 > **not** reintroduce an `[Unreleased]` block — add to (or roll work into) the
 > current dated version instead. See AGENTS.md → "Versioning & Changelog".
 
+## [0.69.5] - 2026-08-15
+
+### Fixed
+- **Live repo diagnostics no longer report false negatives on transient GitHub failures.** The
+  optional live PAT-visibility probes rebuilt the API request by hand with no retry logic, so a
+  single rate-limit or server-error response produced a confident "your token cannot see this
+  repository" verdict. They now route through the shared API client, which retries with backoff
+  and detects rate limits from response headers. The same shared-client migration applies to the
+  assigned-issues search used by the activity pulse, replacing a body-text heuristic for rate
+  limits with header-based detection; its error contract is unchanged.
+- **First test coverage for the diagnostics module** — probe envelopes, offline funnel verdicts,
+  and the rate-limit error contract are now pinned.
+
 ## [0.69.2] - 2026-08-15
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rebalance-os"
-version = "0.69.2"
+version = "0.69.5"
 description = "Local-first workday operating system with MCP tools and Obsidian ingest"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/rebalance/__init__.py
+++ b/src/rebalance/__init__.py
@@ -28,7 +28,7 @@ import logging
 import os
 
 __all__ = ["__version__"]
-__version__ = "0.69.2"
+__version__ = "0.69.5"
 
 
 def _configure_logging() -> None:

--- a/src/rebalance/ingest/diagnose.py
+++ b/src/rebalance/ingest/diagnose.py
@@ -9,13 +9,11 @@ never synced" from "PAT can't see it".
 
 from __future__ import annotations
 
-import json
 import urllib.error
-import urllib.request
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from rebalance.ingest._http import GitHubClient, GitHubHTTPError
 from rebalance.ingest.config import (
     get_github_ignored_repos,
     get_github_token,
@@ -24,7 +22,7 @@ from rebalance.ingest.config import (
 from rebalance.ingest.db import db_connection
 from rebalance.ingest.index_ops import _activity_repos, _project_repos
 from rebalance.ingest.registry import get_projects
-from rebalance.lib.time_ops import _parse_iso, _now, _now_utc
+from rebalance.lib.time_ops import now_utc, parse_utc_iso
 
 
 # Mirrors github_knowledge.sync_github_repo's default lookback for issues/PRs.
@@ -32,93 +30,73 @@ DEFAULT_SYNC_WINDOW_DAYS = 90
 
 
 def _days_since(iso: str | None) -> float | None:
-    parsed = _parse_iso(iso)
+    parsed = parse_utc_iso(iso)
     if parsed is None:
         return None
-    delta = _now_utc() - parsed
+    delta = now_utc() - parsed
     return round(delta.total_seconds() / 86400.0, 2)
+
+
+def _probe_get_json(client: GitHubClient, path: str) -> Any:
+    """One shared-client GET for a live probe.
+
+    The shared client retries 429/5xx with backoff and detects rate limits
+    from response headers — a bare copy of the auth headers here previously
+    turned one transient failure into a false "PAT cannot see this repo"
+    verdict (the reason these probes no longer build their own requests).
+    """
+    return client.get_json(path)
+
+
+def _probe_failure(key: str, exc: Exception) -> dict[str, Any]:
+    """Map a probe exception to the backwards-stable error envelope."""
+    if isinstance(exc, GitHubHTTPError):
+        return {key: False, "status": exc.status, "error": str(exc)}
+    reason = getattr(exc, "reason", None)
+    return {key: False, "status": None, "error": str(reason if reason is not None else exc)}
 
 
 def _live_probe_repo(repo: str, token: str) -> dict[str, Any]:
     """GET /repos/{owner}/{repo}; return {can_see, status, error}."""
-    url = f"https://api.github.com/repos/{repo}"
-    req = urllib.request.Request(
-        url,
-        headers={
-            "Authorization": f"Bearer {token}",
-            "Accept": "application/vnd.github+json",
-            "User-Agent": "rebalance-os/diagnose",
-            "X-GitHub-Api-Version": "2022-11-28",
-        },
-    )
     try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            data = json.loads(resp.read().decode())
-            return {
-                "can_see": True,
-                "status": resp.status,
-                "default_branch": data.get("default_branch"),
-                "private": bool(data.get("private")),
-            }
-    except urllib.error.HTTPError as exc:
-        return {"can_see": False, "status": exc.code, "error": exc.reason}
-    except urllib.error.URLError as exc:
-        return {"can_see": False, "status": None, "error": str(exc.reason)}
+        data = _probe_get_json(GitHubClient(token, job_label="diagnose"), f"/repos/{repo}")
+    except (GitHubHTTPError, urllib.error.URLError, OSError) as exc:
+        return _probe_failure("can_see", exc)
+    return {
+        "can_see": True,
+        "status": 200,
+        "default_branch": data.get("default_branch"),
+        "private": bool(data.get("private")),
+    }
 
 
 def _live_probe_commit(repo: str, sha: str, token: str) -> dict[str, Any]:
-    url = f"https://api.github.com/repos/{repo}/commits/{sha}"
-    req = urllib.request.Request(
-        url,
-        headers={
-            "Authorization": f"Bearer {token}",
-            "Accept": "application/vnd.github+json",
-            "User-Agent": "rebalance-os/diagnose",
-            "X-GitHub-Api-Version": "2022-11-28",
-        },
-    )
     try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            data = json.loads(resp.read().decode())
-            commit = data.get("commit") or {}
-            committer = commit.get("committer") or {}
-            return {
-                "exists": True,
-                "sha": data.get("sha"),
-                "committed_at": committer.get("date"),
-                "message_first_line": (commit.get("message") or "").splitlines()[0][:200],
-            }
-    except urllib.error.HTTPError as exc:
-        return {"exists": False, "status": exc.code, "error": exc.reason}
-    except urllib.error.URLError as exc:
-        return {"exists": False, "status": None, "error": str(exc.reason)}
+        data = _probe_get_json(GitHubClient(token, job_label="diagnose"), f"/repos/{repo}/commits/{sha}")
+    except (GitHubHTTPError, urllib.error.URLError, OSError) as exc:
+        return _probe_failure("exists", exc)
+    commit = data.get("commit") or {}
+    committer = commit.get("committer") or {}
+    return {
+        "exists": True,
+        "sha": data.get("sha"),
+        "committed_at": committer.get("date"),
+        "message_first_line": (commit.get("message") or "").splitlines()[0][:200],
+    }
 
 
 def _live_probe_pr(repo: str, pr: int, token: str) -> dict[str, Any]:
-    url = f"https://api.github.com/repos/{repo}/pulls/{pr}"
-    req = urllib.request.Request(
-        url,
-        headers={
-            "Authorization": f"Bearer {token}",
-            "Accept": "application/vnd.github+json",
-            "User-Agent": "rebalance-os/diagnose",
-            "X-GitHub-Api-Version": "2022-11-28",
-        },
-    )
     try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            data = json.loads(resp.read().decode())
-            return {
-                "exists": True,
-                "state": data.get("state"),
-                "merged": bool(data.get("merged")),
-                "updated_at": data.get("updated_at"),
-                "title": data.get("title"),
-            }
-    except urllib.error.HTTPError as exc:
-        return {"exists": False, "status": exc.code, "error": exc.reason}
-    except urllib.error.URLError as exc:
-        return {"exists": False, "status": None, "error": str(exc.reason)}
+        data = _probe_get_json(GitHubClient(token, job_label="diagnose"), f"/repos/{repo}/pulls/{pr}")
+    except (GitHubHTTPError, urllib.error.URLError, OSError) as exc:
+        return _probe_failure("exists", exc)
+    return {
+        "exists": True,
+        "state": data.get("state"),
+        "merged": bool(data.get("merged")),
+        "updated_at": data.get("updated_at"),
+        "title": data.get("title"),
+    }
 
 
 def diagnose_repo(

--- a/src/rebalance/ingest/pulse.py
+++ b/src/rebalance/ingest/pulse.py
@@ -22,9 +22,7 @@ import hashlib
 import json
 import subprocess
 import time
-import urllib.error
 import urllib.parse
-import urllib.request
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -35,6 +33,7 @@ from rebalance.repair import RepairFSM, RepairResult, RepairStatus
 from rebalance.ingest.agent_tags import classify as classify_source
 from rebalance.ingest.calendar_config import OPERATOR_CALENDAR_ID
 from rebalance.ingest.calendar_helpers import calendar_dt_utc, normalize_aware_utc
+from rebalance.ingest._http import GitHubClient, GitHubHTTPError
 from rebalance.ingest.config import get_github_token, get_pulse_config
 from rebalance.ingest.db import db_connection
 from rebalance.ingest.slack_users import compact_sleuth_reminder
@@ -530,19 +529,15 @@ def fetch_assigned_issues(
     since_str = since_date.date().isoformat()
     query = f"assignee:{github_login} is:issue is:open updated:>={since_str}"
     params = {"q": query, "per_page": 100, "sort": "updated", "order": "desc"}
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-    }
     url = f"{GITHUB_API_ROOT}/search/issues?{urllib.parse.urlencode(params)}"
-    req = urllib.request.Request(url, headers=headers)
+    # Shared client: retries 429/5xx with backoff and detects rate limits from
+    # response headers (x-ratelimit-remaining / retry-after) rather than
+    # string-matching the error body.
+    client = GitHubClient(token, timeout=timeout_seconds, job_label="pulse")
     try:
-        with urllib.request.urlopen(req, timeout=timeout_seconds) as resp:
-            payload = json.loads(resp.read().decode())
-    except urllib.error.HTTPError as exc:
-        body = exc.read().decode("utf-8", errors="replace")
-        if exc.code == 403 and "rate limit" in body.lower():
+        payload = client.get_json(url)
+    except GitHubHTTPError as exc:
+        if exc.is_rate_limit:
             raise RuntimeError("GitHub search rate limit hit") from exc
         raise
     items = payload.get("items") or []

--- a/tests/test_diagnose.py
+++ b/tests/test_diagnose.py
@@ -1,0 +1,130 @@
+"""Tests for the repo diagnostics module (diagnose_repo + live PAT probes).
+
+The live probes route through the shared GitHub client (GH-293): these tests
+pin the backwards-stable probe envelopes and the offline funnel verdicts with
+an injected fake client — no network.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+import urllib.error
+from pathlib import Path
+from unittest.mock import patch
+
+from rebalance.ingest import diagnose
+from rebalance.ingest._http import GitHubHTTPError
+
+
+def _client_cls(result=None, exc: Exception | None = None) -> type:
+    """Build a GitHubClient stand-in returning *result* or raising *exc*."""
+
+    class _FakeClient:
+        def __init__(self, token: str, **_: object) -> None:
+            pass
+
+        def get_json(self, path: str):
+            if exc is not None:
+                raise exc
+            return result
+
+    return _FakeClient
+
+
+class LiveProbeTests(unittest.TestCase):
+    def test_repo_probe_success(self) -> None:
+        fake = _client_cls(result={"default_branch": "development", "private": True})
+        with patch.object(diagnose, "GitHubClient", fake):
+            out = diagnose._live_probe_repo("someone/repo", "tok")
+        self.assertTrue(out["can_see"])
+        self.assertEqual(out["status"], 200)
+        self.assertEqual(out["default_branch"], "development")
+        self.assertTrue(out["private"])
+
+    def test_repo_probe_http_error_maps_status(self) -> None:
+        exc = GitHubHTTPError("GitHub API request failed: 404", status=404)
+        with patch.object(diagnose, "GitHubClient", _client_cls(exc=exc)):
+            out = diagnose._live_probe_repo("someone/repo", "tok")
+        self.assertFalse(out["can_see"])
+        self.assertEqual(out["status"], 404)
+        self.assertIn("404", out["error"])
+
+    def test_repo_probe_network_error_maps_null_status(self) -> None:
+        exc = urllib.error.URLError("connection refused")
+        with patch.object(diagnose, "GitHubClient", _client_cls(exc=exc)):
+            out = diagnose._live_probe_repo("someone/repo", "tok")
+        self.assertFalse(out["can_see"])
+        self.assertIsNone(out["status"])
+        self.assertIn("connection refused", out["error"])
+
+    def test_commit_probe_shape(self) -> None:
+        fake = _client_cls(
+            result={
+                "sha": "abc123",
+                "commit": {
+                    "message": "first line\nsecond line",
+                    "committer": {"date": "2026-08-15T10:00:00Z"},
+                },
+            },
+        )
+        with patch.object(diagnose, "GitHubClient", fake):
+            out = diagnose._live_probe_commit("someone/repo", "abc123", "tok")
+        self.assertTrue(out["exists"])
+        self.assertEqual(out["sha"], "abc123")
+        self.assertEqual(out["committed_at"], "2026-08-15T10:00:00Z")
+        self.assertEqual(out["message_first_line"], "first line")
+
+    def test_pr_probe_shape(self) -> None:
+        fake = _client_cls(result={"state": "open", "merged": False, "updated_at": "t", "title": "T"})
+        with patch.object(diagnose, "GitHubClient", fake):
+            out = diagnose._live_probe_pr("someone/repo", 7, "tok")
+        self.assertTrue(out["exists"])
+        self.assertFalse(out["merged"])
+        self.assertEqual(out["title"], "T")
+
+
+class DiagnoseRepoFunnelTests(unittest.TestCase):
+    """Offline verdicts against an empty temporary database."""
+
+    def test_unknown_repo_is_not_watched_with_registry_next_action(self) -> None:
+        result = diagnose.diagnose_repo(self._empty_db(), repo="someone/unknown-repo")
+        self.assertEqual(result["verdict"], "not_watched_no_signal")
+        self.assertFalse(result["monitoring"]["watched"])
+        self.assertFalse(result["monitoring"]["ignored"])
+        self.assertTrue(any("registry" in action for action in result["next_actions"]))
+        self.assertFalse(result["pat"]["checked"])
+
+    def test_invalid_repo_name_short_circuits(self) -> None:
+        result = diagnose.diagnose_repo(self._empty_db(), repo="not-a-repo-name")
+        self.assertEqual(result["verdict"], "invalid_input")
+        self.assertEqual(result["next_actions"], [])
+
+    def test_live_pat_failure_surfaces_first_next_action(self) -> None:
+        probe = {"can_see": False, "status": 404, "error": "Not Found"}
+        with patch.object(diagnose, "get_github_token", return_value="tok"), \
+             patch.object(diagnose, "_live_probe_repo", return_value=probe):
+            result = diagnose.diagnose_repo(self._empty_db(), repo="someone/unknown-repo", live=True)
+        self.assertTrue(result["pat"]["checked"])
+        self.assertFalse(result["pat"]["can_see"])
+        self.assertIn("PAT", result["next_actions"][0])
+
+    def test_live_without_token_reports_missing_token(self) -> None:
+        with patch.object(diagnose, "get_github_token", return_value=None):
+            result = diagnose.diagnose_repo(self._empty_db(), repo="someone/unknown-repo", live=True)
+        self.assertTrue(result["pat"]["checked"])
+        self.assertIn("token", result["pat"]["error"])
+
+    def _empty_db(self) -> Path:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        path = Path(tmp.name) / "diagnose.db"
+        from rebalance.ingest.db import db_connection
+
+        with db_connection(path):  # create the empty DB file
+            pass
+        return path
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pulse_assigned_issues.py
+++ b/tests/test_pulse_assigned_issues.py
@@ -1,0 +1,84 @@
+"""Tests for the pulse renderer's assigned-issues GitHub search (GH-293).
+
+fetch_assigned_issues routes through the shared GitHub client; these tests pin
+the row mapping and the rate-limit error contract with an injected fake —
+no network.
+"""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+from rebalance.ingest import pulse
+from rebalance.ingest._http import GitHubHTTPError
+
+
+def _client_cls(result=None, exc: Exception | None = None) -> type:
+    class _FakeClient:
+        def __init__(self, token: str, **_: object) -> None:
+            pass
+
+        def get_json(self, url: str):
+            if exc is not None:
+                raise exc
+            return result
+
+    return _FakeClient
+
+
+class FetchAssignedIssuesTests(unittest.TestCase):
+    def _since(self) -> datetime:
+        return datetime(2026, 8, 15, tzinfo=timezone.utc)
+
+    def test_maps_search_rows_to_pulse_shape(self) -> None:
+        payload = {
+            "items": [
+                {
+                    "number": 42,
+                    "title": "Fix the thing",
+                    "state": "open",
+                    "html_url": "https://github.com/someone/repo/issues/42",
+                    "created_at": "2026-08-10T00:00:00Z",
+                    "updated_at": "2026-08-14T00:00:00Z",
+                    "labels": [{"name": "bug"}, {}],
+                    "repository_url": "https://api.github.com/repos/someone/repo",
+                }
+            ]
+        }
+        fake = _client_cls(result=payload)
+        with patch.object(pulse, "GitHubClient", fake):
+            rows = pulse.fetch_assigned_issues(github_login="someone", token="tok", since_date=self._since())
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertEqual(row["repo"], "someone/repo")
+        self.assertEqual(row["number"], 42)
+        self.assertEqual(row["title"], "Fix the thing")
+        self.assertEqual(row["labels"], ["bug"])
+
+    def test_rate_limit_error_keeps_runtime_error_contract(self) -> None:
+        exc = GitHubHTTPError(
+            "GitHub API request failed: 403",
+            status=403,
+            is_rate_limit=True,
+        )
+        with patch.object(pulse, "GitHubClient", _client_cls(exc=exc)):
+            with self.assertRaises(RuntimeError) as ctx:
+                pulse.fetch_assigned_issues(github_login="someone", token="tok", since_date=self._since())
+        self.assertIn("rate limit", str(ctx.exception))
+
+    def test_non_rate_limit_http_error_propagates(self) -> None:
+        exc = GitHubHTTPError("GitHub API request failed: 422", status=422)
+        with patch.object(pulse, "GitHubClient", _client_cls(exc=exc)):
+            with self.assertRaises(GitHubHTTPError):
+                pulse.fetch_assigned_issues(github_login="someone", token="tok", since_date=self._since())
+
+    def test_empty_items_yield_empty_list(self) -> None:
+        with patch.object(pulse, "GitHubClient", _client_cls(result={"items": []})):
+            rows = pulse.fetch_assigned_issues(github_login="someone", token="tok", since_date=self._since())
+        self.assertEqual(rows, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes the diagnose/pulse half of #293 (the `_paginate_list`/`_build_url` verbatim-copy deletion and github_watch pagination stay on the issue checklist).

## What
- **`diagnose.py` — fixes a false-negative bug.** The three live PAT probes hand-built urllib requests with **no retries**, so a single 429/5xx made the `diagnose_repo` MCP tool report a confident "PAT cannot see this repo" verdict. All three now route through `GitHubClient` (retry with backoff, header-based rate-limit detection, request attribution under `job_label=diagnose`). Probe output envelopes are unchanged.
- **`pulse.py::fetch_assigned_issues`** — replaces the manual headers + body-string rate-limit heuristic (`"rate limit" in body.lower()`) with the shared client's header-based detection (`x-ratelimit-remaining` / `retry-after`). The `RuntimeError("GitHub search rate limit hit")` contract is preserved for callers.
- **First test coverage for the diagnostics module** — 13 tests (probe envelopes, offline funnel verdicts, live-block wiring, rate-limit contract), all hermetic via an injected fake client.

## Verification
- Full suite: **1951 passed, 10 xfailed** (baseline 1938 + 13 new)
- Version 0.69.5 + CHANGELOG entry per repo convention.

## Merge notes
- Cut from `development` independently of #302 (ruff) and #304 (time-ops) — expect trivial import-line conflicts if those land first.
- Per the GH-291 consolidation plan, open PRs will be re-opened on the new repo (`HiQS-Suite/rebalanceOS`) before the old one is archived — this branch ports cleanly (new-repo main is content-identical to old development for all files this PR touches).