### PR TITLE
chore: bump dev-scope js-yaml to 4.3.1 (Dependabot alert 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@
 > **not** reintroduce an `[Unreleased]` block — add to (or roll work into) the
 > current dated version instead. See AGENTS.md → "Versioning & Changelog".
 
+## [0.69.3] - 2026-08-17
+
+### Security
+- **Bumped the vulnerable YAML parser in an editor extension's development
+  lockfile to the patched release**, closing the remaining high-severity
+  dependency alert (development-scope only; the other extension lockfile was
+  already patched).
+
 ## [0.69.2] - 2026-08-15
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rebalance-os"
-version = "0.69.2"
+version = "0.69.3"
 description = "Local-first workday operating system with MCP tools and Obsidian ingest"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/rebalance/__init__.py
+++ b/src/rebalance/__init__.py
@@ -28,7 +28,7 @@ import logging
 import os
 
 __all__ = ["__version__"]
-__version__ = "0.69.2"
+__version__ = "0.69.3"
 
 
 def _configure_logging() -> None:

--- a/vscode-extensions/clio/package-lock.json
+++ b/vscode-extensions/clio/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sidebar-markdown",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sidebar-markdown",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "license": "UNLICENSED",
       "dependencies": {
         "markdown-it": "^14.1.0"
@@ -3399,9 +3399,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Closes the open high-severity Dependabot alert (js-yaml < 4.3.1, npm, development scope).

## Why this kept failing for agents
The alert's recorded manifest path (`vscode-extension/...`, singular) predates the extensions-folder rename and **does not exist on any branch** — fixing "the named file" was impossible. The actual vulnerable pin was `js-yaml@4.3.0` in the **clio** lockfile (pulled transitively via `@textlint/linter-formatter` and `rc-config-loader`). pulse-tree-view's lock was already at 4.3.1.

## What
- `npm update js-yaml --package-lock-only` in the clio extension → 4.3.0 → **4.3.1** (patch, within the existing `^4.1.1` range; lockfile-only, node_modules untouched, no runtime/product code affected)
- CHANGELOG security entry + patch version bump per repo convention

## After merge
- Dependabot should dismiss the alert on its next scan of the default branch. If it stays open because of the ghost manifest path, it's safe to dismiss manually as "no longer detectable" — no tracked lockfile contains a vulnerable version after this.
- A follow-up PR will fast-forward `main` to `development` so both required branches carry the fix (main currently predates the extensions entirely, so it has no vulnerable copy at all — the sync just brings it current).